### PR TITLE
Add ability to add reasons to audit loggable actions (#451)

### DIFF
--- a/core/src/main/java/discord4j/core/DiscordClient.java
+++ b/core/src/main/java/discord4j/core/DiscordClient.java
@@ -335,28 +335,16 @@ public final class DiscordClient {
     /**
      * Requests to create a guild.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link GuildCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createGuild(GuildCreateSpec)}.
+     * @param spec A {@link Consumer} that provides a "blank" {@link GuildCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link Guild}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Guild> createGuild(final Consumer<GuildCreateSpec> spec) {
+    public Mono<Guild> createGuild(final Consumer<? super GuildCreateSpec> spec) {
         final GuildCreateSpec mutatedSpec = new GuildCreateSpec();
         spec.accept(mutatedSpec);
-        return createGuild(mutatedSpec);
-    }
 
-    /**
-     * Requests to create a guild.
-     *
-     * @param spec A configured {@link GuildCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link Guild}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Guild> createGuild(final GuildCreateSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .createGuild(spec.asRequest())
+                .createGuild(mutatedSpec.asRequest())
                 .map(BaseGuildBean::new)
                 .map(bean -> new Guild(serviceMediator, bean));
     }

--- a/core/src/main/java/discord4j/core/object/ExtendedPermissionOverwrite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedPermissionOverwrite.java
@@ -23,6 +23,7 @@ import discord4j.core.object.entity.*;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -121,13 +122,14 @@ public final class ExtendedPermissionOverwrite extends PermissionOverwrite imple
     }
 
     /**
-     * Requests to delete this permission overwrite.
+     * Requests to delete this permission overwrite while optionally specifying a reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the permission overwrite has
      * been deleted. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> delete() {
+    public Mono<Void> delete(@Nullable final String reason) {
         return serviceMediator.getRestClient().getChannelService()
-            .deleteChannelPermission(channelId, getTargetId().asLong());
+                .deleteChannelPermission(channelId, getTargetId().asLong(), reason);
     }
 }

--- a/core/src/main/java/discord4j/core/object/ExtendedPermissionOverwrite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedPermissionOverwrite.java
@@ -122,6 +122,16 @@ public final class ExtendedPermissionOverwrite extends PermissionOverwrite imple
     }
 
     /**
+     * Requests to delete this permission overwrite.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the permission overwrite has
+     * been deleted. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this permission overwrite while optionally specifying a reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -104,6 +104,16 @@ public class Invite implements DiscordObject {
     }
 
     /**
+     * Requests to delete this invite.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the invite has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public final Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this invite while optionally specifying a reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -24,6 +24,7 @@ import discord4j.core.object.entity.TextChannel;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -103,13 +104,14 @@ public class Invite implements DiscordObject {
     }
 
     /**
-     * Requests to delete this invite.
+     * Requests to delete this invite while optionally specifying a reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the invite has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public final Mono<Void> delete() {
-        return serviceMediator.getRestClient().getInviteService().deleteInvite(getCode()).then();
+    public final Mono<Void> delete(@Nullable final String reason) {
+        return serviceMediator.getRestClient().getInviteService().deleteInvite(getCode(), reason).then();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/BaseChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/BaseChannel.java
@@ -62,8 +62,8 @@ class BaseChannel implements Channel {
     }
 
     @Override
-    public final Mono<Void> delete() {
-        return serviceMediator.getRestClient().getChannelService().deleteChannel(getId().asLong()).then();
+    public final Mono<Void> delete(@Nullable final String reason) {
+        return serviceMediator.getRestClient().getChannelService().deleteChannel(getId().asLong(), reason).then();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/BaseGuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/BaseGuildChannel.java
@@ -27,6 +27,7 @@ import discord4j.core.util.PermissionUtil;
 import discord4j.rest.json.request.PermissionsEditRequest;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,23 +117,23 @@ class BaseGuildChannel extends BaseChannel implements GuildChannel {
     }
 
     @Override
-    public Mono<Void> addMemberOverwrite(Snowflake memberId, PermissionOverwrite overwrite) {
+    public Mono<Void> addMemberOverwrite(Snowflake memberId, PermissionOverwrite overwrite, @Nullable String reason) {
         PermissionSet allow = overwrite.getAllowed();
         PermissionSet deny = overwrite.getDenied();
         PermissionsEditRequest request = new PermissionsEditRequest(allow.getRawValue(), deny.getRawValue(), "member");
 
         return getServiceMediator().getRestClient().getChannelService()
-            .editChannelPermissions(getId().asLong(), memberId.asLong(), request);
+            .editChannelPermissions(getId().asLong(), memberId.asLong(), request, reason);
     }
 
     @Override
-    public Mono<Void> addRoleOverwrite(Snowflake roleId, PermissionOverwrite overwrite) {
+    public Mono<Void> addRoleOverwrite(Snowflake roleId, PermissionOverwrite overwrite, @Nullable String reason) {
         PermissionSet allow = overwrite.getAllowed();
         PermissionSet deny = overwrite.getDenied();
         PermissionsEditRequest request = new PermissionsEditRequest(allow.getRawValue(), deny.getRawValue(), "role");
 
         return getServiceMediator().getRestClient().getChannelService()
-            .editChannelPermissions(getId().asLong(), roleId.asLong(), request);
+            .editChannelPermissions(getId().asLong(), roleId.asLong(), request, reason);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/BaseMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/BaseMessageChannel.java
@@ -65,16 +65,12 @@ class BaseMessageChannel extends BaseChannel implements MessageChannel {
     }
 
     @Override
-    public final Mono<Message> createMessage(final Consumer<MessageCreateSpec> spec) {
+    public final Mono<Message> createMessage(final Consumer<? super MessageCreateSpec> spec) {
         final MessageCreateSpec mutatedSpec = new MessageCreateSpec();
         spec.accept(mutatedSpec);
-        return createMessage(mutatedSpec);
-    }
 
-    @Override
-    public final Mono<Message> createMessage(final MessageCreateSpec spec) {
         return getServiceMediator().getRestClient().getChannelService()
-                .createMessage(getId().asLong(), spec.asRequest())
+                .createMessage(getId().asLong(), mutatedSpec.asRequest())
                 .map(MessageBean::new)
                 .map(bean -> new Message(getServiceMediator(), bean));
     }

--- a/core/src/main/java/discord4j/core/object/entity/Category.java
+++ b/core/src/main/java/discord4j/core/object/entity/Category.java
@@ -56,29 +56,16 @@ public final class Category extends BaseGuildChannel {
     /**
      * Requests to edit this category.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link CategoryEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(CategoryEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link CategoryEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link Category}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Category> edit(final Consumer<CategoryEditSpec> spec) {
+    public Mono<Category> edit(final Consumer<? super CategoryEditSpec> spec) {
         final CategoryEditSpec mutatedSpec = new CategoryEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this category.
-     *
-     * @param spec A configured {@link CategoryEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Category}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Category> edit(final CategoryEditSpec spec) {
         return getServiceMediator().getRestClient().getChannelService()
-                .modifyChannel(getId().asLong(), spec.asRequest())
+                .modifyChannel(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(EntityUtil::getChannelBean)
                 .map(bean -> EntityUtil.getChannel(getServiceMediator(), bean))
                 .cast(Category.class);

--- a/core/src/main/java/discord4j/core/object/entity/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/Channel.java
@@ -36,6 +36,16 @@ public interface Channel extends Entity {
     Type getType();
 
     /**
+     * Requests to delete this channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the channel has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    default Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this channel while optionally specifying a reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/entity/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/Channel.java
@@ -19,6 +19,8 @@ package discord4j.core.object.entity;
 import discord4j.core.util.EntityUtil;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
+
 /**
  * A Discord channel.
  *
@@ -34,12 +36,13 @@ public interface Channel extends Entity {
     Type getType();
 
     /**
-     * Requests to delete this channel.
+     * Requests to delete this channel while optionally specifying a reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the channel has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    Mono<Void> delete();
+    Mono<Void> delete(@Nullable String reason);
 
     /**
      * Gets the <i>raw</i> mention. This is the format utilized to directly mention another channel. All channels are

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -665,6 +665,17 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Requests to kick the specified user from this guild.
+     *
+     * @param userId The ID of the user to kick from this guild.
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the specified user was kicked
+     * from this guild. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> kick(final Snowflake userId) {
+        return kick(userId, null);
+    }
+
+    /**
      * Requests to kick the specified user from this guild while optionally specifying a reason.
      *
      * @param userId The ID of the user to kick from this guild.
@@ -722,6 +733,17 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Requests to unban the specified user.
+     *
+     * @param userId The ID of the user to unban.
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the specified user was
+     * unbanned. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> unban(final Snowflake userId) {
+        return unban(userId, null);
+    }
+
+    /**
      * Requests to unban the specified user while optionally specifying a reason.
      *
      * @param userId The ID of the user to unban.
@@ -749,6 +771,18 @@ public final class Guild implements Entity {
         return serviceMediator.getRestClient().getGuildService()
                 .getGuildPruneCount(getId().asLong(), queryParams)
                 .map(PruneResponse::getPruned);
+    }
+
+    /**
+     * Requests to prune users. Users are pruned if they have not been seen within the past specified amount of days
+     * <i>and</i> are not assigned to any roles for this guild.
+     *
+     * @param days The number of days since an user must have been seen to avoid being kicked.
+     * @return A {@link Mono} where, upon successful completion, emits the number of users who were pruned. If an error
+     * is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Integer> prune(final int days) {
+        return prune(days, null);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -552,29 +552,16 @@ public final class Guild implements Entity {
     /**
      * Requests to edit this guild.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link GuildEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(GuildEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link GuildEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Guild> edit(final Consumer<GuildEditSpec> spec) {
+    public Mono<Guild> edit(final Consumer<? super GuildEditSpec> spec) {
         final GuildEditSpec mutatedSpec = new GuildEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this guild.
-     *
-     * @param spec A configured {@link GuildEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Guild> edit(final GuildEditSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .modifyGuild(getId().asLong(), spec.asRequest())
+                .modifyGuild(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(BaseGuildBean::new)
                 .map(bean -> new Guild(serviceMediator, bean));
     }
@@ -582,29 +569,16 @@ public final class Guild implements Entity {
     /**
      * Requests to create an emoji.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link GuildEmojiCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createEmoji(GuildEmojiCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link GuildEmojiCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link GuildEmoji}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<GuildEmoji> createEmoji(final Consumer<GuildEmojiCreateSpec> spec) {
+    public Mono<GuildEmoji> createEmoji(final Consumer<? super GuildEmojiCreateSpec> spec) {
         final GuildEmojiCreateSpec mutatedSpec = new GuildEmojiCreateSpec();
         spec.accept(mutatedSpec);
-        return createEmoji(mutatedSpec);
-    }
 
-    /**
-     * Requests to create an emoji.
-     *
-     * @param spec A configured {@link GuildEmojiCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link GuildEmoji}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<GuildEmoji> createEmoji(final GuildEmojiCreateSpec spec) {
         return serviceMediator.getRestClient().getEmojiService()
-                .createGuildEmoji(getId().asLong(), spec.asRequest())
+                .createGuildEmoji(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(GuildEmojiBean::new)
                 .map(bean -> new GuildEmoji(serviceMediator, bean, getId().asLong()));
     }
@@ -612,29 +586,16 @@ public final class Guild implements Entity {
     /**
      * Requests to create a role.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link RoleCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createRole(RoleCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link RoleCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link Role}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Role> createRole(final Consumer<RoleCreateSpec> spec) {
+    public Mono<Role> createRole(final Consumer<? super RoleCreateSpec> spec) {
         final RoleCreateSpec mutatedSpec = new RoleCreateSpec();
         spec.accept(mutatedSpec);
-        return createRole(mutatedSpec);
-    }
 
-    /**
-     * Requests to create a role.
-     *
-     * @param spec A configured {@link RoleCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link Role}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Role> createRole(final RoleCreateSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .createGuildRole(getId().asLong(), spec.asRequest())
+                .createGuildRole(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(RoleBean::new)
                 .map(bean -> new Role(serviceMediator, bean, getId().asLong()));
     }
@@ -642,29 +603,16 @@ public final class Guild implements Entity {
     /**
      * Requests to create a category.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link CategoryCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createCategory(CategoryCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link CategoryCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link Category}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Category> createCategory(final Consumer<CategoryCreateSpec> spec) {
+    public Mono<Category> createCategory(final Consumer<? super CategoryCreateSpec> spec) {
         final CategoryCreateSpec mutatedSpec = new CategoryCreateSpec();
         spec.accept(mutatedSpec);
-        return createCategory(mutatedSpec);
-    }
 
-    /**
-     * Requests to create a category.
-     *
-     * @param spec A configured {@link CategoryCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link Category}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Category> createCategory(final CategoryCreateSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .createGuildChannel(getId().asLong(), spec.asRequest())
+                .createGuildChannel(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(EntityUtil::getChannelBean)
                 .map(bean -> EntityUtil.getChannel(serviceMediator, bean))
                 .cast(Category.class);
@@ -673,29 +621,16 @@ public final class Guild implements Entity {
     /**
      * Requests to create a text channel.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link TextChannelCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createTextChannel(TextChannelCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link TextChannelCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link TextChannel}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<TextChannel> createTextChannel(final Consumer<TextChannelCreateSpec> spec) {
+    public Mono<TextChannel> createTextChannel(final Consumer<? super TextChannelCreateSpec> spec) {
         final TextChannelCreateSpec mutatedSpec = new TextChannelCreateSpec();
         spec.accept(mutatedSpec);
-        return createTextChannel(mutatedSpec);
-    }
 
-    /**
-     * Requests to create a text channel.
-     *
-     * @param spec A configured {@link TextChannelCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link TextChannel}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<TextChannel> createTextChannel(final TextChannelCreateSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .createGuildChannel(getId().asLong(), spec.asRequest())
+                .createGuildChannel(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(EntityUtil::getChannelBean)
                 .map(bean -> EntityUtil.getChannel(serviceMediator, bean))
                 .cast(TextChannel.class);
@@ -704,29 +639,16 @@ public final class Guild implements Entity {
     /**
      * Requests to create a voice channel.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link VoiceChannelCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createVoiceChannel(VoiceChannelCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link VoiceChannelCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link VoiceChannel}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<VoiceChannel> createVoiceChannel(final Consumer<VoiceChannelCreateSpec> spec) {
+    public Mono<VoiceChannel> createVoiceChannel(final Consumer<? super VoiceChannelCreateSpec> spec) {
         final VoiceChannelCreateSpec mutatedSpec = new VoiceChannelCreateSpec();
         spec.accept(mutatedSpec);
-        return createVoiceChannel(mutatedSpec);
-    }
 
-    /**
-     * Requests to create a voice channel.
-     *
-     * @param spec A configured {@link VoiceChannelCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link VoiceChannel}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<VoiceChannel> createVoiceChannel(final VoiceChannelCreateSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .createGuildChannel(getId().asLong(), spec.asRequest())
+                .createGuildChannel(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(EntityUtil::getChannelBean)
                 .map(bean -> EntityUtil.getChannel(serviceMediator, bean))
                 .cast(VoiceChannel.class);
@@ -743,14 +665,17 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Requests to kick the specified user from this guild.
+     * Requests to kick the specified user from this guild while optionally specifying a reason.
      *
      * @param userId The ID of the user to kick from this guild.
+     * @param reason The reason, if present.
+     *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the specified user was kicked
      * from this guild. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> kick(final Snowflake userId) {
-        return serviceMediator.getRestClient().getGuildService().removeGuildMember(getId().asLong(), userId.asLong());
+    public Mono<Void> kick(final Snowflake userId, @Nullable final String reason) {
+        return serviceMediator.getRestClient().getGuildService()
+                .removeGuildMember(getId().asLong(), userId.asLong(), reason);
     }
 
     /**
@@ -784,42 +709,29 @@ public final class Guild implements Entity {
      * Requests to ban the specified user.
      *
      * @param userId The ID of the user to ban.
-     * @param spec A {@link Consumer} that provides a "blank" {@link BanQuerySpec} to be operated on. If some properties
-     * need to be retrieved via blocking operations (such as retrieval from a database), then it is recommended to build
-     * the spec externally and call {@link #ban(Snowflake, BanQuerySpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link BanQuerySpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the specified user was
      * banned. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> ban(final Snowflake userId, final Consumer<BanQuerySpec> spec) {
+    public Mono<Void> ban(final Snowflake userId, final Consumer<? super BanQuerySpec> spec) {
         final BanQuerySpec mutatedSpec = new BanQuerySpec();
         spec.accept(mutatedSpec);
-        return ban(userId, mutatedSpec);
-    }
 
-    /**
-     * Requests to ban the specified user.
-     *
-     * @param userId The ID of the user to ban.
-     * @param spec A configured {@link BanQuerySpec} to perform the request on.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the specified user was
-     * banned. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Void> ban(final Snowflake userId, final BanQuerySpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .createGuildBan(getId().asLong(), userId.asLong(), spec.asRequest());
+                .createGuildBan(getId().asLong(), userId.asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason());
     }
 
     /**
-     * Requests to unban the specified user.
+     * Requests to unban the specified user while optionally specifying a reason.
      *
      * @param userId The ID of the user to unban.
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the specified user was
      * unbanned. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> unban(final Snowflake userId) {
-        return serviceMediator.getRestClient().getGuildService().removeGuildBan(getId().asLong(), userId.asLong());
+    public Mono<Void> unban(final Snowflake userId, @Nullable final String reason) {
+        return serviceMediator.getRestClient().getGuildService()
+                .removeGuildBan(getId().asLong(), userId.asLong(), reason);
     }
 
     /**
@@ -840,19 +752,21 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Requests to prune users. Users are pruned if they have not been seen within the past specified amount of days
-     * <i>and</i> are not assigned to any roles for this guild.
+     * Requests to prune users while optionally specifying a reason. Users are pruned if they have not been seen within
+     * the past specified amount of days <i>and</i> are not assigned to any roles for this guild.
      *
      * @param days The number of days since an user must have been seen to avoid being kicked.
+     * @param reason The reason, if present.
+     *
      * @return A {@link Mono} where, upon successful completion, emits the number of users who were pruned. If an error
      * is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Integer> prune(final int days) {
+    public Mono<Integer> prune(final int days, @Nullable final String reason) {
         final Map<String, Object> queryParams = new HashMap<>(1);
         queryParams.put("days", days);
 
         return serviceMediator.getRestClient().getGuildService()
-                .beginGuildPrune(getId().asLong(), queryParams)
+                .beginGuildPrune(getId().asLong(), queryParams, reason)
                 .map(PruneResponse::getPruned);
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/GuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildChannel.java
@@ -22,6 +22,7 @@ import discord4j.core.object.util.PermissionSet;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 
@@ -98,22 +99,26 @@ public interface GuildChannel extends Channel {
     Mono<Integer> getPosition();
 
     /**
-     * Requests to add a permission overwrite for the given member.
+     * Requests to add a permission overwrite for the given member while optionally specifying a reason.
      *
      * @param memberId The ID of the member to add the overwrite for.
      * @param overwrite The overwrite to add.
+     * @param reason The reason, if present.
+     *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the guild has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    Mono<Void> addMemberOverwrite(Snowflake memberId, PermissionOverwrite overwrite);
+    Mono<Void> addMemberOverwrite(Snowflake memberId, PermissionOverwrite overwrite, @Nullable String reason);
 
     /**
-     * Requests to add a permission overwrite for the given role.
+     * Requests to add a permission overwrite for the given role while optionally specifying a reason.
      *
      * @param roleId The ID of the role to add the overwrite for.
      * @param overwrite The overwrite to add.
+     * @param reason The reason, if present.
+     *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the guild has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    Mono<Void> addRoleOverwrite(Snowflake roleId, PermissionOverwrite overwrite);
+    Mono<Void> addRoleOverwrite(Snowflake roleId, PermissionOverwrite overwrite, @Nullable String reason);
 }

--- a/core/src/main/java/discord4j/core/object/entity/GuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildChannel.java
@@ -99,6 +99,19 @@ public interface GuildChannel extends Channel {
     Mono<Integer> getPosition();
 
     /**
+     * Requests to add a permission overwrite for the given member.
+     *
+     * @param memberId The ID of the member to add the overwrite for.
+     * @param overwrite The overwrite to add.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the guild has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    default Mono<Void> addMemberOverwrite(final Snowflake memberId, final PermissionOverwrite overwrite) {
+        return addMemberOverwrite(memberId, overwrite, null);
+    }
+
+    /**
      * Requests to add a permission overwrite for the given member while optionally specifying a reason.
      *
      * @param memberId The ID of the member to add the overwrite for.
@@ -109,6 +122,19 @@ public interface GuildChannel extends Channel {
      * If an error is received, it is emitted through the {@code Mono}.
      */
     Mono<Void> addMemberOverwrite(Snowflake memberId, PermissionOverwrite overwrite, @Nullable String reason);
+
+    /**
+     * Requests to add a permission overwrite for the given role.
+     *
+     * @param roleId The ID of the role to add the overwrite for.
+     * @param overwrite The overwrite to add.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the guild has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    default Mono<Void> addRoleOverwrite(final Snowflake roleId, final PermissionOverwrite overwrite) {
+        return addRoleOverwrite(roleId, overwrite, null);
+    }
 
     /**
      * Requests to add a permission overwrite for the given role while optionally specifying a reason.

--- a/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
@@ -188,6 +188,16 @@ public final class GuildEmoji implements Entity {
     }
 
     /**
+     * Requests to delete this emoji.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the emoji has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this emoji while optionally specifying a reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
@@ -173,42 +173,30 @@ public final class GuildEmoji implements Entity {
     /**
      * Requests to edit this guild emoji.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link GuildEmojiEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(GuildEmojiEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link GuildEmojiEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link GuildEmoji}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<GuildEmoji> edit(final Consumer<GuildEmojiEditSpec> spec) {
+    public Mono<GuildEmoji> edit(final Consumer<? super GuildEmojiEditSpec> spec) {
         final GuildEmojiEditSpec mutatedSpec = new GuildEmojiEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this guild emoji.
-     *
-     * @param spec A configured {@link GuildEmojiEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link GuildEmoji}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<GuildEmoji> edit(final GuildEmojiEditSpec spec) {
         return serviceMediator.getRestClient().getEmojiService()
-                .modifyGuildEmoji(getGuildId().asLong(), getId().asLong(), spec.asRequest())
+                .modifyGuildEmoji(getGuildId().asLong(), getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(GuildEmojiBean::new)
                 .map(bean -> new GuildEmoji(serviceMediator, bean, getGuildId().asLong()));
     }
 
     /**
-     * Requests to delete this emoji.
+     * Requests to delete this emoji while optionally specifying a reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the emoji has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> delete() {
+    public Mono<Void> delete(@Nullable final String reason) {
         return serviceMediator.getRestClient().getEmojiService()
-                .deleteGuildEmoji(getGuildId().asLong(), getId().asLong());
+                .deleteGuildEmoji(getGuildId().asLong(), getId().asLong(), reason);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -183,6 +183,16 @@ public final class Member extends User {
     }
 
     /**
+     * Requests to kick this member.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the member was kicked. If an
+     * error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> kick() {
+        return kick(null);
+    }
+
+    /**
      * Requests to kick this member while optionally specifying the reason.
      *
      * @param reason The reason, if present.
@@ -210,6 +220,16 @@ public final class Member extends User {
     }
 
     /**
+     * Requests to unban this user.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating this user was unbanned. If an
+     * error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> unban() {
+        return unban(null);
+    }
+
+    /**
      * Requests to unban this user while optionally specifying the reason.
      *
      * @param reason The reason, if present.
@@ -219,6 +239,17 @@ public final class Member extends User {
     public Mono<Void> unban(@Nullable final String reason) {
         return getServiceMediator().getRestClient().getGuildService()
                 .removeGuildBan(getGuildId().asLong(), getId().asLong(), reason);
+    }
+
+    /**
+     * Requests to add a role to this member.
+     *
+     * @param roleId The ID of the role to add to this member.
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the role was added to this
+     * member. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> addRole(final Snowflake roleId) {
+        return addRole(roleId, null);
     }
 
     /**
@@ -233,6 +264,17 @@ public final class Member extends User {
     public Mono<Void> addRole(final Snowflake roleId, @Nullable final String reason) {
         return getServiceMediator().getRestClient().getGuildService()
                 .addGuildMemberRole(guildId, getId().asLong(), roleId.asLong(), reason);
+    }
+
+    /**
+     * Requests to remove a role from this member.
+     *
+     * @param roleId The ID of the role to remove from this member.
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the role was removed from
+     * this member. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> removeRole(final Snowflake roleId) {
+        return removeRole(roleId, null);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -32,6 +32,7 @@ import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -182,77 +183,70 @@ public final class Member extends User {
     }
 
     /**
-     * Requests to kick this member.
+     * Requests to kick this member while optionally specifying the reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the member was kicked. If an
      * error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> kick() {
+    public Mono<Void> kick(@Nullable final String reason) {
         return getServiceMediator().getRestClient().getGuildService()
-                .removeGuildMember(getGuildId().asLong(), getId().asLong());
+                .removeGuildMember(getGuildId().asLong(), getId().asLong(), reason);
     }
 
     /**
      * Requests to ban this user.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link BanQuerySpec} to be operated on. If some properties
-     * need to be retrieved via blocking operations (such as retrieval from a database), then it is recommended to build
-     * the spec externally and call {@link #ban(BanQuerySpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link BanQuerySpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating this user was banned. If an
      * error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> ban(final Consumer<BanQuerySpec> spec) {
+    public Mono<Void> ban(final Consumer<? super BanQuerySpec> spec) {
         final BanQuerySpec mutatedSpec = new BanQuerySpec();
         spec.accept(mutatedSpec);
-        return ban(mutatedSpec);
-    }
 
-    /**
-     * Requests to ban this user.
-     *
-     * @param spec A configured {@link BanQuerySpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating this user was banned. If an
-     * error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Void> ban(final BanQuerySpec spec) {
         return getServiceMediator().getRestClient().getGuildService()
-                .createGuildBan(getGuildId().asLong(), getId().asLong(), spec.asRequest());
+                .createGuildBan(getGuildId().asLong(), getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason());
     }
 
     /**
-     * Requests to unban this user.
+     * Requests to unban this user while optionally specifying the reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating this user was unbanned. If an
      * error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> unban() {
+    public Mono<Void> unban(@Nullable final String reason) {
         return getServiceMediator().getRestClient().getGuildService()
-                .removeGuildBan(getGuildId().asLong(), getId().asLong());
+                .removeGuildBan(getGuildId().asLong(), getId().asLong(), reason);
     }
 
     /**
-     * Requests to add a role to this member.
+     * Requests to add a role to this member while optionally specifying the reason.
      *
      * @param roleId The ID of the role to add to this member.
+     * @param reason The reason, if present.
+     *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the role was added to this
      * member. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> addRole(final Snowflake roleId) {
+    public Mono<Void> addRole(final Snowflake roleId, @Nullable final String reason) {
         return getServiceMediator().getRestClient().getGuildService()
-                .addGuildMemberRole(guildId, getId().asLong(), roleId.asLong());
+                .addGuildMemberRole(guildId, getId().asLong(), roleId.asLong(), reason);
     }
 
     /**
-     * Requests to remove a role from this member.
+     * Requests to remove a role from this member while optionally specifying the reason.
      *
      * @param roleId The ID of the role to remove from this member.
+     * @param reason The reason, if present.
+     *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the role was removed from
      * this member. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> removeRole(final Snowflake roleId) {
+    public Mono<Void> removeRole(final Snowflake roleId, @Nullable final String reason) {
         return getServiceMediator().getRestClient().getGuildService()
-                .removeGuildMemberRole(guildId, getId().asLong(), roleId.asLong());
+                .removeGuildMemberRole(guildId, getId().asLong(), roleId.asLong(), reason);
     }
 
     /**
@@ -273,28 +267,16 @@ public final class Member extends User {
     /**
      * Requests to edit this member.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link GuildMemberEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(GuildMemberEditSpec)}.
+     * @param spec A {@link Consumer} that provides a "blank" {@link GuildMemberEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the member has been edited.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> edit(final Consumer<GuildMemberEditSpec> spec) {
+    public Mono<Void> edit(final Consumer<? super GuildMemberEditSpec> spec) {
         final GuildMemberEditSpec mutatedSpec = new GuildMemberEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this member.
-     *
-     * @param spec A configured {@link GuildMemberEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the member has been edited.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Void> edit(final GuildMemberEditSpec spec) {
         return getServiceMediator().getRestClient().getGuildService()
-                .modifyGuildMember(getGuildId().asLong(), getId().asLong(), spec.asRequest());
+                .modifyGuildMember(getGuildId().asLong(), getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason());
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -339,6 +339,16 @@ public final class Message implements Entity {
     }
 
     /**
+     * Requests to delete this message.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the message has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this message while optionally specifying a reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -324,42 +324,30 @@ public final class Message implements Entity {
     /**
      * Requests to edit this message.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link MessageEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(MessageEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link MessageEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link Message}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Message> edit(final Consumer<MessageEditSpec> spec) {
+    public Mono<Message> edit(final Consumer<? super MessageEditSpec> spec) {
         final MessageEditSpec mutatedSpec = new MessageEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this message.
-     *
-     * @param spec A configured {@link MessageEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Message}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Message> edit(final MessageEditSpec spec) {
         return serviceMediator.getRestClient().getChannelService()
-                .editMessage(getChannelId().asLong(), getId().asLong(), spec.asRequest())
+                .editMessage(getChannelId().asLong(), getId().asLong(), mutatedSpec.asRequest())
                 .map(MessageBean::new)
                 .map(bean -> new Message(serviceMediator, bean));
     }
 
     /**
-     * Requests to delete this message.
+     * Requests to delete this message while optionally specifying a reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the message has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> delete() {
+    public Mono<Void> delete(@Nullable final String reason) {
         return serviceMediator.getRestClient().getChannelService()
-                .deleteMessage(getChannelId().asLong(), getId().asLong());
+                .deleteMessage(getChannelId().asLong(), getId().asLong(), reason);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/MessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/MessageChannel.java
@@ -55,27 +55,14 @@ public interface MessageChannel extends Channel {
     /**
      * Requests to create a message.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link MessageCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createMessage(MessageCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link MessageCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link Message}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    Mono<Message> createMessage(Consumer<MessageCreateSpec> spec);
+    Mono<Message> createMessage(Consumer<? super MessageCreateSpec> spec);
 
     /**
-     * Requests to create a message.
-     *
-     * @param spec A configured {@link MessageCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link Message}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    Mono<Message> createMessage(MessageCreateSpec spec);
-
-    /**
-     * Requests to create a message. This forwards to {@link #createMessage(MessageCreateSpec)} and
-     * acts as a convenience utility.
+     * Requests to create a message with only {@link MessageCreateSpec#setContent(String) content}.
      *
      * @param message A string message to populate the message with.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link Message}. If an error is
@@ -83,8 +70,8 @@ public interface MessageChannel extends Channel {
      *
      * @see MessageCreateSpec#setContent(String)
      */
-    default Mono<Message> createMessage(String message) {
-        return createMessage(new MessageCreateSpec().setContent(message));
+    default Mono<Message> createMessage(final String message) {
+        return createMessage(spec -> spec.setContent(message));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Role.java
+++ b/core/src/main/java/discord4j/core/object/entity/Role.java
@@ -174,42 +174,30 @@ public final class Role implements Entity {
     /**
      * Requests to edit this role.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link RoleEditSpec} to be operated on. If some properties
-     * need to be retrieved via blocking operations (such as retrieval from a database), then it is recommended to build
-     * the spec externally and call {@link #edit(RoleEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link RoleEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link Role}. If an error is received,
      * it is emitted through the {@code Mono}.
      */
-    public Mono<Role> edit(final Consumer<RoleEditSpec> spec) {
+    public Mono<Role> edit(final Consumer<? super RoleEditSpec> spec) {
         final RoleEditSpec mutatedSpec = new RoleEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this role.
-     *
-     * @param spec A configured {@link RoleEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Role}. If an error is received,
-     * it is emitted through the {@code Mono}.
-     */
-    public Mono<Role> edit(final RoleEditSpec spec) {
         return serviceMediator.getRestClient().getGuildService()
-                .modifyGuildRole(getGuildId().asLong(), getId().asLong(), spec.asRequest())
+                .modifyGuildRole(getGuildId().asLong(), getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(RoleBean::new)
                 .map(bean -> new Role(serviceMediator, bean, getGuildId().asLong()));
     }
 
     /**
-     * Requests to delete this role.
+     * Requests to delete this role while optionally specifying the reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the role has been deleted. If
      * an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> delete() {
+    public Mono<Void> delete(@Nullable final String reason) {
         return serviceMediator.getRestClient().getGuildService()
-                .deleteGuildRole(getGuildId().asLong(), getId().asLong());
+                .deleteGuildRole(getGuildId().asLong(), getId().asLong(), reason);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Role.java
+++ b/core/src/main/java/discord4j/core/object/entity/Role.java
@@ -189,6 +189,16 @@ public final class Role implements Entity {
     }
 
     /**
+     * Requests to delete this role.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the role has been deleted. If
+     * an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this role while optionally specifying the reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/entity/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/VoiceChannel.java
@@ -72,9 +72,12 @@ public final class VoiceChannel extends BaseGuildChannel implements Categorizabl
     }
 
     @Override
-    public Mono<ExtendedInvite> createInvite(final InviteCreateSpec spec) {
+    public Mono<ExtendedInvite> createInvite(final Consumer<? super InviteCreateSpec> spec) {
+        final InviteCreateSpec mutatedSpec = new InviteCreateSpec();
+        spec.accept(mutatedSpec);
+
         return getServiceMediator().getRestClient().getChannelService()
-                .createChannelInvite(getId().asLong(), spec.asRequest())
+                .createChannelInvite(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(ExtendedInviteBean::new)
                 .map(bean -> new ExtendedInvite(getServiceMediator(), bean));
     }
@@ -108,29 +111,16 @@ public final class VoiceChannel extends BaseGuildChannel implements Categorizabl
     /**
      * Requests to edit a voice channel.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link VoiceChannelEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(VoiceChannelEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link VoiceChannelEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link VoiceChannel}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<VoiceChannel> edit(final Consumer<VoiceChannelEditSpec> spec) {
+    public Mono<VoiceChannel> edit(final Consumer<? super VoiceChannelEditSpec> spec) {
         final VoiceChannelEditSpec mutatedSpec = new VoiceChannelEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit a voice channel.
-     *
-     * @param spec A configured {@link VoiceChannelEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link VoiceChannel}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<VoiceChannel> edit(final VoiceChannelEditSpec spec) {
         return getServiceMediator().getRestClient().getChannelService()
-                .modifyChannel(getId().asLong(), spec.asRequest())
+                .modifyChannel(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(EntityUtil::getChannelBean)
                 .map(bean -> EntityUtil.getChannel(getServiceMediator(), bean))
                 .cast(VoiceChannel.class);

--- a/core/src/main/java/discord4j/core/object/entity/Webhook.java
+++ b/core/src/main/java/discord4j/core/object/entity/Webhook.java
@@ -148,6 +148,16 @@ public final class Webhook implements Entity {
     }
 
     /**
+     * Requests to delete this webhook.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the webhook has been deleted.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Void> delete() {
+        return delete(null);
+    }
+
+    /**
      * Requests to delete this webhook while optionally specifying a reason.
      *
      * @param reason The reason, if present.

--- a/core/src/main/java/discord4j/core/object/entity/Webhook.java
+++ b/core/src/main/java/discord4j/core/object/entity/Webhook.java
@@ -148,41 +148,29 @@ public final class Webhook implements Entity {
     }
 
     /**
-     * Requests to delete this webhook.
+     * Requests to delete this webhook while optionally specifying a reason.
      *
+     * @param reason The reason, if present.
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the webhook has been deleted.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Void> delete() {
-        return serviceMediator.getRestClient().getWebhookService().deleteWebhook(getId().asLong());
+    public Mono<Void> delete(@Nullable final String reason) {
+        return serviceMediator.getRestClient().getWebhookService().deleteWebhook(getId().asLong(), reason);
     }
 
     /**
      * Requests to edit this webhook.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link WebhookEditSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #edit(WebhookEditSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link WebhookEditSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<Webhook> edit(final Consumer<WebhookEditSpec> spec) {
+    public Mono<Webhook> edit(final Consumer<? super WebhookEditSpec> spec) {
         final WebhookEditSpec mutatedSpec = new WebhookEditSpec();
         spec.accept(mutatedSpec);
-        return edit(mutatedSpec);
-    }
 
-    /**
-     * Requests to edit this webhook.
-     *
-     * @param spec A configured {@link WebhookEditSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Webhook}. If an error is
-     * received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Webhook> edit(final WebhookEditSpec spec) {
         return serviceMediator.getRestClient().getWebhookService()
-                .modifyWebhook(getId().asLong(), spec.asRequest())
+                .modifyWebhook(getId().asLong(), mutatedSpec.asRequest(), mutatedSpec.getReason())
                 .map(WebhookBean::new)
                 .map(bean -> new Webhook(serviceMediator, bean));
     }

--- a/core/src/main/java/discord4j/core/object/trait/Invitable.java
+++ b/core/src/main/java/discord4j/core/object/trait/Invitable.java
@@ -30,27 +30,11 @@ public interface Invitable {
     /**
      * Requests to create an invite.
      *
-     * @param spec A {@link Consumer} that provides a "blank" {@link InviteCreateSpec} to be operated on. If some
-     * properties need to be retrieved via blocking operations (such as retrieval from a database), then it is
-     * recommended to build the spec externally and call {@link #createInvite(InviteCreateSpec)}.
-     *
+     * @param spec A {@link Consumer} that provides a "blank" {@link InviteCreateSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits the created {@link ExtendedInvite}. If an error
      * is received, it is emitted through the {@code Mono}.
      */
-    default Mono<ExtendedInvite> createInvite(final Consumer<InviteCreateSpec> spec) {
-        final InviteCreateSpec mutatedSpec = new InviteCreateSpec();
-        spec.accept(mutatedSpec);
-        return createInvite(mutatedSpec);
-    }
-
-    /**
-     * Requests to create an invite.
-     *
-     * @param spec A configured {@link InviteCreateSpec} to perform the request on.
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link ExtendedInvite}. If an error
-     * is received, it is emitted through the {@code Mono}.
-     */
-    Mono<ExtendedInvite> createInvite(InviteCreateSpec spec);
+    Mono<ExtendedInvite> createInvite(final Consumer<? super InviteCreateSpec> spec);
 
     /**
      * Requests to retrieve this channel's invites.

--- a/core/src/main/java/discord4j/core/spec/AuditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/AuditSpec.java
@@ -16,8 +16,12 @@
  */
 package discord4j.core.spec;
 
-@FunctionalInterface
-public interface Spec<T> {
+import javax.annotation.Nullable;
 
-    T asRequest();
+public interface AuditSpec<T> extends Spec<T> {
+
+    AuditSpec<T> setReason(@Nullable String reason);
+
+    @Nullable
+    String getReason();
 }

--- a/core/src/main/java/discord4j/core/spec/BanQuerySpec.java
+++ b/core/src/main/java/discord4j/core/spec/BanQuerySpec.java
@@ -16,21 +16,30 @@
  */
 package discord4j.core.spec;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
-public final class BanQuerySpec implements Spec<Map<String, Object>> {
+public final class BanQuerySpec implements AuditSpec<Map<String, Object>> {
 
     private final Map<String, Object> request = new HashMap<>(2);
-
-    public BanQuerySpec setReason(final String reason) {
-        request.put("reason", reason);
-        return this;
-    }
 
     public BanQuerySpec setDeleteMessageDays(final int days) {
         request.put("delete-message-days", days);
         return this;
+    }
+
+    @Override
+    public BanQuerySpec setReason(@Nullable final String reason) {
+        request.put("reason", reason);
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return (String) request.get("reason");
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/CategoryCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/CategoryCreateSpec.java
@@ -21,12 +21,16 @@ import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.Channel;
 import discord4j.rest.json.request.ChannelCreateRequest;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
-public class CategoryCreateSpec implements Spec<ChannelCreateRequest> {
+public class CategoryCreateSpec implements AuditSpec<ChannelCreateRequest> {
 
     private final ChannelCreateRequest.Builder requestBuilder = ChannelCreateRequest.builder()
             .type(Channel.Type.GUILD_CATEGORY.getValue());
+    @Nullable
+    private String reason;
 
     public CategoryCreateSpec setName(String name) {
         requestBuilder.name(name);
@@ -40,6 +44,18 @@ public class CategoryCreateSpec implements Spec<ChannelCreateRequest> {
 
         requestBuilder.permissionOverwrites(raw);
         return this;
+    }
+
+    @Override
+    public CategoryCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/CategoryEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/CategoryEditSpec.java
@@ -20,11 +20,15 @@ import discord4j.common.json.OverwriteEntity;
 import discord4j.core.object.PermissionOverwrite;
 import discord4j.rest.json.request.ChannelModifyRequest;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
-public class CategoryEditSpec implements Spec<ChannelModifyRequest> {
+public class CategoryEditSpec implements AuditSpec<ChannelModifyRequest> {
 
     private final ChannelModifyRequest.Builder requestBuilder = ChannelModifyRequest.builder();
+    @Nullable
+    private String reason;
 
     public CategoryEditSpec setName(String name) {
         requestBuilder.name(name);
@@ -43,6 +47,18 @@ public class CategoryEditSpec implements Spec<ChannelModifyRequest> {
 
         requestBuilder.permissionOverwrites(raw);
         return this;
+    }
+
+    @Override
+    public CategoryEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
@@ -27,6 +27,7 @@ import discord4j.rest.json.request.RoleCreateRequest;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class GuildCreateSpec implements Spec<GuildCreateRequest> {
 
@@ -64,13 +65,17 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
         return this;
     }
 
-    public GuildCreateSpec addRole(RoleCreateSpec roleSpec) {
-        roles.add(roleSpec.asRequest());
+    public GuildCreateSpec addRole(Consumer<? super RoleCreateSpec> roleSpec) {
+        final RoleCreateSpec mutatedSpec = new RoleCreateSpec();
+        roleSpec.accept(mutatedSpec);
+        roles.add(mutatedSpec.asRequest());
         return this;
     }
 
-    public GuildCreateSpec addEveryoneRole(RoleCreateSpec roleSpec) {
-        roles.add(0, roleSpec.asRequest());
+    public GuildCreateSpec addEveryoneRole(Consumer<? super RoleCreateSpec> roleSpec) {
+        final RoleCreateSpec mutatedSpec = new RoleCreateSpec();
+        roleSpec.accept(mutatedSpec);
+        roles.add(mutatedSpec.asRequest());
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
@@ -23,10 +23,13 @@ import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.GuildModifyRequest;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
-public class GuildEditSpec implements Spec<GuildModifyRequest> {
+public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
 
     private final GuildModifyRequest.Builder requestBuilder = GuildModifyRequest.builder();
+    @Nullable
+    private String reason;
 
     public GuildEditSpec setName(String name) {
         requestBuilder.name(name);
@@ -71,6 +74,18 @@ public class GuildEditSpec implements Spec<GuildModifyRequest> {
     public GuildEditSpec setSplash(@Nullable String splash) {
         requestBuilder.splash(splash);
         return this;
+    }
+
+    @Override
+    public GuildEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/GuildEmojiCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEmojiCreateSpec.java
@@ -20,14 +20,17 @@ import discord4j.core.object.util.Image;
 import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.GuildEmojiCreateRequest;
 
+import javax.annotation.Nullable;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
-public class GuildEmojiCreateSpec implements Spec<GuildEmojiCreateRequest> {
+public class GuildEmojiCreateSpec implements AuditSpec<GuildEmojiCreateRequest> {
 
     private String name;
     private String image;
     private final Set<Snowflake> roles = new HashSet<>();
+    private String reason;
 
     public GuildEmojiCreateSpec setName(String name) {
         this.name = name;
@@ -42,6 +45,18 @@ public class GuildEmojiCreateSpec implements Spec<GuildEmojiCreateRequest> {
     public GuildEmojiCreateSpec addRole(Snowflake roleId) {
         roles.add(roleId);
         return this;
+    }
+
+    @Override
+    public GuildEmojiCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/GuildEmojiEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEmojiEditSpec.java
@@ -20,12 +20,15 @@ import discord4j.common.jackson.Possible;
 import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.GuildEmojiModifyRequest;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
-public class GuildEmojiEditSpec implements Spec<GuildEmojiModifyRequest> {
+public class GuildEmojiEditSpec implements AuditSpec<GuildEmojiModifyRequest> {
 
     private Possible<String> name = Possible.absent();
     private Possible<long[]> roles = Possible.absent();
+    private String reason;
 
     public GuildEmojiEditSpec setName(String name) {
         this.name = Possible.of(name);
@@ -35,6 +38,18 @@ public class GuildEmojiEditSpec implements Spec<GuildEmojiModifyRequest> {
     public GuildEmojiEditSpec setRoles(Set<Snowflake> roles) {
         this.roles = Possible.of(roles.stream().mapToLong(Snowflake::asLong).toArray());
         return this;
+    }
+
+    @Override
+    public GuildEmojiEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/GuildMemberEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildMemberEditSpec.java
@@ -22,9 +22,11 @@ import discord4j.rest.json.request.GuildMemberModifyRequest;
 import javax.annotation.Nullable;
 import java.util.Set;
 
-public class GuildMemberEditSpec implements Spec<GuildMemberModifyRequest> {
+public class GuildMemberEditSpec implements AuditSpec<GuildMemberModifyRequest> {
 
     private final GuildMemberModifyRequest.Builder builder = GuildMemberModifyRequest.builder();
+    @Nullable
+    private String reason;
 
     public GuildMemberEditSpec setNewVoiceChannel(@Nullable Snowflake channel) {
         builder.channelId(channel == null ? null : channel.asLong());
@@ -49,6 +51,18 @@ public class GuildMemberEditSpec implements Spec<GuildMemberModifyRequest> {
     public GuildMemberEditSpec setRoles(Set<Snowflake> roles) {
         builder.roles(roles.stream().mapToLong(Snowflake::asLong).toArray());
         return this;
+    }
+
+    @Override
+    public GuildMemberEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/InviteCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/InviteCreateSpec.java
@@ -18,12 +18,15 @@ package discord4j.core.spec;
 
 import discord4j.rest.json.request.InviteCreateRequest;
 
-public class InviteCreateSpec implements Spec<InviteCreateRequest> {
+import javax.annotation.Nullable;
+
+public class InviteCreateSpec implements AuditSpec<InviteCreateRequest> {
 
     private int maxAge;
     private int maxUses;
     private boolean temporary;
     private boolean unique;
+    private String reason;
 
     public InviteCreateSpec setMaxAge(int maxAge) {
         this.maxAge = maxAge;
@@ -43,6 +46,18 @@ public class InviteCreateSpec implements Spec<InviteCreateRequest> {
     public InviteCreateSpec setUnique(boolean unique) {
         this.unique = unique;
         return this;
+    }
+
+    @Override
+    public InviteCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -51,14 +51,10 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
         return this;
     }
 
-    public MessageCreateSpec setEmbed(Consumer<EmbedCreateSpec> spec) {
+    public MessageCreateSpec setEmbed(Consumer<? super EmbedCreateSpec> spec) {
         final EmbedCreateSpec mutatedSpec = new EmbedCreateSpec();
         spec.accept(mutatedSpec);
-        return setEmbed(mutatedSpec);
-    }
-
-    public MessageCreateSpec setEmbed(EmbedCreateSpec embed) {
-        this.embed = embed.asRequest();
+        embed = mutatedSpec.asRequest();
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpec.java
@@ -21,6 +21,7 @@ import discord4j.rest.json.request.EmbedRequest;
 import discord4j.rest.json.request.MessageEditRequest;
 
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 
 public class MessageEditSpec implements Spec<MessageEditRequest> {
 
@@ -34,8 +35,15 @@ public class MessageEditSpec implements Spec<MessageEditRequest> {
         return this;
     }
 
-    public MessageEditSpec setEmbed(@Nullable EmbedCreateSpec embed) {
-        this.embed = embed == null ? null : Possible.of(embed.asRequest());
+    public MessageEditSpec setEmbed(@Nullable Consumer<? super EmbedCreateSpec> spec) {
+        if (spec != null) {
+            final EmbedCreateSpec mutatedSpec = new EmbedCreateSpec();
+            spec.accept(mutatedSpec);
+            embed = Possible.of(mutatedSpec.asRequest());
+        } else {
+            embed = null;
+        }
+
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/RoleCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/RoleCreateSpec.java
@@ -19,15 +19,18 @@ package discord4j.core.spec;
 import discord4j.core.object.util.PermissionSet;
 import discord4j.rest.json.request.RoleCreateRequest;
 
+import javax.annotation.Nullable;
 import java.awt.*;
+import java.util.Optional;
 
-public class RoleCreateSpec implements Spec<RoleCreateRequest> {
+public class RoleCreateSpec implements AuditSpec<RoleCreateRequest> {
 
     private String name;
     private long permissions;
     private int color;
     private boolean hoist;
     private boolean mentionable;
+    private String reason;
 
     public RoleCreateSpec setName(String name) {
         this.name = name;
@@ -52,6 +55,18 @@ public class RoleCreateSpec implements Spec<RoleCreateRequest> {
     public RoleCreateSpec setMentionable(boolean mentionable) {
         this.mentionable = mentionable;
         return this;
+    }
+
+    @Override
+    public RoleCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/RoleEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/RoleEditSpec.java
@@ -19,11 +19,14 @@ package discord4j.core.spec;
 import discord4j.core.object.util.PermissionSet;
 import discord4j.rest.json.request.RoleModifyRequest;
 
+import javax.annotation.Nullable;
 import java.awt.*;
 
-public class RoleEditSpec implements Spec<RoleModifyRequest> {
+public class RoleEditSpec implements AuditSpec<RoleModifyRequest> {
 
     private final RoleModifyRequest.Builder requestBuilder = RoleModifyRequest.builder();
+    @Nullable
+    private String reason;
 
     public RoleEditSpec setName(String name) {
         requestBuilder.name(name);
@@ -48,6 +51,18 @@ public class RoleEditSpec implements Spec<RoleModifyRequest> {
     public RoleEditSpec setMentionable(boolean mentionable) {
         requestBuilder.mentionable(mentionable);
         return this;
+    }
+
+    @Override
+    public RoleEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/TextChannelCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelCreateSpec.java
@@ -23,12 +23,15 @@ import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.ChannelCreateRequest;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
-public class TextChannelCreateSpec implements Spec<ChannelCreateRequest> {
+public class TextChannelCreateSpec implements AuditSpec<ChannelCreateRequest> {
 
     private final ChannelCreateRequest.Builder requestBuilder = ChannelCreateRequest.builder()
             .type(Channel.Type.GUILD_TEXT.getValue());
+    @Nullable
+    private String reason;
 
     public TextChannelCreateSpec setName(String name) {
         requestBuilder.name(name);
@@ -62,6 +65,18 @@ public class TextChannelCreateSpec implements Spec<ChannelCreateRequest> {
     public TextChannelCreateSpec setRateLimitPerUser(int rateLimitPerUser) {
         requestBuilder.rateLimitPerUser(rateLimitPerUser);
         return this;
+    }
+
+    @Override
+    public TextChannelCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/TextChannelEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelEditSpec.java
@@ -24,9 +24,11 @@ import discord4j.rest.json.request.ChannelModifyRequest;
 import javax.annotation.Nullable;
 import java.util.Set;
 
-public class TextChannelEditSpec implements Spec<ChannelModifyRequest> {
+public class TextChannelEditSpec implements AuditSpec<ChannelModifyRequest> {
 
     private final ChannelModifyRequest.Builder requestBuilder = ChannelModifyRequest.builder();
+    @Nullable
+    private String reason;
 
     public TextChannelEditSpec setName(String name) {
         requestBuilder.name(name);
@@ -65,6 +67,18 @@ public class TextChannelEditSpec implements Spec<ChannelModifyRequest> {
     public TextChannelEditSpec setRateLimitPerUser(int rateLimitPerUser) {
         requestBuilder.rateLimitPerUser(rateLimitPerUser);
         return this;
+    }
+
+    @Override
+    public TextChannelEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpec.java
@@ -23,12 +23,15 @@ import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.ChannelCreateRequest;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
-public class VoiceChannelCreateSpec implements Spec<ChannelCreateRequest> {
+public class VoiceChannelCreateSpec implements AuditSpec<ChannelCreateRequest> {
 
     private final ChannelCreateRequest.Builder requestBuilder = ChannelCreateRequest.builder()
             .type(Channel.Type.GUILD_VOICE.getValue());
+    @Nullable
+    private String reason;
 
     public VoiceChannelCreateSpec setName(String name) {
         requestBuilder.name(name);
@@ -57,6 +60,18 @@ public class VoiceChannelCreateSpec implements Spec<ChannelCreateRequest> {
     public VoiceChannelCreateSpec setParentId(@Nullable Snowflake parentId) {
         requestBuilder.parentId(parentId == null ? null : parentId.asLong());
         return this;
+    }
+
+    @Override
+    public VoiceChannelCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpec.java
@@ -24,9 +24,11 @@ import discord4j.rest.json.request.ChannelModifyRequest;
 import javax.annotation.Nullable;
 import java.util.Set;
 
-public class VoiceChannelEditSpec implements Spec<ChannelModifyRequest> {
+public class VoiceChannelEditSpec implements AuditSpec<ChannelModifyRequest> {
 
     private final ChannelModifyRequest.Builder requestBuilder = ChannelModifyRequest.builder();
+    @Nullable
+    private String reason;
 
     public VoiceChannelEditSpec setName(String name) {
         requestBuilder.name(name);
@@ -60,6 +62,18 @@ public class VoiceChannelEditSpec implements Spec<ChannelModifyRequest> {
     public VoiceChannelEditSpec setUserLimit(int userLimit) {
         requestBuilder.userLimit(userLimit);
         return this;
+    }
+
+    @Override
+    public VoiceChannelEditSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/WebhookCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookCreateSpec.java
@@ -18,10 +18,13 @@ package discord4j.core.spec;
 
 import discord4j.rest.json.request.WebhookCreateRequest;
 
-public class WebhookCreateSpec implements Spec<WebhookCreateRequest> {
+import javax.annotation.Nullable;
+
+public class WebhookCreateSpec implements AuditSpec<WebhookCreateRequest> {
 
     private String name;
     private String avatar;
+    private String reason;
 
     public WebhookCreateSpec setName(String name) {
         this.name = name;
@@ -31,6 +34,18 @@ public class WebhookCreateSpec implements Spec<WebhookCreateRequest> {
     public WebhookCreateSpec setAvatar(String avatar) {
         this.avatar = avatar;
         return this;
+    }
+
+    @Override
+    public WebhookCreateSpec setReason(@Nullable final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Nullable
+    @Override
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/WebhookEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookEditSpec.java
@@ -19,10 +19,13 @@ package discord4j.core.spec;
 import discord4j.common.jackson.Possible;
 import discord4j.rest.json.request.WebhookModifyRequest;
 
-public class WebhookEditSpec implements Spec<WebhookModifyRequest> {
+import javax.annotation.Nullable;
+
+public class WebhookEditSpec implements AuditSpec<WebhookModifyRequest> {
 
     private Possible<String> name = Possible.absent();
     private Possible<String> avatar = Possible.absent();
+    private String reason;
 
     public WebhookEditSpec setName(String name) {
         this.name = Possible.of(name);
@@ -32,6 +35,18 @@ public class WebhookEditSpec implements Spec<WebhookModifyRequest> {
     public WebhookEditSpec setAvatar(String avatar) {
         this.avatar = Possible.of(avatar);
         return this;
+    }
+
+    @Override
+    public WebhookEditSpec setReason(final String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Nullable
+    @Override
+    public String getReason() {
+        return reason;
     }
 
     @Override

--- a/core/src/test/java/discord4j/core/ExampleBot.java
+++ b/core/src/test/java/discord4j/core/ExampleBot.java
@@ -101,7 +101,7 @@ public class ExampleBot {
                     .map(Mono::just)
                     .orElseGet(Mono::empty)
                     .flatMap(content -> message.getAuthorAsMember())
-                    .flatMap(member -> member.addRole(Snowflake.of(testRole)));
+                    .flatMap(member -> member.addRole(Snowflake.of(testRole), null));
             // if "testRole" is null, the bot will keep processing events despite throwing an error
         }
     }

--- a/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
@@ -126,6 +126,18 @@ public class DiscordRequest<T> {
     }
 
     /**
+     * Adds the given key and value to the headers of this request
+     * if and only if {@code value} is not {@code null}.
+     *
+     * @param key the header key
+     * @param value the header value
+     * @return this request
+     */
+    public DiscordRequest<T> optionalHeader(String key, @Nullable String value) {
+        return (value == null) ? this : header(key, value);
+    }
+
+    /**
      * Exchange this request through the given {@link Router}.
      *
      * @param router a router that performs this request

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -27,6 +27,7 @@ import discord4j.rest.util.MultipartRequest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,14 +42,16 @@ public class ChannelService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<ChannelResponse> modifyChannel(long channelId, ChannelModifyRequest request) {
+    public Mono<ChannelResponse> modifyChannel(long channelId, ChannelModifyRequest request, @Nullable String reason) {
         return Routes.CHANNEL_MODIFY_PARTIAL.newRequest(channelId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<ChannelResponse> deleteChannel(long channelId) {
+    public Mono<ChannelResponse> deleteChannel(long channelId, @Nullable String reason) {
         return Routes.CHANNEL_DELETE.newRequest(channelId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -105,8 +108,9 @@ public class ChannelService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<Void> deleteMessage(long channelId, long messageId) {
+    public Mono<Void> deleteMessage(long channelId, long messageId, @Nullable String reason) {
         return Routes.MESSAGE_DELETE.newRequest(channelId, messageId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -116,9 +120,10 @@ public class ChannelService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<Void> editChannelPermissions(long channelId, long overwriteId, PermissionsEditRequest request) {
+    public Mono<Void> editChannelPermissions(long channelId, long overwriteId, PermissionsEditRequest request, @Nullable String reason) {
         return Routes.CHANNEL_PERMISSIONS_EDIT.newRequest(channelId, overwriteId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -128,14 +133,16 @@ public class ChannelService extends RestService {
                 .flatMapMany(Flux::fromArray);
     }
 
-    public Mono<InviteResponse> createChannelInvite(long channelId, InviteCreateRequest request) {
+    public Mono<InviteResponse> createChannelInvite(long channelId, InviteCreateRequest request, @Nullable String reason) {
         return Routes.CHANNEL_INVITE_CREATE.newRequest(channelId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> deleteChannelPermission(long channelId, long overwriteId) {
+    public Mono<Void> deleteChannelPermission(long channelId, long overwriteId, @Nullable String reason) {
         return Routes.CHANNEL_PERMISSION_DELETE.newRequest(channelId, overwriteId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 

--- a/rest/src/main/java/discord4j/rest/service/EmojiService.java
+++ b/rest/src/main/java/discord4j/rest/service/EmojiService.java
@@ -24,6 +24,8 @@ import discord4j.rest.route.Routes;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
+
 public class EmojiService extends RestService {
 
     public EmojiService(Router router) {
@@ -41,20 +43,23 @@ public class EmojiService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<GuildEmojiResponse> createGuildEmoji(long guildId, GuildEmojiCreateRequest request) {
+    public Mono<GuildEmojiResponse> createGuildEmoji(long guildId, GuildEmojiCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_EMOJI_CREATE.newRequest(guildId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<GuildEmojiResponse> modifyGuildEmoji(long guildId, long emojiId, GuildEmojiModifyRequest request) {
+    public Mono<GuildEmojiResponse> modifyGuildEmoji(long guildId, long emojiId, GuildEmojiModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_EMOJI_MODIFY.newRequest(guildId, emojiId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> deleteGuildEmoji(long guildId, long emojiId) {
+    public Mono<Void> deleteGuildEmoji(long guildId, long emojiId, @Nullable String reason) {
         return Routes.GUILD_EMOJI_DELETE.newRequest(guildId, emojiId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -25,6 +25,7 @@ import discord4j.rest.route.Routes;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public class GuildService extends RestService {
@@ -44,9 +45,10 @@ public class GuildService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<GuildResponse> modifyGuild(long guildId, GuildModifyRequest request) {
+    public Mono<GuildResponse> modifyGuild(long guildId, GuildModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_MODIFY.newRequest(guildId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -61,9 +63,10 @@ public class GuildService extends RestService {
                 .flatMapMany(Flux::fromArray);
     }
 
-    public Mono<ChannelResponse> createGuildChannel(long guildId, ChannelCreateRequest request) {
+    public Mono<ChannelResponse> createGuildChannel(long guildId, ChannelCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_CHANNEL_CREATE.newRequest(guildId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -92,9 +95,10 @@ public class GuildService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<Void> modifyGuildMember(long guildId, long userId, GuildMemberModifyRequest request) {
+    public Mono<Void> modifyGuildMember(long guildId, long userId, GuildMemberModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_MEMBER_MODIFY.newRequest(guildId, userId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -104,18 +108,21 @@ public class GuildService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<Void> addGuildMemberRole(long guildId, long userId, long roleId) {
+    public Mono<Void> addGuildMemberRole(long guildId, long userId, long roleId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_ROLE_ADD.newRequest(guildId, userId, roleId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> removeGuildMemberRole(long guildId, long userId, long roleId) {
+    public Mono<Void> removeGuildMemberRole(long guildId, long userId, long roleId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_ROLE_REMOVE.newRequest(guildId, userId, roleId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> removeGuildMember(long guildId, long userId) {
+    public Mono<Void> removeGuildMember(long guildId, long userId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_REMOVE.newRequest(guildId, userId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -130,14 +137,16 @@ public class GuildService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<Void> createGuildBan(long guildId, long userId, Map<String, Object> queryParams) {
+    public Mono<Void> createGuildBan(long guildId, long userId, Map<String, Object> queryParams, @Nullable String reason) {
         return Routes.GUILD_BAN_CREATE.newRequest(guildId, userId)
                 .query(queryParams)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> removeGuildBan(long guildId, long userId) {
+    public Mono<Void> removeGuildBan(long guildId, long userId, @Nullable String reason) {
         return Routes.GUILD_BAN_REMOVE.newRequest(guildId, userId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -147,9 +156,10 @@ public class GuildService extends RestService {
                 .flatMapMany(Flux::fromArray);
     }
 
-    public Mono<RoleResponse> createGuildRole(long guildId, RoleCreateRequest request) {
+    public Mono<RoleResponse> createGuildRole(long guildId, RoleCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_ROLE_CREATE.newRequest(guildId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -160,14 +170,16 @@ public class GuildService extends RestService {
                 .flatMapMany(Flux::fromArray);
     }
 
-    public Mono<RoleResponse> modifyGuildRole(long guildId, long roleId, RoleModifyRequest request) {
+    public Mono<RoleResponse> modifyGuildRole(long guildId, long roleId, RoleModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_ROLE_MODIFY.newRequest(guildId, roleId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> deleteGuildRole(long guildId, long roleId) {
+    public Mono<Void> deleteGuildRole(long guildId, long roleId, @Nullable String reason) {
         return Routes.GUILD_ROLE_DELETE.newRequest(guildId, roleId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -177,9 +189,10 @@ public class GuildService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<PruneResponse> beginGuildPrune(long guildId, Map<String, Object> queryParams) {
+    public Mono<PruneResponse> beginGuildPrune(long guildId, Map<String, Object> queryParams, @Nullable String reason) {
         return Routes.GUILD_PRUNE_BEGIN.newRequest(guildId)
                 .query(queryParams)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 

--- a/rest/src/main/java/discord4j/rest/service/InviteService.java
+++ b/rest/src/main/java/discord4j/rest/service/InviteService.java
@@ -21,6 +21,8 @@ import discord4j.rest.request.Router;
 import discord4j.rest.route.Routes;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
+
 public class InviteService extends RestService {
 
     public InviteService(Router router) {
@@ -32,8 +34,9 @@ public class InviteService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<InviteResponse> deleteInvite(String inviteCode) {
+    public Mono<InviteResponse> deleteInvite(String inviteCode, @Nullable String reason) {
         return Routes.INVITE_DELETE.newRequest(inviteCode)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/WebhookService.java
+++ b/rest/src/main/java/discord4j/rest/service/WebhookService.java
@@ -24,15 +24,18 @@ import discord4j.rest.route.Routes;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.Nullable;
+
 public class WebhookService extends RestService {
 
     public WebhookService(Router router) {
         super(router);
     }
 
-    public Mono<WebhookResponse> createWebhook(long channelId, WebhookCreateRequest request) {
+    public Mono<WebhookResponse> createWebhook(long channelId, WebhookCreateRequest request, @Nullable String reason) {
         return Routes.CHANNEL_WEBHOOK_CREATE.newRequest(channelId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
@@ -53,14 +56,16 @@ public class WebhookService extends RestService {
                 .exchange(getRouter());
     }
 
-    public Mono<WebhookResponse> modifyWebhook(long webhookId, WebhookModifyRequest request) {
+    public Mono<WebhookResponse> modifyWebhook(long webhookId, WebhookModifyRequest request, @Nullable String reason) {
         return Routes.WEBHOOK_MODIFY.newRequest(webhookId)
                 .body(request)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 
-    public Mono<Void> deleteWebhook(long webhookId) {
+    public Mono<Void> deleteWebhook(long webhookId, @Nullable String reason) {
         return Routes.WEBHOOK_DELETE.newRequest(webhookId)
+                .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter());
     }
 }

--- a/rest/src/test/java/discord4j/rest/service/ChannelServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/ChannelServiceTest.java
@@ -64,7 +64,7 @@ public class ChannelServiceTest {
     @Test
     public void testModifyChannel() {
         ChannelModifyRequest req = ChannelModifyRequest.builder().topic("test modify").build();
-        getChannelService().modifyChannel(modifyChannel, req).block();
+        getChannelService().modifyChannel(modifyChannel, req, null).block();
     }
 
     @Test
@@ -174,7 +174,7 @@ public class ChannelServiceTest {
     @Test
     public void testEditChannelPermissions() {
         PermissionsEditRequest req = new PermissionsEditRequest(0, 0, "member");
-        getChannelService().editChannelPermissions(modifyChannel, permanentOverwrite, req).block();
+        getChannelService().editChannelPermissions(modifyChannel, permanentOverwrite, req, null).block();
     }
 
     @Test
@@ -185,7 +185,7 @@ public class ChannelServiceTest {
     @Test
     public void testCreateChannelInvite() {
         InviteCreateRequest req = new InviteCreateRequest(1, 0, true, true);
-        getChannelService().createChannelInvite(modifyChannel, req).block();
+        getChannelService().createChannelInvite(modifyChannel, req, null).block();
     }
 
     @Test

--- a/rest/src/test/java/discord4j/rest/service/GuildServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/GuildServiceTest.java
@@ -74,7 +74,7 @@ public class GuildServiceTest {
     @Test
     public void testModifyGuild() {
         GuildModifyRequest req = GuildModifyRequest.builder().region("us-south").build();
-        getGuildService().modifyGuild(guild, req).block();
+        getGuildService().modifyGuild(guild, req, null).block();
     }
 
     @Test
@@ -91,7 +91,7 @@ public class GuildServiceTest {
     public void testCreateGuildChannel() {
         String randomName = Long.toHexString(Double.doubleToLongBits(Math.random()));
         ChannelCreateRequest req = ChannelCreateRequest.builder().name(randomName).parentId(trashCategory).build();
-        getGuildService().createGuildChannel(guild, req).block();
+        getGuildService().createGuildChannel(guild, req, null).block();
     }
 
     @Test
@@ -99,7 +99,7 @@ public class GuildServiceTest {
         getGuildService().getGuildChannels(guild)
                 .filter(res -> res.getParentId() != null && trashCategory == res.getParentId())
                 .map(ChannelResponse::getId)
-                .flatMap(id -> getChannelService().deleteChannel(id))
+                .flatMap(id -> getChannelService().deleteChannel(id, null))
                 .then()
                 .block();
     }
@@ -127,7 +127,7 @@ public class GuildServiceTest {
     @Test
     public void testModifyGuildMember() {
         GuildMemberModifyRequest req = GuildMemberModifyRequest.builder().nick("nickname").build();
-        getGuildService().modifyGuildMember(guild, member, req).block();
+        getGuildService().modifyGuildMember(guild, member, req, null).block();
     }
 
     @Test
@@ -180,7 +180,7 @@ public class GuildServiceTest {
     public void testCreateGuildRole() {
         String randomName = "test_" + Long.toHexString(Double.doubleToLongBits(Math.random()));
         RoleCreateRequest req = new RoleCreateRequest(randomName, 0, 0, false, false);
-        getGuildService().createGuildRole(guild, req).block();
+        getGuildService().createGuildRole(guild, req, null).block();
     }
 
     @Test
@@ -191,7 +191,7 @@ public class GuildServiceTest {
     @Test
     public void testModifyGuildRole() {
         RoleModifyRequest req = RoleModifyRequest.builder().permissions(0).build();
-        getGuildService().modifyGuildRole(guild, permanentRole, req).block();
+        getGuildService().modifyGuildRole(guild, permanentRole, req, null).block();
     }
 
     @Test
@@ -199,7 +199,7 @@ public class GuildServiceTest {
         getGuildService().getGuildRoles(guild)
                 .filter(role -> role.getName().startsWith("test_") || role.getName().startsWith("3f"))
                 .limitRequest(5)
-                .flatMap(role -> getGuildService().deleteGuildRole(guild, role.getId()))
+                .flatMap(role -> getGuildService().deleteGuildRole(guild, role.getId(), null))
                 .blockLast();
     }
 
@@ -211,7 +211,7 @@ public class GuildServiceTest {
     @Test
     public void testBeginGuildPrune() {
         // shouldn't actually prune anyone because everyone in test server should have a role
-        getGuildService().beginGuildPrune(guild, Collections.emptyMap()).block();
+        getGuildService().beginGuildPrune(guild, Collections.emptyMap(), null).block();
     }
 
     @Test

--- a/rest/src/test/java/discord4j/rest/service/InviteServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/InviteServiceTest.java
@@ -77,7 +77,7 @@ public class InviteServiceTest {
                         .map(ts -> ts.isBefore(Instant.now()))
                         .orElse(false))
                 .map(InviteResponse::getCode)
-                .flatMap(code -> getInviteService().deleteInvite(code))
+                .flatMap(code -> getInviteService().deleteInvite(code, null))
                 .blockLast();
     }
 

--- a/rest/src/test/java/discord4j/rest/service/WebhookServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/WebhookServiceTest.java
@@ -68,7 +68,7 @@ public class WebhookServiceTest {
     @Test
     public void testModifyWebhook() {
         WebhookModifyRequest req = new WebhookModifyRequest(Possible.of("Permanent Webhook"), Possible.absent());
-        getWebhookService().modifyWebhook(permanentWebhook, req).block();
+        getWebhookService().modifyWebhook(permanentWebhook, req, null).block();
     }
 
     @Test


### PR DESCRIPTION
Description:
Add ability for users to be able to specify a reason to the Audit Log where actions are applicable. This is a feature completely absent on v2.

Justification:
Audit log reasons are cool.