### PR TITLE
Race Condition Fix on Guild Create

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -349,6 +349,7 @@ class DispatchHandler {
 
 		new RequestBuilder(client).setAsync(true).doAction(() -> {
 			try {
+				if (client.getOurUser() == null) client.getDispatcher().waitFor((LoginEvent e) -> e.getShard() == guild.getShard());
 				if (json.large) {
 					shard.ws.send(GatewayOps.REQUEST_GUILD_MEMBERS, new GuildMembersRequest(json.id));
 					client.getDispatcher().waitFor((AllUsersReceivedEvent e) ->
@@ -356,7 +357,7 @@ class DispatchHandler {
 					);
 				}
 			} catch (InterruptedException e) {
-				Discord4J.LOGGER.error(LogMarkers.EVENTS, "Wait for AllUsersReceivedEvent on guild create was interrupted.", e);
+				Discord4J.LOGGER.error(LogMarkers.EVENTS, "Waiting on guild create was interrupted.", e);
 			}
 			return true;
 		}).andThen(() -> {

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -349,7 +349,9 @@ class DispatchHandler {
 
 		new RequestBuilder(client).setAsync(true).doAction(() -> {
 			try {
-				if (client.getOurUser() == null) client.getDispatcher().waitFor((LoginEvent e) -> e.getShard().getInfo()[0] == guild.getShard().getInfo()[0]);
+				while (client.getOurUser() == null) {
+					client.getDispatcher().waitFor((LoginEvent e) -> e.getShard().getInfo()[0] == guild.getShard().getInfo()[0], 5000L);
+				}
 				if (json.large) {
 					shard.ws.send(GatewayOps.REQUEST_GUILD_MEMBERS, new GuildMembersRequest(json.id));
 					client.getDispatcher().waitFor((AllUsersReceivedEvent e) ->

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -349,7 +349,7 @@ class DispatchHandler {
 
 		new RequestBuilder(client).setAsync(true).doAction(() -> {
 			try {
-				if (client.getOurUser() == null) client.getDispatcher().waitFor((LoginEvent e) -> e.getShard() == guild.getShard());
+				if (client.getOurUser() == null) client.getDispatcher().waitFor((LoginEvent e) -> e.getShard().getInfo()[0] == guild.getShard().getInfo()[0]);
 				if (json.large) {
 					shard.ws.send(GatewayOps.REQUEST_GUILD_MEMBERS, new GuildMembersRequest(json.id));
 					client.getDispatcher().waitFor((AllUsersReceivedEvent e) ->


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [X] I have tested this feature thoroughly
  * [Proof of testing](https://i.imgur.com/a3TdY8N.png)

**Issues Fixed:** If a guild create event is dispatched before the bot user is logged in, it now waits before proceeding

### Changes Proposed in this Pull Request
* If the bot user is null, an `EventDispatcher#waitFor` line is called that proceeds only after a `LoginEvent` with the shard of the guild is received