### PR TITLE
Issue #370 Fix

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -73,7 +73,7 @@ public class Message implements IMessage {
 	/**
 	 * The users mentioned in the message.
 	 */
-	protected volatile List<IUser> mentions;
+	protected volatile List<Long> mentions;
 
 	/**
 	 * The roles mentioned in the message.
@@ -157,12 +157,12 @@ public class Message implements IMessage {
 				   List<Embed> embeds, List<IReaction> reactions, long webhookID, Type type) {
 		this.client = client;
 		this.id = id;
-		setContent(content);
 		this.author = (User) user;
 		this.channel = (Channel) channel;
 		this.timestamp = timestamp;
 		this.editedTimestamp = editedTimestamp;
-		setMentions(mentions, roleMentions);
+		this.mentions = mentions;
+		this.roleMentions = roleMentions;
 		this.attachments = attachments;
 		this.isPinned = pinned;
 		this.channelMentions = new ArrayList<>();
@@ -172,6 +172,7 @@ public class Message implements IMessage {
 		this.webhookID = webhookID;
 		this.type = type;
 
+		setContent(content);
 		setChannelMentions();
 	}
 
@@ -195,7 +196,7 @@ public class Message implements IMessage {
 	 */
 	public void setContent(String content) {
 		this.content = content;
-		this.formattedContent = null; // Force re-update later
+		setFormattedContent();
 
 		if (content != null) {
 			this.mentionsEveryone = content.contains("@everyone");
@@ -210,7 +211,7 @@ public class Message implements IMessage {
 	 * @param roleMentions The role mentions of the message.
 	 */
 	public void setMentions(List<Long> mentions, List<Long> roleMentions) {
-		this.mentions = mentions.stream().map(client::getUserByID).collect(Collectors.toList());
+		this.mentions = mentions;
 		this.roleMentions = roleMentions;
 	}
 
@@ -285,7 +286,10 @@ public class Message implements IMessage {
 		if (mentionsEveryone()) {
 			return channel.isPrivate() ? channel.getUsersHere() : channel.getGuild().getUsers();
 		}
-		return mentions;
+
+		return mentions.stream()
+				.map(client::getUserByID)
+				.collect(Collectors.toList());
 	}
 
 	@Override
@@ -357,7 +361,7 @@ public class Message implements IMessage {
 	 * @return A list of the unique snowflake IDs of the users mentioned in the message.
 	 */
 	public List<Long> getRawMentionsLong() {
-		return mentions.stream().map(IIDLinkedObject::getLongID).collect(Collectors.toList());
+		return mentions;
 	}
 
 	/**
@@ -432,7 +436,7 @@ public class Message implements IMessage {
 	@Override
 	public IMessage copy() {
 		return new Message(client, id, content, author, channel, timestamp, editedTimestamp, everyoneMentionIsValid,
-				getRawMentionsLong(), roleMentions, attachments, isPinned, embeds, reactions, webhookID, type);
+				mentions, roleMentions, attachments, isPinned, embeds, reactions, webhookID, type);
 	}
 
 	@Override
@@ -440,27 +444,29 @@ public class Message implements IMessage {
 		return getChannel().isPrivate() ? null : getChannel().getGuild();
 	}
 
+	private void setFormattedContent() {
+		String currentContent = content;
+
+		for (long userID : mentions) {
+			IUser u = client.getUserByID(userID);
+			currentContent = u == null ? currentContent.replace("<@" + userID + ">", "invalid-user")
+					: currentContent.replace(u.mention(false), "@" + u.getName())
+					.replace(u.mention(true), "@" + u.getDisplayName(getGuild()));
+		}
+
+		for (IChannel ch : getChannelMentions())
+			currentContent = currentContent.replace(ch.mention(), "#" + ch.getName());
+
+		for (IRole r : getRoleMentions())
+			currentContent = currentContent.replace(r.mention(), "@" + r.getName());
+
+		formattedContent = currentContent;
+	}
+
 	@Override
 	public String getFormattedContent() {
 		if (content == null)
 			return null;
-
-		if (formattedContent == null) {
-			String currentContent = content;
-
-			for (IUser u : getMentions())
-				currentContent = currentContent.replace(u.mention(false), "@" + u.getName())
-						.replace(u.mention(true), "@" + u.getDisplayName(getGuild()));
-
-			for (IChannel ch : getChannelMentions())
-				currentContent = currentContent.replace(ch.mention(), "#" + ch.getName());
-
-			for (IRole r : getRoleMentions())
-				currentContent = currentContent.replace(r.mention(), "@" + r.getName());
-
-			formattedContent = currentContent;
-		}
-
 		return formattedContent;
 	}
 

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -444,29 +444,34 @@ public class Message implements IMessage {
 		return getChannel().isPrivate() ? null : getChannel().getGuild();
 	}
 
+	/**
+	 * Sets the CACHED formatted content of the message.
+	 */
 	private void setFormattedContent() {
-		String currentContent = content;
+		if (content == null) {
+			formattedContent = null;
+		} else {
+			String currentContent = content;
 
-		for (long userID : mentions) {
-			IUser u = client.getUserByID(userID);
-			currentContent = u == null ? currentContent.replace("<@" + userID + ">", "invalid-user")
-					: currentContent.replace(u.mention(false), "@" + u.getName())
-					.replace(u.mention(true), "@" + u.getDisplayName(getGuild()));
+			for (long userID : mentions) {
+				IUser u = client.getUserByID(userID);
+				currentContent = u == null ? currentContent.replace("<@" + userID + ">", "@invalid-user")
+						: currentContent.replace(u.mention(false), "@" + u.getName())
+						.replace(u.mention(true), "@" + u.getDisplayName(getGuild()));
+			}
+
+			for (IChannel ch : getChannelMentions())
+				currentContent = currentContent.replace(ch.mention(), "#" + ch.getName());
+
+			for (IRole r : getRoleMentions())
+				currentContent = currentContent.replace(r.mention(), "@" + r.getName());
+
+			formattedContent = currentContent;
 		}
-
-		for (IChannel ch : getChannelMentions())
-			currentContent = currentContent.replace(ch.mention(), "#" + ch.getName());
-
-		for (IRole r : getRoleMentions())
-			currentContent = currentContent.replace(r.mention(), "@" + r.getName());
-
-		formattedContent = currentContent;
 	}
 
 	@Override
 	public String getFormattedContent() {
-		if (content == null)
-			return null;
 		return formattedContent;
 	}
 

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -73,7 +73,7 @@ public class Message implements IMessage {
 	/**
 	 * The users mentioned in the message.
 	 */
-	protected volatile List<Long> mentions;
+	protected volatile List<IUser> mentions;
 
 	/**
 	 * The roles mentioned in the message.
@@ -162,8 +162,7 @@ public class Message implements IMessage {
 		this.channel = (Channel) channel;
 		this.timestamp = timestamp;
 		this.editedTimestamp = editedTimestamp;
-		this.mentions = mentions;
-		this.roleMentions = roleMentions;
+		setMentions(mentions, roleMentions);
 		this.attachments = attachments;
 		this.isPinned = pinned;
 		this.channelMentions = new ArrayList<>();
@@ -211,7 +210,7 @@ public class Message implements IMessage {
 	 * @param roleMentions The role mentions of the message.
 	 */
 	public void setMentions(List<Long> mentions, List<Long> roleMentions) {
-		this.mentions = mentions;
+		this.mentions = mentions.stream().map(client::getUserByID).collect(Collectors.toList());
 		this.roleMentions = roleMentions;
 	}
 
@@ -286,10 +285,7 @@ public class Message implements IMessage {
 		if (mentionsEveryone()) {
 			return channel.isPrivate() ? channel.getUsersHere() : channel.getGuild().getUsers();
 		}
-
-		return mentions.stream()
-				.map(client::getUserByID)
-				.collect(Collectors.toList());
+		return mentions;
 	}
 
 	@Override
@@ -361,7 +357,7 @@ public class Message implements IMessage {
 	 * @return A list of the unique snowflake IDs of the users mentioned in the message.
 	 */
 	public List<Long> getRawMentionsLong() {
-		return mentions;
+		return mentions.stream().map(IIDLinkedObject::getLongID).collect(Collectors.toList());
 	}
 
 	/**
@@ -436,7 +432,7 @@ public class Message implements IMessage {
 	@Override
 	public IMessage copy() {
 		return new Message(client, id, content, author, channel, timestamp, editedTimestamp, everyoneMentionIsValid,
-				mentions, roleMentions, attachments, isPinned, embeds, reactions, webhookID, type);
+				getRawMentionsLong(), roleMentions, attachments, isPinned, embeds, reactions, webhookID, type);
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [*] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [*] This pull request follows the code style of the project
* [*] I have tested this feature thoroughly
  * [Proof of testing](screenshot, any evidence you tested this pull request)
[Screenshot](https://cdn.discordapp.com/attachments/504804309884469270/505558381189267456/Untitled.png)
**Issues Fixed:** IUser is no longer null when mentioned in a previous message if the discord user left the guild.

### Changes Proposed in this Pull Request
IMessage now stores List<IUser> instead of List<Long> for mentions. Previously when a user was mentioned and then leaves the guild, Message#getMentions would return a null object for that user. The issue is now gone because the IUser objects are cached.
...


