### PR TITLE
Deprecate AudioReceiver

### DIFF
--- a/core/src/main/java/discord4j/core/spec/VoiceChannelJoinSpec.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelJoinSpec.java
@@ -50,6 +50,7 @@ public class VoiceChannelJoinSpec implements Spec<Mono<VoiceConnection>> {
         return this;
     }
 
+    @Deprecated
     public VoiceChannelJoinSpec setReceiver(final AudioReceiver receiver) {
         this.receiver = receiver;
         return this;

--- a/voice/src/main/java/discord4j/voice/AudioReceiver.java
+++ b/voice/src/main/java/discord4j/voice/AudioReceiver.java
@@ -24,7 +24,11 @@ import java.nio.ByteBuffer;
  * The receiver uses a shared buffer. Keep this in mind when implementing.
  *
  * @see #receive()
+ *
+ * @deprecated Discord does not officially support bots receiving audio. It is not guaranteed that this functionality
+ * works properly. Use at your own risk.
  */
+@Deprecated
 public abstract class AudioReceiver {
 
     public static final int DEFAULT_BUFFER_SIZE = 2048;


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Deprecate AudioReceiver.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
The functionality is not supported by Discord. I don't think it should be entirely removed, but it should be clear to users that it is unsupported. If they can get it to work, that's fine.

See discordapp/discord-api-docs#808