### PR TITLE
Allow multiple files to be sent with a message

### DIFF
--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -20,9 +20,14 @@ import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.EmbedRequest;
 import discord4j.rest.json.request.MessageCreateRequest;
 import discord4j.rest.util.MultipartRequest;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import javax.annotation.Nullable;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class MessageCreateSpec implements Spec<MultipartRequest> {
@@ -33,8 +38,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
     private String nonce;
     private boolean tts;
     private EmbedRequest embed;
-    private String fileName;
-    private InputStream file;
+    private List<Tuple2<String, InputStream>> files;
 
     public MessageCreateSpec setContent(String content) {
         this.content = content;
@@ -58,20 +62,15 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
         return this;
     }
 
-    public MessageCreateSpec setFile(String fileName, InputStream file) {
-        this.fileName = fileName;
-        this.file = file;
+    public MessageCreateSpec addFile(String fileName, InputStream file) {
+        if (files == null) files = new ArrayList<>(1);
+        files.add(Tuples.of(fileName, file));
         return this;
     }
 
     @Override
     public MultipartRequest asRequest() {
         MessageCreateRequest json = new MessageCreateRequest(content, nonce, tts, embed);
-
-        if (file != null) {
-            return new MultipartRequest(json, fileName, file);
-        } else {
-            return new MultipartRequest(json);
-        }
+        return new MultipartRequest(json, files == null ? Collections.emptyList() : files);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -69,8 +69,8 @@ public class ChannelService extends RestService {
 
     public Mono<MessageResponse> createMessage(long channelId, MultipartRequest request) {
         return Routes.MESSAGE_CREATE.newRequest(channelId)
-                .header("content-type", request.getFile() != null ? "multipart/form-data" : "application/json")
-                .body(Objects.requireNonNull(request.getFile() != null ? request : request.getCreateRequest()))
+                .header("content-type", request.getFiles().isEmpty() ? "application/json" : "multipart/form-data")
+                .body(Objects.requireNonNull(request.getFiles().isEmpty() ? request.getCreateRequest() : request))
                 .exchange(getRouter());
     }
 

--- a/rest/src/main/java/discord4j/rest/util/MultipartRequest.java
+++ b/rest/src/main/java/discord4j/rest/util/MultipartRequest.java
@@ -18,24 +18,30 @@
 package discord4j.rest.util;
 
 import discord4j.rest.json.request.MessageCreateRequest;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import javax.annotation.Nullable;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
 
 public class MultipartRequest {
 
     private final MessageCreateRequest createRequest;
-    private final String fileName;
-    private final InputStream file;
+    private final List<Tuple2<String, InputStream>> files;
 
     public MultipartRequest(MessageCreateRequest createRequest) {
-        this(createRequest, null, null);
+        this(createRequest, Collections.emptyList());
     }
 
-    public MultipartRequest(MessageCreateRequest createRequest, @Nullable String fileName, @Nullable InputStream file) {
+    public MultipartRequest(MessageCreateRequest createRequest, String fileName, InputStream file) {
+        this(createRequest, Collections.singletonList(Tuples.of(fileName, file)));
+    }
+
+    public MultipartRequest(MessageCreateRequest createRequest, List<Tuple2<String, InputStream>> files) {
         this.createRequest = createRequest;
-        this.fileName = fileName;
-        this.file = file;
+        this.files = files;
     }
 
     @Nullable
@@ -43,13 +49,7 @@ public class MultipartRequest {
         return createRequest;
     }
 
-    @Nullable
-    public String getFileName() {
-        return fileName;
-    }
-
-    @Nullable
-    public InputStream getFile() {
-        return file;
+    public List<Tuple2<String, InputStream>> getFiles() {
+        return files;
     }
 }

--- a/rest/src/test/java/discord4j/rest/service/ChannelServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/ChannelServiceTest.java
@@ -23,6 +23,8 @@ import discord4j.rest.json.request.*;
 import discord4j.rest.request.Router;
 import discord4j.rest.util.MultipartRequest;
 import org.junit.Test;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 public class ChannelServiceTest {
 
@@ -97,6 +100,25 @@ public class ChannelServiceTest {
             }
             byte[] bytes = readAllBytes(inputStream);
             MultipartRequest request = new MultipartRequest(req, "fileTest.txt", new ByteArrayInputStream(bytes));
+            getChannelService().createMessage(permanentChannel, request).block();
+        }
+    }
+
+    @Test
+    public void testCreateMessagesWithMultipleFiles() throws IOException {
+        MessageCreateRequest req = new MessageCreateRequest("Hello world with *multiple* files!", null, false, null);
+        try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("fileTest.txt")) {
+            if (inputStream == null) {
+                throw new NullPointerException();
+            }
+            byte[] bytes = readAllBytes(inputStream);
+
+            ByteArrayInputStream in0 = new ByteArrayInputStream(bytes);
+            ByteArrayInputStream in1 = new ByteArrayInputStream(bytes);
+            List<Tuple2<String, InputStream>> files = Arrays.asList(Tuples.of("file0.txt", in0),
+                    Tuples.of("file1.txt", in1));
+
+            MultipartRequest request = new MultipartRequest(req, files);
             getChannelService().createMessage(permanentChannel, request).block();
         }
     }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Add the ability to send multiple files in a message. Involves changes both to `rest` and `core` (it was not possible previously at either level). 

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
This is allowed by Discord. 