### PR TITLE
Modify MessageTokenizer custom emoji regex

### DIFF
--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -48,7 +48,7 @@ public class MessageTokenizer {
 	/**
 	 * Regex for matching custom emoji.
 	 */
-	public static final String CUSTOM_EMOJI_REGEX = "<:[A-Za-z0-9_]{2,}:\\d+>";
+	public static final String CUSTOM_EMOJI_REGEX = "<a?:[A-Za-z0-9_]{2,}:\\d+>";
 	/**
 	 * Regex for matching invite URLs.
 	 */


### PR DESCRIPTION
Modify MessageTokenizer custom emoji regex to also accept animated custom emojis.

### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://lyrth.github.io/img/d4j-emreg-1.PNG)

**Issues Fixed:** `hasNextEmoji` and `nextEmoji` not matching animated custom emojis (for example `<a:idk:471662328983715851>`).

### Changes Proposed in this Pull Request
* Modify the MessageTokenizer custom emoji regex `<:[A-Za-z0-9_]{2,}:\\d+>` to also accept animated custom emojis (to `<a?:[A-Za-z0-9_]{2,}:\\d+>`).

