### PR TITLE
Add documented audit log reason length constant

### DIFF
--- a/core/src/main/java/discord4j/core/object/audit/AuditLogEntry.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogEntry.java
@@ -25,6 +25,9 @@ import discord4j.core.object.util.Snowflake;
 import java.util.Optional;
 
 public class AuditLogEntry implements Entity {
+    
+    /** The maximum amount of characters that can be in an audit log reason. */
+	public static final int MAX_REASON_LENGTH = 512;
 
     private final ServiceMediator serviceMediator;
     private final AuditLogEntryBean data;


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [X] I have tested this feature thoroughly
  * This change does not need to be tested.

### Changes Proposed in this Pull Request
As discussed [here](https://github.com/discordapp/discord-api-docs/issues/811), the X-Audit-Log-Reason length ~~is~~ should be documented. Documented constants are allowed in Discord4J, this is why I propose to add it in the AuditLogEntry class.
