### PR TITLE
Add support for @everyone role

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ ext {
     jackson_version = '2.9.5'
     jsr305_version = '3.0.2'
     junit_version = '4.12'
+    mockito_version = '2.7.22'
     logback_version = '1.3.0-alpha4'
     autoservice_version = '1.0-rc4'
     jdkstores_version = 'ea3e145'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile "com.discord4j.stores:stores-jdk:$jdkstores_version"
 
     testCompile "junit:junit:$junit_version"
+    testCompile "org.mockito:mockito-core:$mockito_version"
     testCompile "ch.qos.logback:logback-classic:$logback_version"
     testCompile "io.projectreactor:reactor-test"
 }

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -282,6 +282,16 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Requests to retrieve the guild's @everyone {@link Role}.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the @everyone {@link Role}, if
+     * present. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Role> getEveryoneRole() {
+        return getClient().getRoleById(getId(), getId());
+    }
+
+    /**
      * Gets the guild's emoji's IDs.
      *
      * @return The guild's emoji's IDs.

--- a/core/src/main/java/discord4j/core/object/entity/Role.java
+++ b/core/src/main/java/discord4j/core/object/entity/Role.java
@@ -129,6 +129,15 @@ public final class Role implements Entity {
     }
 
     /**
+     * Gets whether this role corresponds to the @everyone role.
+     *
+     * @return {@code true} if this role represents the @everyone role, {@code false} otherwise.
+     */
+    public boolean isEveryone() {
+        return getId().equals(getGuildId());
+    }
+
+    /**
      * Gets the ID of the guild this role is associated to.
      *
      * @return The ID of the guild this role is associated to.

--- a/core/src/test/java/discord4j/core/object/entity/EveryoneRoleLiveTest.java
+++ b/core/src/test/java/discord4j/core/object/entity/EveryoneRoleLiveTest.java
@@ -1,0 +1,41 @@
+package discord4j.core.object.entity;
+
+import discord4j.core.DiscordClient;
+import discord4j.core.DiscordClientBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EveryoneRoleLiveTest {
+    private DiscordClient client;
+
+    @Before
+    public void initialize() {
+        String token = System.getenv("token");
+
+        client = new DiscordClientBuilder(token).build();
+    }
+
+    @Test
+    public void testEveryoneRolesLive() {
+        List<Guild> guilds = client.getGuilds().collectList().block();
+
+        for (Guild g : guilds) {
+            // Get everyone role via Guild#getEveryoneRole
+            Role everyoneRole = g.getEveryoneRole().block();
+
+            assertTrue(everyoneRole.isEveryone());
+            assertEquals(g.getId(), everyoneRole.getId());
+
+            // Get everyone role via Role#isEveryone
+            List<Role> everyoneRoles = g.getRoles().filter(Role::isEveryone).collectList().block();
+
+            assertEquals(1, everyoneRoles.size());
+            assertEquals(everyoneRole, everyoneRoles.get(0));
+        }
+    }
+}

--- a/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * Unit test included; ran with the token of a bot in multiple guilds.

**Issues Fixed:** Lack of ability to cleanly get the @everyone role, and to check if a role is the @everyone role

### Changes Proposed in this Pull Request
* Add Guild#getEveryoneRole() returning a Mono<Role>
* Add Role#isEveryone() returning boolean

### Changes Considered but NOT Proposed in this Pull Request
* Add Guild#getEveryoneRoleId() returning Snowflake
    Though this would be more consistent with many of the features in entity classes, this method would simply return Guild#getId, so I’m not sure that it’s necessary. Open to comments here.

### Motivation
Playing with D4J internal permissions handling, these utility methods came in handy. I also imagine it could be useful for readability of client code, given that it relies on knowing how everyone roles behave.