### PR TITLE
Ensure audit log entries are correctly ordered

### DIFF
--- a/src/main/java/sx/blah/discord/handle/audit/AuditLog.java
+++ b/src/main/java/sx/blah/discord/handle/audit/AuditLog.java
@@ -25,6 +25,7 @@ import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.util.cache.LongMap;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -52,11 +53,11 @@ public class AuditLog {
 	}
 
 	/**
-	 * Gets the entries for the log as a list.
+	 * Gets the entries for the log as a collection.
 	 *
-	 * @return The entries for the log as a list.
+	 * @return The entries for the log as a collection.
 	 */
-	public List<AuditLogEntry> getEntries() {
+	public Collection<AuditLogEntry> getEntries() {
 		return entries.values().stream()
 				.sorted(Comparator.comparing(AuditLogEntry::getLongID).reversed())
 				.collect(Collectors.toList());
@@ -68,7 +69,7 @@ public class AuditLog {
 	 * @return The entries of the log which have a target.
 	 * @see TargetedEntry
 	 */
-	public List<TargetedEntry> getTargetedEntries() {
+	public Collection<TargetedEntry> getTargetedEntries() {
 		return getEntries().stream()
 				.filter(TargetedEntry.class::isInstance)
 				.map(TargetedEntry.class::cast)
@@ -81,7 +82,7 @@ public class AuditLog {
 	 * @return The entries of the log which have a target which is a Discord object.
 	 * @see DiscordObjectEntry
 	 */
-	public List<DiscordObjectEntry<?>> getDiscordObjectEntries() {
+	public Collection<DiscordObjectEntry<?>> getDiscordObjectEntries() {
 		return getEntries().stream()
 				.filter(DiscordObjectEntry.class::isInstance)
 				.map(entry -> (DiscordObjectEntry<?>) entry)
@@ -95,7 +96,7 @@ public class AuditLog {
 	 * @param <T> The type of target to search for.
 	 * @return The entries of the log which have a target which is of the given type.
 	 */
-	public <T extends IDiscordObject<T>> List<DiscordObjectEntry<T>> getDiscordObjectEntries(Class<T> clazz) {
+	public <T extends IDiscordObject<T>> Collection<DiscordObjectEntry<T>> getDiscordObjectEntries(Class<T> clazz) {
 		return getDiscordObjectEntries().stream()
 				.filter(entry -> clazz.isAssignableFrom(entry.getTarget().getClass()))
 				.map(entry -> (DiscordObjectEntry<T>) entry)

--- a/src/main/java/sx/blah/discord/handle/audit/AuditLog.java
+++ b/src/main/java/sx/blah/discord/handle/audit/AuditLog.java
@@ -25,7 +25,7 @@ import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.util.cache.LongMap;
 
-import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,12 +52,16 @@ public class AuditLog {
 	}
 
 	/**
-	 * Gets the entries for the log as a collection.
+	 * Gets the entries for the log as a list.
 	 *
-	 * @return The entries for the log as a collection.
+	 * @return The entries for the log as a list.
 	 */
-	public Collection<AuditLogEntry> getEntries() {
-		return entries.values();
+	public List<AuditLogEntry> getEntries() {
+		return entries
+				.values()
+				.stream()
+				.sorted(Comparator.comparing(AuditLogEntry::getLongID).reversed())
+				.collect(Collectors.toList());
 	}
 
 	/**
@@ -66,8 +70,9 @@ public class AuditLog {
 	 * @return The entries of the log which have a target.
 	 * @see TargetedEntry
 	 */
-	public Collection<TargetedEntry> getTargetedEntries() {
-		return entries.values().stream()
+	public List<TargetedEntry> getTargetedEntries() {
+		return getEntries()
+				.stream()
 				.filter(TargetedEntry.class::isInstance)
 				.map(TargetedEntry.class::cast)
 				.collect(Collectors.toList());
@@ -79,8 +84,9 @@ public class AuditLog {
 	 * @return The entries of the log which have a target which is a Discord object.
 	 * @see DiscordObjectEntry
 	 */
-	public Collection<DiscordObjectEntry<?>> getDiscordObjectEntries() {
-		return entries.values().stream()
+	public List<DiscordObjectEntry<?>> getDiscordObjectEntries() {
+		return getEntries()
+				.stream()
 				.filter(DiscordObjectEntry.class::isInstance)
 				.map(entry -> (DiscordObjectEntry<?>) entry)
 				.collect(Collectors.toList());
@@ -93,8 +99,9 @@ public class AuditLog {
 	 * @param <T> The type of target to search for.
 	 * @return The entries of the log which have a target which is of the given type.
 	 */
-	public <T extends IDiscordObject<T>> Collection<DiscordObjectEntry<T>> getDiscordObjectEntries(Class<T> clazz) {
-		return getDiscordObjectEntries().stream()
+	public <T extends IDiscordObject<T>> List<DiscordObjectEntry<T>> getDiscordObjectEntries(Class<T> clazz) {
+		return getDiscordObjectEntries()
+				.stream()
 				.filter(entry -> clazz.isAssignableFrom(entry.getTarget().getClass()))
 				.map(entry -> (DiscordObjectEntry<T>) entry)
 				.collect(Collectors.toList());
@@ -117,7 +124,8 @@ public class AuditLog {
 	 * @return The entries with the given action type.
 	 */
 	public List<AuditLogEntry> getEntriesByType(ActionType actionType) {
-		return getEntries().stream()
+		return getEntries()
+				.stream()
 				.filter(entry -> entry.getActionType() == actionType)
 				.collect(Collectors.toList());
 	}
@@ -129,7 +137,8 @@ public class AuditLog {
 	 * @return The entries which have a target which have the given unique snowflake ID.
 	 */
 	public List<TargetedEntry> getEntriesByTarget(long targetID) {
-		return getEntries().stream()
+		return getEntries()
+				.stream()
 				.filter(TargetedEntry.class::isInstance)
 				.map(TargetedEntry.class::cast)
 				.filter(entry -> entry.getTargetID() == targetID)
@@ -143,7 +152,8 @@ public class AuditLog {
 	 * @return The entries with the given responsible user.
 	 */
 	public List<AuditLogEntry> getEntriesByResponsibleUser(IUser user) {
-		return getEntries().stream()
+		return getEntries()
+				.stream()
 				.filter(entry -> entry.getResponsibleUser().equals(user))
 				.collect(Collectors.toList());
 	}

--- a/src/main/java/sx/blah/discord/handle/audit/AuditLog.java
+++ b/src/main/java/sx/blah/discord/handle/audit/AuditLog.java
@@ -57,9 +57,7 @@ public class AuditLog {
 	 * @return The entries for the log as a list.
 	 */
 	public List<AuditLogEntry> getEntries() {
-		return entries
-				.values()
-				.stream()
+		return entries.values().stream()
 				.sorted(Comparator.comparing(AuditLogEntry::getLongID).reversed())
 				.collect(Collectors.toList());
 	}
@@ -71,8 +69,7 @@ public class AuditLog {
 	 * @see TargetedEntry
 	 */
 	public List<TargetedEntry> getTargetedEntries() {
-		return getEntries()
-				.stream()
+		return getEntries().stream()
 				.filter(TargetedEntry.class::isInstance)
 				.map(TargetedEntry.class::cast)
 				.collect(Collectors.toList());
@@ -85,8 +82,7 @@ public class AuditLog {
 	 * @see DiscordObjectEntry
 	 */
 	public List<DiscordObjectEntry<?>> getDiscordObjectEntries() {
-		return getEntries()
-				.stream()
+		return getEntries().stream()
 				.filter(DiscordObjectEntry.class::isInstance)
 				.map(entry -> (DiscordObjectEntry<?>) entry)
 				.collect(Collectors.toList());
@@ -100,8 +96,7 @@ public class AuditLog {
 	 * @return The entries of the log which have a target which is of the given type.
 	 */
 	public <T extends IDiscordObject<T>> List<DiscordObjectEntry<T>> getDiscordObjectEntries(Class<T> clazz) {
-		return getDiscordObjectEntries()
-				.stream()
+		return getDiscordObjectEntries().stream()
 				.filter(entry -> clazz.isAssignableFrom(entry.getTarget().getClass()))
 				.map(entry -> (DiscordObjectEntry<T>) entry)
 				.collect(Collectors.toList());
@@ -124,8 +119,7 @@ public class AuditLog {
 	 * @return The entries with the given action type.
 	 */
 	public List<AuditLogEntry> getEntriesByType(ActionType actionType) {
-		return getEntries()
-				.stream()
+		return getEntries().stream()
 				.filter(entry -> entry.getActionType() == actionType)
 				.collect(Collectors.toList());
 	}
@@ -137,8 +131,7 @@ public class AuditLog {
 	 * @return The entries which have a target which have the given unique snowflake ID.
 	 */
 	public List<TargetedEntry> getEntriesByTarget(long targetID) {
-		return getEntries()
-				.stream()
+		return getEntries().stream()
 				.filter(TargetedEntry.class::isInstance)
 				.map(TargetedEntry.class::cast)
 				.filter(entry -> entry.getTargetID() == targetID)
@@ -152,8 +145,7 @@ public class AuditLog {
 	 * @return The entries with the given responsible user.
 	 */
 	public List<AuditLogEntry> getEntriesByResponsibleUser(IUser user) {
-		return getEntries()
-				.stream()
+		return getEntries().stream()
 				.filter(entry -> entry.getResponsibleUser().equals(user))
 				.collect(Collectors.toList());
 	}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * **Scenario:** I banned and unbanned a testing account 5 times. Each time, I put the ban reason as a number in order from 1-5; 1 being the first ban and 5 being the last. The ban reasons are printed to the console in the order that they come from the list returned by `AuditLog#getEntries()`
  * [List of ban reasons before ordering](https://i.imgur.com/TSOo5kl.png)
  * [List of ban reasons after ordering correctly](https://i.imgur.com/qm5twG3.png)

**Issues Fixed:** This pull request makes sure that Audit Log Entries are ordered when retrieved. They have the possibility of being out of order, which can cause problems depending on what the user is doing with the entries. (Fixes the bug mentioned by Panda in #411)

### Changes Proposed in this Pull Request
* Ensures there is order in audit log entries (ordered from most recent to oldest)


