### PR TITLE
Subscribe only until a connection has succeeded

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.gorylenko.gradle-git-properties'
 
 dependencies {
     compile "io.projectreactor.netty:reactor-netty"
+    compile "io.projectreactor.addons:reactor-pool:0.0.1.M1"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jackson_version"
 

--- a/core/src/main/java/discord4j/core/DiscordClient.java
+++ b/core/src/main/java/discord4j/core/DiscordClient.java
@@ -33,6 +33,7 @@ import discord4j.core.spec.UserEditSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.core.util.PaginationUtil;
 import discord4j.gateway.GatewayClient;
+import discord4j.gateway.GatewayConnection;
 import discord4j.gateway.GatewayObserver;
 import discord4j.gateway.json.GatewayPayload;
 import discord4j.rest.json.response.GatewayResponse;
@@ -41,8 +42,11 @@ import discord4j.rest.util.RouteUtils;
 import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Scheduler;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
@@ -314,7 +318,7 @@ public final class DiscordClient {
     }
 
     /**
-     * Logs in the client to the gateway.
+     * Login the client to the gateway.
      *
      * @return A {@link Mono} that completes (either successfully or with an error) when the client disconnects from the
      * gateway without a reconnect attempt. It is recommended to call this from {@code main} and as a final statement
@@ -328,16 +332,54 @@ public final class DiscordClient {
                     }
                 })
                 .then(serviceMediator.getRestClient().getGatewayService().getGateway())
-                .transform(loginSequence(serviceMediator.getGatewayClient()));
+                .transform(loginSequence(serviceMediator.getGatewayClient(), null));
     }
 
-    private Function<Mono<GatewayResponse>, Mono<Void>> loginSequence(GatewayClient client) {
+    /**
+     * Establish a connection to the gateway and log in with this client, returning a {@link GatewayConnection} after
+     * the underlying websocket has connected, and can be used to manipulate its lifecycle.
+     *
+     * @return a {@link Mono} deferring completion until the gateway has connected. If a gateway connection is still
+     * active under this client, an error will be emitted through the Mono.
+     */
+    public Mono<GatewayConnection> login(Consumer<? super LoginConfigSpec> consumer) {
+        return Mono.create(sink -> {
+            final LoginConfigSpec baseSpec = new LoginConfigSpec(serviceMediator);
+            if (!isDisposed.compareAndSet(true, false)) {
+                throw new AlreadyConnectedException();
+            }
+            GatewayClient client = serviceMediator.getGatewayClient(); // or a custom one
+            MonoProcessor<Void> disconnectFuture = MonoProcessor.create();
+            ConnectedObserver observer = new ConnectedObserver(identify -> {
+                GatewayConnection connection = new GatewayConnection(client, identify, disconnectFuture);
+                sink.success(connection);
+            });
+            Mono<Void> gatewayFuture = serviceMediator.getRestClient().getGatewayService().getGateway()
+                    .transform(loginSequence(client, observer))
+                    .doOnError(t -> !(t instanceof AlreadyConnectedException), t -> disconnectFuture.onComplete())
+                    .doOnCancel(disconnectFuture::onComplete)
+                    .doOnTerminate(disconnectFuture::onComplete);
+            consumer.accept(baseSpec);
+            LoginConfig loginConfig = baseSpec.asRequest();
+            Scheduler blockScheduler = loginConfig.getBlockScheduler();
+            if (blockScheduler != null) {
+                sink.onCancel(() -> client.close(false));
+                gatewayFuture.publishOn(blockScheduler).block();
+            } else {
+                sink.onCancel(gatewayFuture
+                        .subscribe(null, t -> log.error("Gateway terminated with an error", t)));
+            }
+        });
+    }
+
+    private Function<Mono<GatewayResponse>, Mono<Void>> loginSequence(GatewayClient client,
+                                                                      @Nullable ConnectedObserver observer) {
         return sequence -> sequence
                 .subscriberContext(ctx -> ctx.put("shard", serviceMediator.getClientConfig().getShardIndex()))
                 .flatMap(response -> client.execute(
                         RouteUtils.expandQuery(response.getUrl(),
                                 serviceMediator.getClientConfig().getGatewayParameters()),
-                        GatewayObserver.NOOP_LISTENER))
+                        observer == null ? GatewayObserver.NOOP_LISTENER : observer))
                 .then(serviceMediator.getStateHolder().invalidateStores())
                 .then(serviceMediator.getStoreService().dispose())
                 .doOnCancel(this::setDisposed)

--- a/core/src/main/java/discord4j/core/LoginConfig.java
+++ b/core/src/main/java/discord4j/core/LoginConfig.java
@@ -15,17 +15,21 @@
  * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package discord4j.gateway;
+package discord4j.core;
 
-import io.netty.buffer.ByteBuf;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
-import reactor.util.function.Tuple2;
+import reactor.core.scheduler.Scheduler;
+import reactor.util.annotation.Nullable;
 
-import java.util.function.Function;
+public class LoginConfig {
 
-/**
- * A transformation function to a sequence of raw {@link ByteBuf} payloads.
- */
-public interface PayloadTransformer extends Function<Flux<Tuple2<GatewayClient, ByteBuf>>, Publisher<ByteBuf>> {
+    private final Scheduler blockScheduler;
+
+    public LoginConfig(@Nullable Scheduler blockScheduler) {
+        this.blockScheduler = blockScheduler;
+    }
+
+    @Nullable
+    public Scheduler getBlockScheduler() {
+        return blockScheduler;
+    }
 }

--- a/core/src/main/java/discord4j/core/LoginConfigSpec.java
+++ b/core/src/main/java/discord4j/core/LoginConfigSpec.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core;
+
+import discord4j.core.spec.Spec;
+import reactor.core.scheduler.Scheduler;
+
+public class LoginConfigSpec implements Spec<LoginConfig> {
+
+    private final ServiceMediator serviceMediator;
+
+    private Scheduler blockScheduler;
+
+    LoginConfigSpec(ServiceMediator serviceMediator) {
+        this.serviceMediator = serviceMediator;
+    }
+
+    /**
+     * Define the {@link Scheduler} used to wait until the created gateway is disconnected.
+     *
+     * @param blockScheduler a {@link Scheduler}
+     * @return this spec
+     */
+    public LoginConfigSpec setBlockUntilLogout(Scheduler blockScheduler) {
+        this.blockScheduler = blockScheduler;
+        return this;
+    }
+
+    @Override
+    public LoginConfig asRequest() {
+        return new LoginConfig(blockScheduler);
+    }
+}

--- a/gateway/src/main/java/discord4j/gateway/GatewayConnection.java
+++ b/gateway/src/main/java/discord4j/gateway/GatewayConnection.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.gateway;
+
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+
+/**
+ * A handle to manipulate a gateway connection, represents a connection to an active {@link GatewayClient}.
+ */
+public class GatewayConnection {
+
+    private final GatewayClient gatewayClient;
+    private final IdentifyOptions identifyOptions;
+    private final MonoProcessor<Void> disconnectFuture;
+
+    public GatewayConnection(GatewayClient gatewayClient, IdentifyOptions identifyOptions,
+                             MonoProcessor<Void> disconnectFuture) {
+        this.gatewayClient = gatewayClient;
+        this.identifyOptions = identifyOptions;
+        this.disconnectFuture = disconnectFuture;
+    }
+
+    /**
+     * Logs out the client from the gateway.
+     *
+     * @return a {@link Mono} deferring completion until this client has completely disconnected from the gateway
+     */
+    public Mono<Void> logout() {
+        return gatewayClient.close(false);
+    }
+
+    /**
+     * Returns whether this client is currently connected to Discord Gateway.
+     *
+     * @return true if the gateway connection is currently established, false otherwise.
+     */
+    public boolean isConnected() {
+        return gatewayClient.isConnected();
+    }
+
+    /**
+     * Gets the amount of time it last took Discord Gateway to respond to a heartbeat with an ack.
+     *
+     * @return the time in milliseconds took Discord to respond to the last heartbeat with an ack.
+     */
+    public long getResponseTime() {
+        return gatewayClient.getResponseTime();
+    }
+
+    /**
+     * Get the set of {@link IdentifyOptions} currently used by this connection.
+     *
+     * @return an {@code IdentifyOptions} object
+     */
+    public IdentifyOptions getIdentifyOptions() {
+        return identifyOptions;
+    }
+
+    /**
+     * Get a {@link Mono} that completes when the current gateway has disconnected.
+     *
+     * @return a {@link Mono} signaling completion upon disconnect
+     */
+    public Mono<Void> onDisconnect() {
+        return disconnectFuture;
+    }
+
+    @Override
+    public String toString() {
+        return "GatewayConnection{" +
+                "gatewayClient=" + gatewayClient +
+                ", identifyOptions=" + identifyOptions +
+                '}';
+    }
+}

--- a/gateway/src/main/java/discord4j/gateway/GatewayOptions.java
+++ b/gateway/src/main/java/discord4j/gateway/GatewayOptions.java
@@ -17,15 +17,20 @@
 
 package discord4j.gateway;
 
-import io.netty.buffer.ByteBuf;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
-import reactor.util.function.Tuple2;
+public class GatewayOptions {
 
-import java.util.function.Function;
 
-/**
- * A transformation function to a sequence of raw {@link ByteBuf} payloads.
- */
-public interface PayloadTransformer extends Function<Flux<Tuple2<GatewayClient, ByteBuf>>, Publisher<ByteBuf>> {
+    protected GatewayOptions(Builder builder) {
+
+    }
+
+    public static class Builder {
+
+        protected Builder() {
+        }
+
+        public GatewayOptions build() {
+            return new GatewayOptions(this);
+        }
+    }
 }

--- a/gateway/src/main/java/discord4j/gateway/PoolingTransformer.java
+++ b/gateway/src/main/java/discord4j/gateway/PoolingTransformer.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.gateway;
+
+import io.netty.buffer.ByteBuf;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.pool.Pool;
+import reactor.pool.PoolBuilder;
+import reactor.pool.PooledRef;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.function.Tuple2;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PoolingTransformer implements PayloadTransformer {
+
+    private static final Logger log = Loggers.getLogger(PoolingTransformer.class);
+
+    private final int capacity;
+    private final long refillPeriodNanos;
+
+    private final Pool<Permit> pool;
+    private final AtomicInteger count = new AtomicInteger(0);
+    private final AtomicLong nextRefillAt = new AtomicLong(0);
+
+    public PoolingTransformer(int capacity, Duration refillPeriod) {
+        this.capacity = capacity;
+        this.refillPeriodNanos = refillPeriod.toNanos();
+        this.pool = PoolBuilder.from(Mono.fromCallable(Permit::new))
+                .sizeMax(capacity)
+                .releaseHandler(permit -> Mono.delay(getDurationUntilNextRefill().plus(permit.releaseDelay))
+                        .doOnNext(tick -> log.warn("[{}] Released permit", permit))
+                        .then())
+                .build();
+    }
+
+    private Duration getDurationUntilNextRefill() {
+        if (count.get() + 1 <= capacity) {
+            return Duration.ZERO;
+        }
+        long now = System.nanoTime();
+        return Duration.ofNanos(nextRefillAt.get() - now);
+    }
+
+    @Override
+    public Publisher<ByteBuf> apply(Flux<Tuple2<GatewayClient, ByteBuf>> publisher) {
+        AtomicReference<PooledRef<Permit>> emitted = new AtomicReference<>();
+        return publisher.flatMap(t2 -> this.pool.acquire()
+                .doOnNext(pooledRef -> {
+                    log.warn("[{}] Acquired permit", pooledRef.poolable());
+                    emitted.set(pooledRef);
+                    long now = System.nanoTime();
+                    if (nextRefillAt.get() <= now) {
+                        count.set(0);
+                        nextRefillAt.set(now + refillPeriodNanos);
+                    }
+                    if (count.get() + 1 <= capacity) {
+                        count.incrementAndGet();
+                    }
+                    pooledRef.poolable().releaseDelay = Duration.ofMillis(t2.getT1().getResponseTime());
+                })
+                .doFinally(st -> {
+                    PooledRef<Permit> ref = emitted.get();
+                    if (ref != null && emitted.compareAndSet(ref, null)) {
+                        log.warn("[{}] Releasing permit", ref.poolable());
+                        ref.release().subscribe();
+                    }
+                })
+                .thenReturn(t2.getT2()));
+    }
+
+    private static class Permit {
+        private Duration releaseDelay = Duration.ZERO;
+    }
+}

--- a/gateway/src/main/java/discord4j/gateway/RateLimiterTransformer.java
+++ b/gateway/src/main/java/discord4j/gateway/RateLimiterTransformer.java
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.function.Tuple2;
 
 import java.time.Duration;
 
@@ -38,11 +39,11 @@ public class RateLimiterTransformer implements PayloadTransformer {
     }
 
     @Override
-    public Publisher<ByteBuf> apply(Flux<ByteBuf> publisher) {
-        return publisher.concatMap(payload -> Mono
+    public Publisher<ByteBuf> apply(Flux<Tuple2<GatewayClient, ByteBuf>> publisher) {
+        return publisher.concatMap(t2 -> Mono
                 .<ByteBuf>create(sink -> {
                     if (limiter.tryConsume(1)) {
-                        sink.success(payload);
+                        sink.success(t2.getT2());
                     } else {
                         sink.error(new RuntimeException());
                     }

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile project(':common')
 
-    compile "io.projectreactor.addons:reactor-pool:0.0.1.M1"
     compile "io.projectreactor.addons:reactor-extra"
 
     testCompile "junit:junit:$junit_version"


### PR DESCRIPTION
**Description:**
Add support for ``DiscordClient#login(Consumer)``. Allows a user to subscribe only until the client has successfully connected to the gateway, returning the control back to the caller thread, obtaining a new object called ``GatewayConnection``.

``DiscordClient#login()`` signature has not changed, but its behavior is adapted to the previous requirement.

**Justification:**
Very useful if we wish to explore a model where exposing ``GatewayClient`` properties and methods could go *only* through ``GatewayConnection``.