### PR TITLE
Add getUserByMention(String mention) to IDiscordClient and its implementation.

### DIFF
--- a/src/main/java/sx/blah/discord/api/IDiscordClient.java
+++ b/src/main/java/sx/blah/discord/api/IDiscordClient.java
@@ -260,6 +260,14 @@ public interface IDiscordClient {
 	 * @return The user with the provided ID (or null if one was not found).
 	 */
 	IUser getUserByID(long userID);
+	
+	/**
+	* Returns a user based on a given mention.
+	*
+	* @param mention The mention of the user.
+	* @return The user.
+	*/
+	IUser getUserByMention(String mention);
 
 	/**
 	 * Gets a user by its unique snowflake ID from the client's user cache <b>or</b> by fetching it from Discord.

--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -597,7 +597,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 	
 	@Override
-    	public static IUser getUserByMention(String mention) {
+    	public IUser getUserByMention(String mention) {
         	if(mention.startsWith("<@!")) {
 		    String userID = mention.substring(3, mention.length() - 1);
 		    try {

--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -595,6 +595,29 @@ public final class DiscordClientImpl implements IDiscordClient {
 
 		return null;
 	}
+	
+	@Override
+    	public static IUser getUserByMention(String mention) {
+        	if(mention.startsWith("<@!")) {
+		    String userID = mention.substring(3, mention.length() - 1);
+		    try {
+			return client.getUserByID(Long.parseLong(userID));
+		    }
+		    catch(NumberFormatException e) {
+			return null;
+		    }
+		}
+		else if(mention.startsWith("<@")) {
+		    String userID = mention.substring(2, mention.length() - 1);
+		    try {
+			return client.getUserByID(Long.parseLong(userID));
+		    }
+		    catch(NumberFormatException e) {
+			return null;
+		    }
+		}
+		else return null;
+	}
 
 	@Override
 	public IUser fetchUser(long id) {


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * https://i.imgur.com/ArRptCY.png

**Issues Fixed:** I no longer have to add this method in manually every time I make a Discord4J where I have commands.

### Changes Proposed in this Pull Request
* Create a getUserByMention method, which automates the process of pulling a user ID out of a mention such as <@15919875109689515> or <@15919875109689515>