### PR TITLE
Aggregate javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,11 @@ subprojects {
 
     archivesBaseName = "discord4j-$project.name"
 
+    tasks.withType(Javadoc) {
+        title = "$archivesBaseName ${version} API"
+        options.windowTitle = "$archivesBaseName ($version)"
+    }
+
     publishing {
         publications {
             maven(MavenPublication) {
@@ -161,9 +166,9 @@ task aggregateJavadoc(type: Javadoc,
 ) {
     destinationDir file("${rootProject.buildDir}/docs/aggregateJavadoc")
     failOnError false
+    title = "$rootProject.name ${version} API"
 
     options {
-        title = "$rootProject.name ${rootProject.version} API"
         windowTitle = "$rootProject.name ($version)"
         addStringOption "Xdoclint:none", "-quiet"
         author true

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,46 @@ publishing {
 
 bintrayUpload.dependsOn build
 
+task aggregatedJavadocs(type: Javadoc,
+		description: "Generate javadocs from all child projects as if it was a single project",
+		group: "Documentation"
+){
+	def destination = file("${rootDir}/docs/javadoc/${projectVersion.toLowerCase()}")
+
+	doFirst {
+		// replace existing directory
+		if (destination.exists()) {
+			destination.deleteDir()
+		}
+	}
+
+	destinationDir destination
+	failOnError false
+
+	options {
+		title = "$rootProject.name ${rootProject.version} API"
+		windowTitle = "$rootProject.name ($version)"
+		addStringOption "Xdoclint:none", "-quiet"
+		author true
+		// adding links to javadocs for filling specific classes when not existing inside current javadoc
+		links = [
+				"http://projectreactor.io/docs/core/release/api/",
+				"http://projectreactor.io/docs/netty/release/api/",
+				"http://projectreactor.io/docs/extra/release/api/"
+		]
+	}
+
+	subprojects.each { project ->
+		project.tasks.withType(Javadoc.class).each { doc ->
+			source += doc.source
+			classpath += doc.classpath
+			excludes += doc.excludes
+			includes += doc.includes
+		}
+	}
+}
+
 wrapper {
     gradleVersion = "4.9"
-    distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
+	distributionType = Wrapper.DistributionType.ALL
 }

--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ task aggregateJavadoc(type: Javadoc,
     description: "Generate javadocs from all child projects as if it was a single project",
     group: JavaBasePlugin.DOCUMENTATION_GROUP
 ) {
-    destinationDir file("${rootDir}/build/docs/aggregateJavadoc")
+    destinationDir file("${rootProject.buildDir}/docs/aggregateJavadoc")
     failOnError false
 
     options {

--- a/build.gradle
+++ b/build.gradle
@@ -53,11 +53,24 @@ allprojects {
     }
 
     tasks.withType(Javadoc) {
-        options.encoding = 'UTF-8'
-        options.addStringOption('encoding', 'UTF-8')
-        options.tags = ["apiNote:a:API Note:",
-                        "implSpec:a:Implementation Requirements:",
-                        "implNote:a:Implementation Note:"]
+        options {
+            encoding = 'UTF-8'
+            tags = ["apiNote:a:API Note:",
+                    "implSpec:a:Implementation Requirements:",
+                    "implNote:a:Implementation Note:"]
+            addStringOption 'encoding', 'UTF-8'
+            // adding links to javadocs for filling specific classes when not existing inside current javadoc
+            links = [
+                "https://docs.oracle.com/javase/8/docs/api/",
+                "https://docs.oracle.com/javaee/7/api/",
+                "http://fasterxml.github.io/jackson-databind/javadoc/2.9/",
+                "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/",
+                "http://projectreactor.io/docs/core/milestone/api/",
+                "http://projectreactor.io/docs/netty/milestone/api/",
+                "http://projectreactor.io/docs/extra/milestone/api/",
+                "http://netty.io/4.1/api/"
+            ]
+        }
     }
 
     tasks.withType(JavaCompile) {
@@ -140,48 +153,43 @@ subprojects {
     }
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
+bintrayUpload.dependsOn build
+
+task aggregateJavadoc(type: Javadoc,
+    description: "Generate javadocs from all child projects as if it was a single project",
+    group: JavaBasePlugin.DOCUMENTATION_GROUP
+) {
+    destinationDir file("${rootDir}/build/docs/aggregateJavadoc")
+    failOnError false
+
+    options {
+        title = "$rootProject.name ${rootProject.version} API"
+        windowTitle = "$rootProject.name ($version)"
+        addStringOption "Xdoclint:none", "-quiet"
+        author true
+    }
+
+    subprojects.each { project ->
+        project.tasks.withType(Javadoc.class).each { doc ->
+            source += doc.source
+            classpath += doc.classpath
+            excludes += doc.excludes
+            includes += doc.includes
         }
     }
 }
 
-bintrayUpload.dependsOn build
+task aggregateJavadocJar(type: Jar, dependsOn: aggregateJavadoc) {
+    classifier = 'javadoc'
+    from aggregateJavadoc.destinationDir
+}
 
-task aggregateJavadoc(type: Javadoc,
-		description: "Generate javadocs from all child projects as if it was a single project",
-		group: JavaBasePlugin.DOCUMENTATION_GROUP
-){
-	destinationDir file("${rootDir}/build/docs/aggregateJavadoc")
-	failOnError false
-
-	options {
-        encoding = 'UTF-8'
-        tags = ["apiNote:a:API Note:",
-                "implSpec:a:Implementation Requirements:",
-                "implNote:a:Implementation Note:"]
-		title = "$rootProject.name ${rootProject.version} API"
-		windowTitle = "$rootProject.name ($version)"
-        addStringOption "encoding", "UTF-8"
-		addStringOption "Xdoclint:none", "-quiet"
-		author true
-		// adding links to javadocs for filling specific classes when not existing inside current javadoc
-		links = [
-				"http://projectreactor.io/docs/core/release/api/",
-				"http://projectreactor.io/docs/netty/release/api/",
-				"http://projectreactor.io/docs/extra/release/api/"
-		]
-	}
-
-	subprojects.each { project ->
-		project.tasks.withType(Javadoc.class).each { doc ->
-			source += doc.source
-			classpath += doc.classpath
-			excludes += doc.excludes
-			includes += doc.includes
-		}
-	}
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact aggregateJavadocJar
+        }
+    }
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -166,10 +166,10 @@ task aggregateJavadoc(type: Javadoc,
 ) {
     destinationDir file("${rootProject.buildDir}/docs/aggregateJavadoc")
     failOnError false
-    title = "$rootProject.name ${version} API"
+    title = "$project_name ${project_version} API"
 
     options {
-        windowTitle = "$rootProject.name ($version)"
+        windowTitle = "$project_name $project_version"
         addStringOption "Xdoclint:none", "-quiet"
         author true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -166,8 +166,13 @@ task aggregatedJavadocs(type: Javadoc,
 	failOnError false
 
 	options {
+        encoding = 'UTF-8'
+        tags = ["apiNote:a:API Note:",
+                "implSpec:a:Implementation Requirements:",
+                "implNote:a:Implementation Note:"]
 		title = "$rootProject.name ${rootProject.version} API"
 		windowTitle = "$rootProject.name ($version)"
+        addStringOption "encoding", "UTF-8"
 		addStringOption "Xdoclint:none", "-quiet"
 		author true
 		// adding links to javadocs for filling specific classes when not existing inside current javadoc
@@ -190,5 +195,5 @@ task aggregatedJavadocs(type: Javadoc,
 
 wrapper {
     gradleVersion = "4.9"
-	distributionType = Wrapper.DistributionType.ALL
+    distributionType = Wrapper.DistributionType.ALL
 }

--- a/build.gradle
+++ b/build.gradle
@@ -149,20 +149,11 @@ publishing {
 
 bintrayUpload.dependsOn build
 
-task aggregatedJavadocs(type: Javadoc,
+task aggregateJavadoc(type: Javadoc,
 		description: "Generate javadocs from all child projects as if it was a single project",
-		group: "Documentation"
+		group: JavaBasePlugin.DOCUMENTATION_GROUP
 ){
-	def destination = file("${rootDir}/docs/javadoc/${rootProject.version.toLowerCase()}")
-
-	doFirst {
-		// replace existing directory
-		if (destination.exists()) {
-			destination.deleteDir()
-		}
-	}
-
-	destinationDir destination
+	destinationDir file("${rootDir}/build/docs/aggregateJavadoc")
 	failOnError false
 
 	options {

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ task aggregatedJavadocs(type: Javadoc,
 		description: "Generate javadocs from all child projects as if it was a single project",
 		group: "Documentation"
 ){
-	def destination = file("${rootDir}/docs/javadoc/${projectVersion.toLowerCase()}")
+	def destination = file("${rootDir}/docs/javadoc/${rootProject.version.toLowerCase()}")
 
 	doFirst {
 		// replace existing directory


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Javadocs aggregation for documentation build. All sub-projects will be aggregate into one place. All of it is uploading into website. Just use `./gradlew aggregatedJavadocs`
* Gradle Wapper have `distributionType` filed - it was setted into `Wrapper.DistributionType.ALL` works same like `distributionUrl` last time.

### Additional Notes
I was notice your site for D3J is in progress, so I thinking adding this one. I think it will be helpful for some shading your Javadocs in one place. I tried it many times. Having some questions? I'm in on Discord or try put your expressions in this PR. 😉 
