### PR TITLE
Bugfix/time monotonicity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IntelliJ
 .idea
+*.iml
 
 # Eclipse
 .classpath

--- a/gateway/src/main/java/discord4j/gateway/GatewayClient.java
+++ b/gateway/src/main/java/discord4j/gateway/GatewayClient.java
@@ -373,32 +373,6 @@ public class GatewayClient {
         return connected.get();
     }
 
-    /**
-     * Gets the atomic reference for the time of the last acknowledged heartbeat.
-     *
-     * @return an AtomicLong representing the last heartbeat ACK timestamp in milliseconds since
-     * Unix epoch (1/1/1970 0:00:00.000 UTC)
-     */
-    public AtomicLong lastAck() {
-        return lastAckSinceEpochMillis;
-    }
-
-    /**
-     * Gets the last heartbeat latency. That is, the time elapsed between a heartbeat being sent to
-     * the gateway, and a successful heartbeat ACK being sent from the gateway in response.
-     * <p>
-     * This only measures client-heartbeat to gateway-ack, not vice-versa.
-     *
-     * @return an AtomicLong representing the last heartbeat latency in milliseconds. This may be
-     *      zero if no heartbeat ACK has yet been received from the gateway. Callers should safely
-     *      be able to make the assumption in general that this value will never be non-negative,
-     *      however, this is in reality is down to the constraints and implementation of the user's
-     *      high precision monotonic clock implementation.
-     */
-    public AtomicLong lastHeartbeatLatency() {
-        return lastAckSinceEpochMillis;
-    }
-
     ///////////////////////////////////////////
     // Fields for PayloadHandler consumption //
     ///////////////////////////////////////////
@@ -474,5 +448,31 @@ public class GatewayClient {
      */
     RetryOptions retryOptions() {
         return retryOptions;
+    }
+
+    /**
+     * Gets the atomic reference for the time of the last acknowledged heartbeat.
+     *
+     * @return an AtomicLong representing the last heartbeat ACK timestamp in milliseconds since
+     * Unix epoch (1/1/1970 0:00:00.000 UTC)
+     */
+    AtomicLong lastAck() {
+        return lastAckSinceEpochMillis;
+    }
+
+    /**
+     * Gets the last heartbeat latency. That is, the time elapsed between a heartbeat being sent to
+     * the gateway, and a successful heartbeat ACK being sent from the gateway in response.
+     * <p>
+     * This only measures client-heartbeat to gateway-ack, not vice-versa.
+     *
+     * @return an AtomicLong representing the last heartbeat latency in milliseconds. This may be
+     * zero if no heartbeat ACK has yet been received from the gateway. Callers should safely
+     * be able to make the assumption in general that this value will never be non-negative,
+     * however, this is in reality is down to the constraints and implementation of the user's
+     * high precision monotonic clock implementation.
+     */
+    AtomicLong lastHeartbeatLatency() {
+        return lastAckSinceEpochMillis;
     }
 }


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * There is nothing that can really be tested that is not just testing that Java compiles
    in the way it is supposed to compile. All that has been changed is one entry to the gitignore, one 
    method changed from package-private to public, and one simple accessor added to the 
    DiscordClient implementation. Nonetheless, I will provide proof that this has not _broken_ 
    anything in the existing client.

![image](https://user-images.githubusercontent.com/44550897/48981676-9f395a80-f0d0-11e8-9c91-b8ba3751f114.png)

![image](https://user-images.githubusercontent.com/44550897/48981679-a95b5900-f0d0-11e8-801f-9318450133c8.png)


**Issues Fixed:**
- #464 
- This provides information that would be useful for implementing #462, but does not expose it publicly. 

### Changes Proposed in this Pull Request
* Implement monotonic time difference measurements in the gateway without affecting existing dependencies on the package-private accessor that uses a non monotonic time source.
* Implement monotonic time differences in SimpleBucket.
* Added `*.iml` to `.gitignore` as you probably don't want those being uploaded here.

I hope I have not forgotten anything important. If anything needs to be discussed, you can alternatively ping `@Espy#7235` in your Discord guild, as that is my account, if that is easier.

Thanks :)