### PR TITLE
Allow registering custom error functions

### DIFF
--- a/core/src/main/java/discord4j/core/DiscordClientBuilder.java
+++ b/core/src/main/java/discord4j/core/DiscordClientBuilder.java
@@ -41,6 +41,7 @@ import discord4j.rest.request.DefaultRouterFactory;
 import discord4j.rest.request.Router;
 import discord4j.rest.request.RouterFactory;
 import discord4j.rest.request.RouterOptions;
+import discord4j.rest.response.ResponseFunction;
 import discord4j.store.api.service.StoreService;
 import discord4j.store.api.service.StoreServiceLoader;
 import discord4j.store.api.util.StoreContext;
@@ -303,6 +304,11 @@ public final class DiscordClientBuilder {
         return routerFactory;
     }
 
+    /**
+     * Gets the current {@link RouterOptions} used to configure {@link RouterFactory} instances.
+     *
+     * @return the current {@code RouterOptions} used by this client
+     */
     @Nullable
     public RouterOptions getRouterOptions() {
         return routerOptions;
@@ -326,6 +332,19 @@ public final class DiscordClientBuilder {
         return this;
     }
 
+    /**
+     * Sets a new {@link RouterOptions} used to configure a {@link RouterFactory}.
+     * <p>
+     * {@code RouterOptions} instances provide a way to override the {@link Scheduler} used for retrieving API responses
+     * and scheduling rate limiting actions. It also allows changing the behavior associated with API errors through
+     * {@link RouterOptions.Builder#onClientResponse(ResponseFunction)}.
+     * <p>
+     * If you use a default {@code RouterFactory}, it will use the supplied {@code RouterOptions} to configure itself
+     * while building this client.
+     *
+     * @param routerOptions a new {@code RouterOptions} to configure a {@code RouterFactory}
+     * @return this builder
+     */
     public DiscordClientBuilder setRouterOptions(@Nullable RouterOptions routerOptions) {
         this.routerOptions = routerOptions;
         return this;

--- a/core/src/main/java/discord4j/core/DiscordClientBuilder.java
+++ b/core/src/main/java/discord4j/core/DiscordClientBuilder.java
@@ -38,7 +38,9 @@ import discord4j.rest.RestClient;
 import discord4j.rest.http.ExchangeStrategies;
 import discord4j.rest.http.client.DiscordWebClient;
 import discord4j.rest.request.DefaultRouterFactory;
+import discord4j.rest.request.Router;
 import discord4j.rest.request.RouterFactory;
+import discord4j.rest.request.RouterOptions;
 import discord4j.store.api.service.StoreService;
 import discord4j.store.api.service.StoreServiceLoader;
 import discord4j.store.api.util.StoreContext;
@@ -94,6 +96,9 @@ public final class DiscordClientBuilder {
 
     @Nullable
     private RouterFactory routerFactory;
+
+    @Nullable
+    private RouterOptions routerOptions;
 
     @Nullable
     private GatewayClientFactory gatewayClientFactory;
@@ -298,6 +303,11 @@ public final class DiscordClientBuilder {
         return routerFactory;
     }
 
+    @Nullable
+    public RouterOptions getRouterOptions() {
+        return routerOptions;
+    }
+
     /**
      * Set a new {@link RouterFactory} used to create a {@link discord4j.rest.request.Router} that executes Discord
      * REST API requests.
@@ -313,6 +323,11 @@ public final class DiscordClientBuilder {
      */
     public DiscordClientBuilder setRouterFactory(@Nullable RouterFactory routerFactory) {
         this.routerFactory = routerFactory;
+        return this;
+    }
+
+    public DiscordClientBuilder setRouterOptions(@Nullable RouterOptions routerOptions) {
+        this.routerOptions = routerOptions;
         return this;
     }
 
@@ -557,6 +572,13 @@ public final class DiscordClientBuilder {
         return new DefaultRouterFactory();
     }
 
+    private Router initRouter(RouterFactory factory, DiscordWebClient webClient) {
+        if (routerOptions != null) {
+            return factory.getRouter(webClient, routerOptions);
+        }
+        return factory.getRouter(webClient);
+    }
+
     private GatewayClientFactory initGatewayClientFactory() {
         if (gatewayClientFactory != null) {
             return gatewayClientFactory;
@@ -599,7 +621,7 @@ public final class DiscordClientBuilder {
         final HttpClient httpClient = initHttpClient();
         final DiscordWebClient webClient = initWebClient(httpClient, jackson.getObjectMapper());
         final RouterFactory routerFactory = initRouterFactory();
-        final RestClient restClient = new RestClient(routerFactory.getRouter(webClient));
+        final RestClient restClient = new RestClient(initRouter(routerFactory, webClient));
 
         // Prepare Stores
         final StoreService storeService = initStoreService();

--- a/core/src/main/java/discord4j/core/DiscordClientBuilder.java
+++ b/core/src/main/java/discord4j/core/DiscordClientBuilder.java
@@ -305,7 +305,7 @@ public final class DiscordClientBuilder {
     }
 
     /**
-     * Gets the current {@link RouterOptions} used to configure {@link RouterFactory} instances.
+     * Return the current {@link RouterOptions} used to configure {@link RouterFactory} instances.
      *
      * @return the current {@code RouterOptions} used by this client
      */

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration scan="true">
     <logger name="io.netty" level="INFO"/>
     <logger name="reactor" level="INFO"/>
-    <logger name="reactor.retry" level="DEBUG"/>
+    <logger name="reactor.retry" level="INFO"/>
     <logger name="discord4j.core" level="INFO"/>
     <logger name="discord4j.gateway.client" level="INFO"/>
     <logger name="discord4j.gateway.inbound" level="INFO"/>

--- a/rest/src/main/java/discord4j/rest/http/client/ClientException.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientException.java
@@ -75,8 +75,15 @@ public class ClientException extends RuntimeException {
     private final HttpHeaders headers;
     private final ErrorResponse errorResponse;
 
+    /**
+     * Create a new {@link ClientException} with the given HTTP request and response details.
+     *
+     * @param request the original {@link ClientRequest} that caused this exception
+     * @param response the failing {@link HttpClientResponse}
+     * @param errorResponse the response body converted to an {@link ErrorResponse}, or {@code null} if not available
+     */
     public ClientException(ClientRequest request, HttpClientResponse response, @Nullable ErrorResponse errorResponse) {
-        super(request.method().toString() + " " + request.url() + " returned " + response.status().toString() +
+        super(request.getMethod().toString() + " " + request.getUrl() + " returned " + response.status().toString() +
                 (errorResponse != null ? " with response " + errorResponse.getFields() : ""));
         this.request = request;
         this.status = response.status();
@@ -85,7 +92,7 @@ public class ClientException extends RuntimeException {
     }
 
     /**
-     * Gets the {@link ClientRequest} encapsulating a Discord API request.
+     * Return the {@link ClientRequest} encapsulating a Discord API request.
      *
      * @return the request that caused this exception
      */
@@ -94,7 +101,7 @@ public class ClientException extends RuntimeException {
     }
 
     /**
-     * Gets the {@link HttpResponseStatus} with information related to the HTTP error. The actual status code can be
+     * Return the {@link HttpResponseStatus} with information related to the HTTP error. The actual status code can be
      * obtained through {@link HttpResponseStatus#code()}.
      *
      * @return the HTTP error associated to this exception
@@ -104,8 +111,8 @@ public class ClientException extends RuntimeException {
     }
 
     /**
-     * Gets the {@link HttpHeaders} from the error <strong>response</strong>. To get request headers refer to
-     * {@link #getRequest()} and then {@link ClientRequest#headers()}.
+     * Return the {@link HttpHeaders} from the error <strong>response</strong>. To get request headers refer to
+     * {@link #getRequest()} and then {@link ClientRequest#getHeaders()}.
      *
      * @return the HTTP response headers
      */
@@ -114,7 +121,7 @@ public class ClientException extends RuntimeException {
     }
 
     /**
-     * Gets the HTTP response body in the form of a Discord {@link ErrorResponse}, if present. {@link ErrorResponse}
+     * Return the HTTP response body in the form of a Discord {@link ErrorResponse}, if present. {@link ErrorResponse}
      * is a common object that contains an internal status code and messages, and could be used to further clarify
      * the source of the API error.
      *
@@ -210,7 +217,7 @@ public class ClientException extends RuntimeException {
     }
 
     /**
-     * Transformation function that be used within an operator such as {@link Mono#transform(Function)} or
+     * Transformation function that can be used within an operator such as {@link Mono#transform(Function)} or
      * {@link Mono#compose(Function)} to turn an error sequence matching the given HTTP status code, into an empty
      * sequence, effectively suppressing the original error.
      *
@@ -223,7 +230,7 @@ public class ClientException extends RuntimeException {
     }
 
     /**
-     * Transformation function that be used within an operator such as {@link Mono#transform(Function)} or
+     * Transformation function that can be used within an operator such as {@link Mono#transform(Function)} or
      * {@link Mono#compose(Function)} to apply a retrying strategy in case of an error matching the given HTTP status
      * code. The provided retrying strategy will wait 1 second, and then retry once.
      *

--- a/rest/src/main/java/discord4j/rest/http/client/ClientRequest.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientRequest.java
@@ -17,27 +17,29 @@
 
 package discord4j.rest.http.client;
 
+import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.route.Route;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 
 /**
- * A wrapper over a partial HTTP client request definition.
+ * An adapted request definition from an original {@link DiscordRequest}.
  */
 public class ClientRequest {
 
-    private final HttpMethod method;
+    private final DiscordRequest<?> request;
     private final String url;
     private final HttpHeaders headers;
 
-    public ClientRequest(HttpMethod method, String url, HttpHeaders headers) {
-        this.method = method;
+    public ClientRequest(DiscordRequest<?> request, String url, HttpHeaders headers) {
+        this.request = request;
         this.url = url;
         this.headers = headers;
     }
 
     public HttpMethod method() {
-        return method;
+        return request.getRoute().getMethod();
     }
 
     public String url() {
@@ -48,10 +50,18 @@ public class ClientRequest {
         return headers;
     }
 
+    public DiscordRequest<?> getDiscordRequest() {
+        return request;
+    }
+
+    public Route<?> getRoute() {
+        return request.getRoute();
+    }
+
     @Override
     public String toString() {
         return "ClientRequest{" +
-                "method=" + method +
+                "method=" + method() +
                 ", url='" + url + '\'' +
                 ", headers=" + headers.copy().remove(HttpHeaderNames.AUTHORIZATION).toString() +
                 '}';

--- a/rest/src/main/java/discord4j/rest/http/client/DiscordWebClient.java
+++ b/rest/src/main/java/discord4j/rest/http/client/DiscordWebClient.java
@@ -91,7 +91,7 @@ public class DiscordWebClient {
      * @return a {@link reactor.core.publisher.Mono} of {@link T} with the response
      */
     public <R, T> Mono<T> exchange(ClientRequest request, @Nullable R body, Class<T> responseType,
-            Consumer<HttpClientResponse> responseConsumer) {
+                                   Consumer<HttpClientResponse> responseConsumer) {
         Objects.requireNonNull(responseType);
 
         HttpHeaders requestHeaders = new DefaultHttpHeaders().add(defaultHeaders).setAll(request.headers());
@@ -110,6 +110,7 @@ public class DiscordWebClient {
                 .orElseGet(() -> Mono.error(noWriterException(body, contentType)))
                 .flatMap(receiver -> receiver.responseSingle((response, content) -> {
                     responseConsumer.accept(response);
+
                     String responseContentType = response.responseHeaders().get(HttpHeaderNames.CONTENT_TYPE);
                     Optional<ReaderStrategy<?>> readerStrategy = exchangeStrategies.readers().stream()
                             .filter(s -> s.canRead(responseType, responseContentType))
@@ -140,7 +141,7 @@ public class DiscordWebClient {
     }
 
     private static ClientException clientException(ClientRequest request, HttpClientResponse response,
-            @Nullable ErrorResponse errorResponse) {
+                                                   @Nullable ErrorResponse errorResponse) {
         return new ClientException(request, response, errorResponse);
     }
 

--- a/rest/src/main/java/discord4j/rest/http/client/DiscordWebClient.java
+++ b/rest/src/main/java/discord4j/rest/http/client/DiscordWebClient.java
@@ -39,7 +39,7 @@ import java.util.Properties;
 import java.util.function.Consumer;
 
 /**
- * HTTP client tailored for Discord REST API requests.
+ * Reactor Netty based HTTP client dedicated to Discord REST API requests.
  */
 public class DiscordWebClient {
 
@@ -49,6 +49,13 @@ public class DiscordWebClient {
     private final HttpHeaders defaultHeaders;
     private final ExchangeStrategies exchangeStrategies;
 
+    /**
+     * Create a new {@link DiscordWebClient} wrapping HTTP, Discord and encoding/decoding resources.
+     *
+     * @param httpClient a Reactor Netty HTTP client
+     * @param exchangeStrategies a strategy to transform requests and responses
+     * @param token a Discord token for API authorization
+     */
     public DiscordWebClient(HttpClient httpClient, ExchangeStrategies exchangeStrategies, String token) {
         final Properties properties = GitProperties.getProperties();
         final String version = properties.getProperty(GitProperties.APPLICATION_VERSION, "3");
@@ -64,14 +71,29 @@ public class DiscordWebClient {
         this.exchangeStrategies = exchangeStrategies;
     }
 
+    /**
+     * Return the underlying Reactor Netty HTTP client.
+     *
+     * @return the HTTP client used by this {@link DiscordWebClient}
+     */
     public HttpClient getHttpClient() {
         return httpClient;
     }
 
+    /**
+     * Return the default headers used in every request.
+     *
+     * @return the {@link HttpHeaders} used by this {@link DiscordWebClient} in every request
+     */
     public HttpHeaders getDefaultHeaders() {
         return defaultHeaders;
     }
 
+    /**
+     * Return the strategy used for request and response conversion
+     *
+     * @return the {@link ExchangeStrategies} used by this {@link DiscordWebClient} in every request
+     */
     public ExchangeStrategies getExchangeStrategies() {
         return exchangeStrategies;
     }
@@ -94,14 +116,14 @@ public class DiscordWebClient {
                                    Consumer<HttpClientResponse> responseConsumer) {
         Objects.requireNonNull(responseType);
 
-        HttpHeaders requestHeaders = new DefaultHttpHeaders().add(defaultHeaders).setAll(request.headers());
+        HttpHeaders requestHeaders = new DefaultHttpHeaders().add(defaultHeaders).setAll(request.getHeaders());
         String contentType = requestHeaders.get(HttpHeaderNames.CONTENT_TYPE);
         HttpClient.RequestSender sender = httpClient
                 .baseUrl(Routes.BASE_URL)
                 .observe((connection, newState) -> log.debug("{} {}", newState, connection))
                 .headers(headers -> headers.setAll(requestHeaders))
-                .request(request.method())
-                .uri(request.url());
+                .request(request.getMethod())
+                .uri(request.getUrl());
         return exchangeStrategies.writers().stream()
                 .filter(s -> s.canWrite(body != null ? body.getClass() : null, contentType))
                 .findFirst()

--- a/rest/src/main/java/discord4j/rest/request/BucketKey.java
+++ b/rest/src/main/java/discord4j/rest/request/BucketKey.java
@@ -16,6 +16,7 @@
  */
 package discord4j.rest.request;
 
+import discord4j.rest.route.Route;
 import discord4j.rest.util.RouteUtils;
 import reactor.util.annotation.Nullable;
 
@@ -28,7 +29,7 @@ import java.util.Objects;
  * Following the <a href="https://discordapp.com/developers/docs/topics/rate-limits#rate-limits">
  * Discord documentation</a>, requests belong to the same bucket if:
  * <ul>
- * <li>The {@link discord4j.rest.route.Route#uriTemplate uriTemplates} are equal.</li>
+ * <li>The {@link Route#getUriTemplate()} are equal.</li>
  * <li>The {@link #majorParam major parameters} are equal.</li>
  * </ul>
  * Note that HTTP method is <b>not</b> considered (requests fall into the same bucket even if the methods are different)

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
@@ -50,21 +50,21 @@ public class DefaultRouter implements Router {
     private final Map<BucketKey, RequestStream<?>> streamMap = new ConcurrentHashMap<>();
 
     /**
-     * Create a bucket-aware router using the {@link reactor.core.scheduler.Schedulers#elastic()} scheduler, to allow
-     * the use of blocking API. Use the alternate constructor to customize it.
+     * Create a bucket-aware router using the defaults provided by {@link RouterOptions#create()}.
      *
      * @param httpClient the web client executing each request instructed by this router
      */
     public DefaultRouter(DiscordWebClient httpClient) {
-        this(httpClient, RouterOptions.builder().build());
+        this(httpClient, RouterOptions.create());
     }
 
     /**
-     * Create a bucket-aware router that uses the given {@link reactor.core.scheduler.Scheduler}.
+     * Create a Discord API bucket-aware {@link Router} that uses the given {@link reactor.core.scheduler.Scheduler}.
      *
      * @param httpClient the web client executing each request instructed by this router
      * @param responseScheduler the scheduler used to execute each request
      * @param rateLimitScheduler the scheduler used to perform delays caused by rate limiting
+     * @deprecated use {@link #DefaultRouter(DiscordWebClient, RouterOptions)}
      */
     @Deprecated
     public DefaultRouter(DiscordWebClient httpClient, Scheduler responseScheduler, Scheduler rateLimitScheduler) {
@@ -75,6 +75,12 @@ public class DefaultRouter implements Router {
                 .build();
     }
 
+    /**
+     * Create a Discord API bucket-aware {@link Router} configured with the given options.
+     *
+     * @param httpClient the web client executing each request instructed by this router
+     * @param routerOptions the options that configure this {@link Router}
+     */
     public DefaultRouter(DiscordWebClient httpClient, RouterOptions routerOptions) {
         this.httpClient = httpClient;
         this.routerOptions = routerOptions;
@@ -105,7 +111,8 @@ public class DefaultRouter implements Router {
                                         k, request.getRoute().getUriTemplate(), request.getCompleteUri());
                             }
                             RequestStream<T> stream = new RequestStream<>(k, httpClient, globalRateLimiter,
-                                    getRateLimitStrategy(request), routerOptions.getRateLimitScheduler(), routerOptions);
+                                    getRateLimitStrategy(request), routerOptions.getRateLimitScheduler(),
+                                    routerOptions);
                             stream.start();
                             return stream;
                         });

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouterFactory.java
@@ -19,24 +19,34 @@ package discord4j.rest.request;
 
 import discord4j.rest.http.client.DiscordWebClient;
 import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 public class DefaultRouterFactory implements RouterFactory {
 
-    private final Scheduler responseScheduler;
-    private final Scheduler rateLimitScheduler;
+    private final RouterOptions routerOptions;
 
     public DefaultRouterFactory() {
-        this(Schedulers.elastic(), Schedulers.elastic());
+        this.routerOptions = RouterOptions.builder().build();
     }
 
+    @Deprecated
     public DefaultRouterFactory(Scheduler responseScheduler, Scheduler rateLimitScheduler) {
-        this.responseScheduler = responseScheduler;
-        this.rateLimitScheduler = rateLimitScheduler;
+        this.routerOptions = RouterOptions.builder()
+                .responseScheduler(responseScheduler)
+                .rateLimitScheduler(rateLimitScheduler)
+                .build();
+    }
+
+    public DefaultRouterFactory(RouterOptions routerOptions) {
+        this.routerOptions = routerOptions;
     }
 
     @Override
-    public Router getRouter(DiscordWebClient httpClient) {
-        return new DefaultRouter(httpClient, responseScheduler, rateLimitScheduler);
+    public Router getRouter(DiscordWebClient webClient) {
+        return new DefaultRouter(webClient, routerOptions);
+    }
+
+    @Override
+    public Router getRouter(DiscordWebClient webClient, RouterOptions routerOptions) {
+        return new DefaultRouter(webClient, routerOptions);
     }
 }

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouterFactory.java
@@ -20,6 +20,12 @@ package discord4j.rest.request;
 import discord4j.rest.http.client.DiscordWebClient;
 import reactor.core.scheduler.Scheduler;
 
+/**
+ * A monolithic {@link RouterFactory} that can build {@link Router} instances to execute Discord API requests.
+ * <p>
+ * This factory creates a new instance each time so it is not fit for coordinating sharding requests. For those cases,
+ * see {@link SingleRouterFactory}.
+ */
 public class DefaultRouterFactory implements RouterFactory {
 
     private final RouterOptions routerOptions;

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouterFactory.java
@@ -30,10 +30,21 @@ public class DefaultRouterFactory implements RouterFactory {
 
     private final RouterOptions routerOptions;
 
+    /**
+     * Create a {@link DefaultRouterFactory} with default options. See {@link RouterOptions#create()} for information
+     * about the default values.
+     */
     public DefaultRouterFactory() {
-        this.routerOptions = RouterOptions.builder().build();
+        this.routerOptions = RouterOptions.create();
     }
 
+    /**
+     * Create a {@link DefaultRouterFactory} with the given {@link Scheduler} options.
+     *
+     * @param responseScheduler the {@link Scheduler} used to publish responses
+     * @param rateLimitScheduler the {@link Scheduler} used to delay rate limited requests
+     * @deprecated use {@link #DefaultRouterFactory(RouterOptions)}
+     */
     @Deprecated
     public DefaultRouterFactory(Scheduler responseScheduler, Scheduler rateLimitScheduler) {
         this.routerOptions = RouterOptions.builder()
@@ -42,6 +53,11 @@ public class DefaultRouterFactory implements RouterFactory {
                 .build();
     }
 
+    /**
+     * Create a {@link DefaultRouterFactory} configured with the given {@link RouterOptions}.
+     *
+     * @param routerOptions the options to configure the produced {@link Router} instances
+     */
     public DefaultRouterFactory(RouterOptions routerOptions) {
         this.routerOptions = routerOptions;
     }

--- a/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
@@ -50,11 +50,11 @@ public class DiscordRequest<T> {
         this.completeUri = completeUri;
     }
 
-    Route<T> getRoute() {
+    public Route<T> getRoute() {
         return route;
     }
 
-    String getCompleteUri() {
+    public String getCompleteUri() {
         return completeUri;
     }
 

--- a/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Encodes all of the needed information to make an HTTP request to Discord.
+ * Template encoding all of the needed information to make an HTTP request to Discord.
  *
  * @param <T> The response type.
  * @since 3.0

--- a/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordRequest.java
@@ -45,29 +45,60 @@ public class DiscordRequest<T> {
     @Nullable
     private Map<String, Set<String>> headers;
 
+    /**
+     * Create a new {@link DiscordRequest} template based on a {@link Route} and its compiled URI.
+     *
+     * @param route the API resource targeted by this request
+     * @param completeUri the request URI compiled with the appropriate path variables
+     */
     public DiscordRequest(Route<T> route, String completeUri) {
         this.route = route;
         this.completeUri = completeUri;
     }
 
+    /**
+     * Return the API endpoint targeted by this request.
+     *
+     * @return the {@link Route} of this {@link DiscordRequest}
+     */
     public Route<T> getRoute() {
         return route;
     }
 
+    /**
+     * Return the compiled URI of this request.
+     *
+     * @return the compiled URI, containing the actual path variables
+     */
     public String getCompleteUri() {
         return completeUri;
     }
 
+    /**
+     * Return the body of this request, if present.
+     *
+     * @return the body of this request, or {@code null} if this request carries no HTTP body
+     */
     @Nullable
     public Object getBody() {
         return body;
     }
 
+    /**
+     * Return the query parameters saved in this request, if present.
+     *
+     * @return a map representing query parameters, or {@code null} if none are defined
+     */
     @Nullable
     public Map<String, Object> getQueryParams() {
         return queryParams;
     }
 
+    /**
+     * Return the request headers, if present.
+     *
+     * @return a map representing HTTP headers, or {@code null} if none are defined
+     */
     @Nullable
     public Map<String, Set<String>> getHeaders() {
         return headers;

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -34,7 +34,9 @@ import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -59,15 +61,17 @@ class RequestStream<T> {
     private final GlobalRateLimiter globalRateLimiter;
     private final RateLimitStrategy rateLimitStrategy;
     private final Scheduler rateLimitScheduler;
+    private final RouterOptions routerOptions;
 
     RequestStream(BucketKey id, DiscordWebClient httpClient, GlobalRateLimiter globalRateLimiter,
-                  RateLimitStrategy rateLimitStrategy, Scheduler rateLimitScheduler) {
+                  RateLimitStrategy rateLimitStrategy, Scheduler rateLimitScheduler, RouterOptions routerOptions) {
         this.id = id;
         this.log = Loggers.getLogger("discord4j.rest.traces." + id);
         this.httpClient = httpClient;
         this.globalRateLimiter = globalRateLimiter;
         this.rateLimitStrategy = rateLimitStrategy;
         this.rateLimitScheduler = rateLimitScheduler;
+        this.routerOptions = routerOptions;
     }
 
     /**
@@ -112,7 +116,7 @@ class RequestStream<T> {
      * 502, 503 and 504). The delay is calculated using exponential backoff with jitter.
      */
     private Retry<?> serverErrorRetryFactory() {
-        return Retry.onlyIf(this::isServerError)
+        return Retry.onlyIf(ClientException.isRetryContextStatusCode(502, 503, 504))
                 .exponentialBackoffWithJitter(Duration.ofSeconds(2), Duration.ofSeconds(30))
                 .doOnRetry(ctx -> {
                     if (log.isTraceEnabled()) {
@@ -120,17 +124,6 @@ class RequestStream<T> {
                                 ctx.backoff());
                     }
                 });
-    }
-
-    private boolean isServerError(IterationContext<?> context) {
-        RetryContext<?> ctx = (RetryContext) context;
-        Throwable exception = ctx.exception();
-        if (exception instanceof ClientException) {
-            ClientException clientException = (ClientException) exception;
-            int code = clientException.getStatus().code();
-            return code == 502 || code == 503 || code == 504;
-        }
-        return false;
     }
 
     void push(RequestCorrelation<T> request) {
@@ -169,6 +162,23 @@ class RequestStream<T> {
             };
         }
 
+        private Mono<ClientRequest> adaptRequest(DiscordRequest<?> req) {
+            return Mono.fromCallable(() -> new ClientRequest(req,
+                    RouteUtils.expandQuery(req.getCompleteUri(), req.getQueryParams()),
+                    adaptHeaders(req.getHeaders())));
+        }
+
+        private HttpHeaders adaptHeaders(@Nullable Map<String, Set<String>> requestHeaders) {
+            return Optional.ofNullable(requestHeaders)
+                    .map(map -> map.entrySet().stream()
+                            .reduce((HttpHeaders) new DefaultHttpHeaders(), (headers, entry) -> {
+                                String key = entry.getKey();
+                                entry.getValue().forEach(value -> headers.add(key, value));
+                                return headers;
+                            }, HttpHeaders::add))
+                    .orElse(new DefaultHttpHeaders());
+        }
+
         @Override
         protected void hookOnNext(RequestCorrelation<T> correlation) {
             DiscordRequest<T> request = correlation.getRequest();
@@ -186,6 +196,7 @@ class RequestStream<T> {
                     .log(requestLog, Level.FINEST, false)
                     .flatMap(r -> httpClient.exchange(r, request.getBody(), responseType, rateLimitHandler))
                     .retryWhen(rateLimitRetryFactory())
+                    .transform(getResponseTransformers(request))
                     .retryWhen(serverErrorRetryFactory())
                     .log(responseLog, Level.FINEST, false)
                     .doFinally(signal -> next(signal, traceLog)))
@@ -203,17 +214,12 @@ class RequestStream<T> {
                     });
         }
 
-        private Mono<ClientRequest> adaptRequest(DiscordRequest<?> req) {
-            return Mono.fromCallable(() -> new ClientRequest(req.getRoute().getMethod(),
-                    RouteUtils.expandQuery(req.getCompleteUri(), req.getQueryParams()),
-                    Optional.ofNullable(req.getHeaders())
-                            .map(map -> map.entrySet().stream()
-                                    .reduce((HttpHeaders) new DefaultHttpHeaders(), (headers, entry) -> {
-                                        String key = entry.getKey();
-                                        entry.getValue().forEach(value -> headers.add(key, value));
-                                        return headers;
-                                    }, HttpHeaders::add))
-                            .orElse(new DefaultHttpHeaders())));
+        private Function<Mono<T>, Mono<T>> getResponseTransformers(DiscordRequest<T> discordRequest) {
+            return routerOptions.getResponseTransformers()
+                    .stream()
+                    .map(rt -> rt.transform(discordRequest))
+                    .reduce(Function::andThen)
+                    .orElse(mono -> mono);
         }
 
         private void next(SignalType signal, Logger logger) {

--- a/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
+++ b/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
@@ -18,8 +18,12 @@
 package discord4j.rest.request;
 
 import discord4j.rest.route.Route;
+import discord4j.rest.route.Routes;
 import reactor.util.annotation.Nullable;
 
+/**
+ * A predicate that can match a given {@link DiscordRequest}.
+ */
 public class RouteMatcher {
 
     @Nullable
@@ -29,14 +33,32 @@ public class RouteMatcher {
         this.request = request;
     }
 
+    /**
+     * Create a new {@link RouteMatcher} that returns true for every request.
+     *
+     * @return a new {@link RouteMatcher}
+     */
     public static RouteMatcher any() {
         return new RouteMatcher(null);
     }
 
+    /**
+     * Create a new {@link RouteMatcher} that matches any request made for the given {@link Route}. A list of
+     * {@link Route} objects exist in the {@link Routes} class.
+     *
+     * @param route the {@link Route} to be matched by this instance
+     * @return a new {@link RouteMatcher}
+     */
     public static RouteMatcher route(Route<?> route) {
         return new RouteMatcher(route.newRequest());
     }
 
+    /**
+     * Tests this matcher against the given {@link DiscordRequest}.
+     *
+     * @param otherRequest the {@link DiscordRequest} argument
+     * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
+     */
     public boolean matches(DiscordRequest<?> otherRequest) {
         return request == null || request.getRoute().getResponseType().isInstance(otherRequest.getRoute().getResponseType());
     }

--- a/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
+++ b/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
@@ -17,20 +17,27 @@
 
 package discord4j.rest.request;
 
-import discord4j.rest.http.client.DiscordWebClient;
+import discord4j.rest.route.Route;
+import reactor.util.annotation.Nullable;
 
-/**
- * Factory used to produce {@link discord4j.rest.request.Router} instances dedicated to execute API requests.
- */
-public interface RouterFactory {
+public class RouteMatcher {
 
-    /**
-     * Retrieve a {@link discord4j.rest.request.Router} configured to process API requests.
-     *
-     * @param webClient a web client to parameterize the Router creation
-     * @return a Router prepared to process API requests
-     */
-    Router getRouter(DiscordWebClient webClient);
+    @Nullable
+    private final DiscordRequest<?> request;
 
-    Router getRouter(DiscordWebClient webClient, RouterOptions routerOptions);
+    public RouteMatcher(DiscordRequest<?> request) {
+        this.request = request;
+    }
+
+    public static RouteMatcher any() {
+        return new RouteMatcher(null);
+    }
+
+    public static RouteMatcher route(Route<?> route) {
+        return new RouteMatcher(route.newRequest());
+    }
+
+    public boolean matches(DiscordRequest<?> otherRequest) {
+        return request == null || request.getRoute().getResponseType().isInstance(otherRequest.getRoute().getResponseType());
+    }
 }

--- a/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
+++ b/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
@@ -17,20 +17,34 @@
 
 package discord4j.rest.request;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.rest.route.Route;
 import discord4j.rest.route.Routes;
 import reactor.util.annotation.Nullable;
 
+import java.util.Map;
+import java.util.function.Predicate;
+
 /**
- * A predicate that can match a given {@link DiscordRequest}.
+ * A predicate that can match a given {@link DiscordRequest}. You can create instances of this class using the
+ * {@link #route(Route)} factory, or through {@link #any()} to provide a catch-all matcher.
  */
+@Experimental
 public class RouteMatcher {
 
     @Nullable
     private final DiscordRequest<?> request;
 
-    public RouteMatcher(DiscordRequest<?> request) {
+    @Nullable
+    private final Predicate<Map<String, String>> requestVariableMatcher;
+
+    private RouteMatcher(DiscordRequest<?> request) {
+        this(request, null);
+    }
+
+    public RouteMatcher(DiscordRequest<?> request, Predicate<Map<String, String>> requestVariableMatcher) {
         this.request = request;
+        this.requestVariableMatcher = requestVariableMatcher;
     }
 
     /**
@@ -54,12 +68,39 @@ public class RouteMatcher {
     }
 
     /**
+     * Create a new {@link RouteMatcher} that matches every request made for the given {@link Route} that also match
+     * a given {@link Predicate} of URI variables.
+     * <p>
+     * The given predicate will receive a {@link Map} of {@code String} URI template parameters as keys and {@code
+     * String} values used to compile the URI for a {@link DiscordRequest}. This means you would expect keys as
+     * {@code guild.id}, {@code channel.id}, {@code message.id}, {@code user.id}, among others. Refer to the actual
+     * {@link Route} instances declared in the {@link Routes} class for the exact template keys used in the requests
+     * you want to match.
+     *
+     * @param route the {@link Route} to be matched by this instance
+     * @param requestVariableMatcher a {@link Map} of {@code String} keys and values representing the URI template and
+     * the completed value for a given {@link DiscordRequest}, respectively
+     * @return a new {@link RouteMatcher}
+     */
+    public static RouteMatcher route(Route<?> route, Predicate<Map<String, String>> requestVariableMatcher) {
+        return new RouteMatcher(route.newRequest(), requestVariableMatcher);
+    }
+
+    /**
      * Tests this matcher against the given {@link DiscordRequest}.
      *
      * @param otherRequest the {@link DiscordRequest} argument
      * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
      */
     public boolean matches(DiscordRequest<?> otherRequest) {
-        return request == null || request.getRoute().getResponseType().isInstance(otherRequest.getRoute().getResponseType());
+        return matchesRoute(otherRequest) && matchesVariables(otherRequest);
+    }
+
+    private boolean matchesRoute(DiscordRequest<?> otherRequest) {
+        return request == null || request.getRoute().equals(otherRequest.getRoute());
+    }
+
+    private boolean matchesVariables(DiscordRequest<?> otherRequest) {
+        return requestVariableMatcher == null || otherRequest.matchesVariables(requestVariableMatcher);
     }
 }

--- a/rest/src/main/java/discord4j/rest/request/RouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/RouterFactory.java
@@ -27,10 +27,18 @@ public interface RouterFactory {
     /**
      * Retrieve a {@link discord4j.rest.request.Router} configured to process API requests.
      *
-     * @param webClient a web client to parameterize the Router creation
-     * @return a Router prepared to process API requests
+     * @param webClient a web client to parameterize the {@link Router} creation
+     * @return a {@link Router} prepared to process API requests
      */
     Router getRouter(DiscordWebClient webClient);
 
+    /**
+     * Retrieve a {@link discord4j.rest.request.Router} that can be further configured with the given
+     * {@link RouterOptions} to process API requests.
+     *
+     * @param webClient a web client to parameterize the {@link Router} creation
+     * @param routerOptions a configuration object to control the behavior of the resulting {@link Router}
+     * @return a {@link Router} prepared to process API requests
+     */
     Router getRouter(DiscordWebClient webClient, RouterOptions routerOptions);
 }

--- a/rest/src/main/java/discord4j/rest/request/RouterOptions.java
+++ b/rest/src/main/java/discord4j/rest/request/RouterOptions.java
@@ -24,26 +24,42 @@ import reactor.core.scheduler.Schedulers;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Options used to control the behavior of a {@link Router}.
+ */
 public class RouterOptions {
 
     private final Scheduler responseScheduler;
     private final Scheduler rateLimitScheduler;
     private final List<ResponseFunction> responseTransformers;
 
-    public RouterOptions(Builder builder) {
+    protected RouterOptions(Builder builder) {
         this.responseScheduler = builder.responseScheduler;
         this.rateLimitScheduler = builder.rateLimitScheduler;
         this.responseTransformers = builder.responseTransformers;
     }
 
+    /**
+     * Returns a new {@link RouterOptions.Builder} to construct {@link RouterOptions}.
+     *
+     * @return a new {@code RouterOptions} builder
+     */
     public static RouterOptions.Builder builder() {
         return new RouterOptions.Builder();
     }
 
+    /**
+     * Returns a new {@link RouterOptions} with default settings.
+     *
+     * @return a new {@code RouterOptions}
+     */
     public static RouterOptions create() {
         return builder().build();
     }
 
+    /**
+     * Builder for {@link RouterOptions}.
+     */
     public static class Builder {
 
         private Scheduler responseScheduler = Schedulers.elastic();
@@ -53,16 +69,46 @@ public class RouterOptions {
         protected Builder() {
         }
 
+        /**
+         * Sets the {@link Scheduler} used to process API responses. Defaults to {@link Schedulers#elastic()}.
+         *
+         * @param responseScheduler the {@code Scheduler} used to process responses
+         * @return this builder
+         */
         public Builder responseScheduler(Scheduler responseScheduler) {
             this.responseScheduler = responseScheduler;
             return this;
         }
 
+        /**
+         * Sets the {@link Scheduler} used to handle delays introduced by rate limiting. Defaults to
+         * {@link Schedulers#elastic()}.
+         *
+         * @param rateLimitScheduler the {@code Scheduler} used to handle rate limiting
+         * @return this builder
+         */
         public Builder rateLimitScheduler(Scheduler rateLimitScheduler) {
             this.rateLimitScheduler = rateLimitScheduler;
             return this;
         }
 
+        /**
+         * Sets a new API response behavior to the supporting {@link Router}, allowing cross-cutting behavior across
+         * all requests made by the {@code Router}.
+         * <p>
+         * The given {@link ResponseFunction} will be applied after every response. Calling
+         * {@link #onClientResponse(ResponseFunction)} multiple times will result in additive behavior, so care must be
+         * taken regarding the <strong>order</strong> in which multiple calls occur. Responses will processed in this
+         * order and only the first matching one will be transformed.
+         * <p>
+         * Built-in factories are supplied for commonly used behavior:
+         * <ul>
+         * <li>{@link ResponseFunction}</li>
+         * </ul>
+         *
+         * @param errorHandler
+         * @return
+         */
         public Builder onClientResponse(ResponseFunction errorHandler) {
             responseTransformers.add(errorHandler);
             return this;

--- a/rest/src/main/java/discord4j/rest/request/RouterOptions.java
+++ b/rest/src/main/java/discord4j/rest/request/RouterOptions.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.request;
+
+import discord4j.rest.response.ResponseFunction;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RouterOptions {
+
+    private final Scheduler responseScheduler;
+    private final Scheduler rateLimitScheduler;
+    private final List<ResponseFunction> responseTransformers;
+
+    public RouterOptions(Builder builder) {
+        this.responseScheduler = builder.responseScheduler;
+        this.rateLimitScheduler = builder.rateLimitScheduler;
+        this.responseTransformers = builder.responseTransformers;
+    }
+
+    public static RouterOptions.Builder builder() {
+        return new RouterOptions.Builder();
+    }
+
+    public static RouterOptions create() {
+        return builder().build();
+    }
+
+    public static class Builder {
+
+        private Scheduler responseScheduler = Schedulers.elastic();
+        private Scheduler rateLimitScheduler = Schedulers.elastic();
+        private final List<ResponseFunction> responseTransformers = new ArrayList<>();
+
+        protected Builder() {
+        }
+
+        public Builder responseScheduler(Scheduler responseScheduler) {
+            this.responseScheduler = responseScheduler;
+            return this;
+        }
+
+        public Builder rateLimitScheduler(Scheduler rateLimitScheduler) {
+            this.rateLimitScheduler = rateLimitScheduler;
+            return this;
+        }
+
+        public Builder onClientResponse(ResponseFunction errorHandler) {
+            responseTransformers.add(errorHandler);
+            return this;
+        }
+
+        public RouterOptions build() {
+            return new RouterOptions(this);
+        }
+    }
+
+    public Scheduler getResponseScheduler() {
+        return responseScheduler;
+    }
+
+    public Scheduler getRateLimitScheduler() {
+        return rateLimitScheduler;
+    }
+
+    public List<ResponseFunction> getResponseTransformers() {
+        return responseTransformers;
+    }
+}

--- a/rest/src/main/java/discord4j/rest/request/RouterOptions.java
+++ b/rest/src/main/java/discord4j/rest/request/RouterOptions.java
@@ -115,8 +115,8 @@ public class RouterOptions {
          * <p>
          * Built-in factories are supplied for commonly used behavior:
          * <ul>
-         * <li>{@link ResponseFunction#emptyWhenNotFound()} transforms any HTTP 404 error into an empty sequence.</li>
-         * <li>{@link ResponseFunction#emptyWhenNotFound(RouteMatcher)} transforms HTTP 404 errors from the given
+         * <li>{@link ResponseFunction#emptyIfNotFound()} transforms any HTTP 404 error into an empty sequence.</li>
+         * <li>{@link ResponseFunction#emptyIfNotFound(RouteMatcher)} transforms HTTP 404 errors from the given
          * {@link Route}s into an empty sequence.</li>
          * <li>{@link ResponseFunction#emptyOnErrorStatus(RouteMatcher, Integer...)} provides the same behavior as
          * above but for any given status codes.</li>

--- a/rest/src/main/java/discord4j/rest/request/RouterOptions.java
+++ b/rest/src/main/java/discord4j/rest/request/RouterOptions.java
@@ -17,6 +17,7 @@
 
 package discord4j.rest.request;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.rest.response.ResponseFunction;
 import discord4j.rest.route.Route;
 import reactor.core.scheduler.Scheduler;
@@ -106,12 +107,11 @@ public class RouterOptions {
 
         /**
          * Sets a new API response behavior to the supporting {@link Router}, allowing cross-cutting behavior across
-         * all requests made by the {@code Router}.
+         * all requests made by it.
          * <p>
          * The given {@link ResponseFunction} will be applied after every response. Calling this function multiple
          * times will result in additive behavior, so care must be taken regarding the <strong>order</strong> in
-         * which multiple calls occur. Responses will processed in this order and only the first matching one will be
-         * transformed.
+         * which multiple calls occur. Transformations will be added to the response pipeline in that order.
          * <p>
          * Built-in factories are supplied for commonly used behavior:
          * <ul>
@@ -128,6 +128,7 @@ public class RouterOptions {
          * @param errorHandler the {@link ResponseFunction} to transform the responses from matching requests.
          * @return this builder
          */
+        @Experimental
         public Builder onClientResponse(ResponseFunction errorHandler) {
             responseTransformers.add(errorHandler);
             return this;

--- a/rest/src/main/java/discord4j/rest/request/RouterOptions.java
+++ b/rest/src/main/java/discord4j/rest/request/RouterOptions.java
@@ -30,6 +30,16 @@ import java.util.List;
  */
 public class RouterOptions {
 
+    /**
+     * The default {@link Scheduler} to publish responses. Allows blocking usage.
+     */
+    public static final Scheduler DEFAULT_RESPONSE_SCHEDULER = Schedulers.elastic();
+
+    /**
+     * The default {@link Scheduler} to delay rate limited requests.
+     */
+    public static final Scheduler DEFAULT_RATE_LIMIT_SCHEDULER = Schedulers.elastic();
+
     private final Scheduler responseScheduler;
     private final Scheduler rateLimitScheduler;
     private final List<ResponseFunction> responseTransformers;
@@ -50,7 +60,8 @@ public class RouterOptions {
     }
 
     /**
-     * Returns a new {@link RouterOptions} with default settings.
+     * Returns a new {@link RouterOptions} with default settings. See {@link #DEFAULT_RESPONSE_SCHEDULER} and
+     * {@link #DEFAULT_RATE_LIMIT_SCHEDULER} for the default values.
      *
      * @return a new {@code RouterOptions}
      */
@@ -63,8 +74,8 @@ public class RouterOptions {
      */
     public static class Builder {
 
-        private Scheduler responseScheduler = Schedulers.elastic();
-        private Scheduler rateLimitScheduler = Schedulers.elastic();
+        private Scheduler responseScheduler = DEFAULT_RESPONSE_SCHEDULER;
+        private Scheduler rateLimitScheduler = DEFAULT_RATE_LIMIT_SCHEDULER;
         private final List<ResponseFunction> responseTransformers = new ArrayList<>();
 
         protected Builder() {

--- a/rest/src/main/java/discord4j/rest/request/SingleRouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/SingleRouterFactory.java
@@ -20,11 +20,13 @@ package discord4j.rest.request;
 import discord4j.rest.http.client.DiscordWebClient;
 
 /**
- * A {@link discord4j.rest.request.RouterFactory} that caches a {@link discord4j.rest.request.Router} captured at
- * instantiation instead of producing a new one each time
- * {@link #getRouter(discord4j.rest.http.client.DiscordWebClient)} is called.
+ * A monolithic {@link discord4j.rest.request.RouterFactory} that caches a {@link discord4j.rest.request.Router}
+ * captured at instantiation instead of producing a new one each time
+ * {@link #getRouter(discord4j.rest.http.client.DiscordWebClient)} or
+ * {@link #getRouter(DiscordWebClient, RouterOptions)} is called.
  * <p>
- * Suited for sharing a router in order to coordinate its work across shards.
+ * Suited for sharing a router in order to coordinate its work across shards. It is not suited for distributed scenarios
+ * where multiple shards exist across processes unless care is taken to properly coordinate each request externally.
  */
 public class SingleRouterFactory implements RouterFactory {
 

--- a/rest/src/main/java/discord4j/rest/request/SingleRouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/SingleRouterFactory.java
@@ -38,4 +38,9 @@ public class SingleRouterFactory implements RouterFactory {
     public Router getRouter(DiscordWebClient httpClient) {
         return router;
     }
+
+    @Override
+    public Router getRouter(DiscordWebClient httpClient, RouterOptions routerOptions) {
+        return router;
+    }
 }

--- a/rest/src/main/java/discord4j/rest/request/SingleRouterFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/SingleRouterFactory.java
@@ -32,6 +32,11 @@ public class SingleRouterFactory implements RouterFactory {
 
     private final Router router;
 
+    /**
+     * Create a new {@link SingleRouterFactory} that will always produce the given {@link Router} instance.
+     *
+     * @param router the {@link Router} instance that will be produced by this factory.
+     */
     public SingleRouterFactory(Router router) {
         this.router = router;
     }

--- a/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
@@ -26,6 +26,14 @@ import reactor.util.Loggers;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * A {@link ResponseFunction} that is able to transform an error sequence with a HTTP 404 status, into an empty
+ * sequence.
+ *
+ * @see ResponseFunction#emptyWhenNotFound()
+ * @see ResponseFunction#emptyWhenNotFound(RouteMatcher)
+ * @see ResponseFunction#emptyOnErrorStatus(RouteMatcher, Integer...)
+ */
 public class EmptyResponseTransformer implements ResponseFunction {
 
     private static final Logger log = Loggers.getLogger(EmptyResponseTransformer.class);
@@ -42,7 +50,7 @@ public class EmptyResponseTransformer implements ResponseFunction {
     public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
         if (routeMatcher.matches(request)) {
             return mono -> mono.onErrorResume(predicate, t -> {
-                log.info("Returning empty response for {} after {}", request, t.toString());
+                log.debug("Returning empty response for {} after {}", request, t.toString());
                 return Mono.empty();
             });
         }

--- a/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.response;
+
+import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.RouteMatcher;
+import reactor.core.publisher.Mono;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class EmptyResponseTransformer implements ResponseFunction {
+
+    private static final Logger log = Loggers.getLogger(EmptyResponseTransformer.class);
+
+    private final RouteMatcher routeMatcher;
+    private final Predicate<Throwable> predicate;
+
+    public EmptyResponseTransformer(RouteMatcher routeMatcher, Predicate<Throwable> predicate) {
+        this.routeMatcher = routeMatcher;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
+        if (routeMatcher.matches(request)) {
+            return mono -> mono.onErrorResume(predicate, t -> {
+                log.info("Returning empty response for {} after {}", request, t.toString());
+                return Mono.empty();
+            });
+        }
+        return mono -> mono;
+    }
+}

--- a/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
@@ -17,11 +17,10 @@
 
 package discord4j.rest.response;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.rest.request.DiscordRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -34,9 +33,8 @@ import java.util.function.Predicate;
  * @see ResponseFunction#emptyWhenNotFound(RouteMatcher)
  * @see ResponseFunction#emptyOnErrorStatus(RouteMatcher, Integer...)
  */
+@Experimental
 public class EmptyResponseTransformer implements ResponseFunction {
-
-    private static final Logger log = Loggers.getLogger(EmptyResponseTransformer.class);
 
     private final RouteMatcher routeMatcher;
     private final Predicate<Throwable> predicate;
@@ -49,10 +47,7 @@ public class EmptyResponseTransformer implements ResponseFunction {
     @Override
     public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
         if (routeMatcher.matches(request)) {
-            return mono -> mono.onErrorResume(predicate, t -> {
-                log.debug("Returning empty response for {} after {}", request, t.toString());
-                return Mono.empty();
-            });
+            return mono -> mono.onErrorResume(predicate, t -> Mono.empty());
         }
         return mono -> mono;
     }

--- a/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
@@ -29,8 +29,8 @@ import java.util.function.Predicate;
  * A {@link ResponseFunction} that is able to transform an error sequence with a HTTP 404 status, into an empty
  * sequence.
  *
- * @see ResponseFunction#emptyWhenNotFound()
- * @see ResponseFunction#emptyWhenNotFound(RouteMatcher)
+ * @see ResponseFunction#emptyIfNotFound()
+ * @see ResponseFunction#emptyIfNotFound(RouteMatcher)
  * @see ResponseFunction#emptyOnErrorStatus(RouteMatcher, Integer...)
  */
 @Experimental

--- a/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
+++ b/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.response;
+
+import discord4j.rest.http.client.ClientException;
+import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.RouteMatcher;
+import reactor.core.publisher.Mono;
+import reactor.retry.Retry;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+public interface ResponseFunction {
+
+    <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request);
+
+    static EmptyResponseTransformer emptyWhenNotFound() {
+        return new EmptyResponseTransformer(RouteMatcher.any(), ClientException.isStatusCode(404));
+    }
+
+    static EmptyResponseTransformer emptyWhenNotFound(RouteMatcher routeMatcher) {
+        return new EmptyResponseTransformer(routeMatcher, ClientException.isStatusCode(404));
+    }
+
+    static EmptyResponseTransformer emptyOnErrorStatus(RouteMatcher routeMatcher, Integer... codes) {
+        return new EmptyResponseTransformer(routeMatcher, ClientException.isStatusCode(codes));
+    }
+
+    static RetryingTransformer retryOnceOnErrorStatus(Integer... codes) {
+        return new RetryingTransformer(RouteMatcher.any(),
+                Retry.onlyIf(ClientException.isRetryContextStatusCode(codes))
+                        .fixedBackoff(Duration.ofSeconds(1))
+                        .retryOnce());
+    }
+
+    static RetryingTransformer retryWhen(RouteMatcher routeMatcher, Retry<?> retry) {
+        return new RetryingTransformer(routeMatcher, retry);
+    }
+}

--- a/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
+++ b/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
@@ -20,28 +20,86 @@ package discord4j.rest.response;
 import discord4j.rest.http.client.ClientException;
 import discord4j.rest.request.DiscordRequest;
 import discord4j.rest.request.RouteMatcher;
+import discord4j.rest.request.Router;
 import reactor.core.publisher.Mono;
 import reactor.retry.Retry;
 
 import java.time.Duration;
 import java.util.function.Function;
 
+/**
+ * A transformation function used while processing {@link DiscordRequest} objects.
+ * <p>
+ * Using {@code ResponseFunction} objects is targeted to supporting {@link Router} implementations that allow enrichment
+ * of a response {@link Mono} pipeline, allowing cross-cutting behavior for specialized error handling or retrying under
+ * specific conditions like an HTTP status code or a given API request route. Usage beyond this concern is not
+ * supported and could interfere with downstream operations.
+ */
 public interface ResponseFunction {
 
+    /**
+     * Transform a {@link Mono} pipeline using the given {@link DiscordRequest} as hint for parameterization of the
+     * resulting transformation.
+     *
+     * @param request the {@code DiscordRequest} used for the targeted {@code Mono} sequence
+     * @param <T> the type of the sequence
+     * @return a {@link Function} that allows immediately mapping this {@code Mono} into a target {@code Mono} instance
+     */
     <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request);
 
+    /**
+     * Transform every HTTP 404 status code into an empty response into an empty sequence, effectively suppressing
+     * the {@link ClientException} that would be forwarded otherwise. See {@link #emptyWhenNotFound(RouteMatcher)}
+     * for an override that supports applying the transformation to a subset of requests.
+     *
+     * @return a {@link ResponseFunction} that transforms any HTTP 404 error into an empty sequence
+     */
     static EmptyResponseTransformer emptyWhenNotFound() {
         return new EmptyResponseTransformer(RouteMatcher.any(), ClientException.isStatusCode(404));
     }
 
+    /**
+     * Transforms HTTP 404 status codes received by the requests matching the given {@link RouteMatcher} into an
+     * empty sequence, effectively suppressing the {@link ClientException} that would be forwarded otherwise. See
+     * {@link #emptyWhenNotFound()} to apply this transformation across all {@link Router} requests.
+     *
+     * @param routeMatcher the {@link RouteMatcher} determining whether to match a particular request
+     * @return a {@link ResponseFunction} that transforms matching HTTP 404 errors into an empty sequence
+     */
     static EmptyResponseTransformer emptyWhenNotFound(RouteMatcher routeMatcher) {
         return new EmptyResponseTransformer(routeMatcher, ClientException.isStatusCode(404));
     }
 
+    /**
+     * Transforms the given <strong>error</strong> status codes received by the requests matching the given
+     * {@link RouteMatcher}, effectively suppressing the {@link ClientException} that would be forwarded otherwise.
+     * <p>
+     * Only a subset of HTTP status codes is supported, like all the ones from 400 and 500 series, except for the 429
+     * (Too Many Requests) error that is handled upstream.
+     *
+     * @param routeMatcher the {@link RouteMatcher} determining whether to match a particular request
+     * @param codes the list of HTTP status codes to match when applying this transformation
+     * @return a {@link ResponseFunction} that transforms matching requests and response statuses into an empty sequence
+     */
     static EmptyResponseTransformer emptyOnErrorStatus(RouteMatcher routeMatcher, Integer... codes) {
         return new EmptyResponseTransformer(routeMatcher, ClientException.isStatusCode(codes));
     }
 
+    /**
+     * Applies a retry strategy to retry <strong>once</strong> with a fixed backoff of 1 second to the given
+     * <strong>error</strong> status codes received by the requests matching the given {@link RouteMatcher},
+     * effectively suppressing the {@link ClientException} that would be forwarded otherwise.
+     * <p>
+     * Only a subset of HTTP status codes is supported, like all the ones from 400 and 500 series, except for the 429
+     * (Too Many Requests) error that is handled upstream.
+     * <p>
+     * Please note that if you specify error codes 502, 503 or 504 you will replace a built-in retry factory that
+     * handles Discord service errors using an exponential backoff with jitter strategy.
+     *
+     * @param codes the list of HTTP status codes to match when applying this transformation
+     * @return a {@link ResponseFunction} that transforms matching response statuses into sequence that retries the
+     * request once after waiting 1 second.
+     */
     static RetryingTransformer retryOnceOnErrorStatus(Integer... codes) {
         return new RetryingTransformer(RouteMatcher.any(),
                 Retry.onlyIf(ClientException.isRetryContextStatusCode(codes))
@@ -49,6 +107,18 @@ public interface ResponseFunction {
                         .retryOnce());
     }
 
+    /**
+     * Applies a custom retry strategy to the requests matching the given {@link RouteMatcher}, effectively
+     * suppressing the {@link ClientException} that would be forwarded otherwise.
+     * <p>
+     * Care must be taken when applying this transformation while using a long running retry factory, as it may
+     * effectively block further requests on the same rate limiting bucket.
+     *
+     * @param routeMatcher the {@link RouteMatcher} determining whether to match a particular request
+     * @param retry the {@link Retry} factory to install while applying this transformation
+     * @return a {@link ResponseFunction} that transforms matching response statuses into sequence that retries the
+     * request once after waiting 1 second.
+     */
     static RetryingTransformer retryWhen(RouteMatcher routeMatcher, Retry<?> retry) {
         return new RetryingTransformer(routeMatcher, retry);
     }

--- a/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
+++ b/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
@@ -56,24 +56,24 @@ public interface ResponseFunction {
 
     /**
      * Transform every HTTP 404 status code into an empty response into an empty sequence, effectively suppressing
-     * the {@link ClientException} that would be forwarded otherwise. See {@link #emptyWhenNotFound(RouteMatcher)}
+     * the {@link ClientException} that would be forwarded otherwise. See {@link #emptyIfNotFound(RouteMatcher)}
      * for an override that supports applying the transformation to a subset of requests.
      *
      * @return a {@link ResponseFunction} that transforms any HTTP 404 error into an empty sequence
      */
-    static EmptyResponseTransformer emptyWhenNotFound() {
+    static EmptyResponseTransformer emptyIfNotFound() {
         return new EmptyResponseTransformer(RouteMatcher.any(), ClientException.isStatusCode(404));
     }
 
     /**
      * Transforms HTTP 404 status codes caused by requests matching the given {@link RouteMatcher} into an empty
      * sequence, effectively suppressing the {@link ClientException} that would be forwarded otherwise. See
-     * {@link #emptyWhenNotFound()} to apply this transformation across all {@link Router} requests.
+     * {@link #emptyIfNotFound()} to apply this transformation across all {@link Router} requests.
      *
      * @param routeMatcher the {@link RouteMatcher} determining whether to match a particular request
      * @return a {@link ResponseFunction} that transforms matching HTTP 404 errors into an empty sequence
      */
-    static EmptyResponseTransformer emptyWhenNotFound(RouteMatcher routeMatcher) {
+    static EmptyResponseTransformer emptyIfNotFound(RouteMatcher routeMatcher) {
         return new EmptyResponseTransformer(routeMatcher, ClientException.isStatusCode(404));
     }
 

--- a/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
+++ b/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
@@ -17,6 +17,7 @@
 
 package discord4j.rest.response;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.rest.http.client.ClientException;
 import discord4j.rest.request.DiscordRequest;
 import discord4j.rest.request.RouteMatcher;
@@ -40,6 +41,7 @@ import java.util.function.Function;
  * {@link RouterOptions.Builder#onClientResponse(ResponseFunction)}, where it can be applied using one of the static
  * helper methods defined in this class.
  */
+@Experimental
 public interface ResponseFunction {
 
     /**

--- a/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
@@ -24,14 +24,17 @@ import reactor.core.publisher.Mono;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * A {@link ResponseFunction} that is able to transform an error sequence into a custom response.
+ */
 public class ResumingTransformer implements ResponseFunction {
 
     private final RouteMatcher routeMatcher;
     private final Predicate<Throwable> predicate;
     private Function<Throwable, Mono<?>> fallback;
 
-    public ResumingTransformer(RouteMatcher routeMatcher, Predicate<Throwable> predicate, Function<Throwable,
-            Mono<?>> fallback) {
+    public ResumingTransformer(RouteMatcher routeMatcher, Predicate<Throwable> predicate,
+                               Function<Throwable, Mono<?>> fallback) {
         this.routeMatcher = routeMatcher;
         this.predicate = predicate;
         this.fallback = fallback;

--- a/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.response;
+
+import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.RouteMatcher;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ResumingTransformer implements ResponseFunction {
+
+    private final RouteMatcher routeMatcher;
+    private final Predicate<Throwable> predicate;
+    private Function<Throwable, Mono<?>> fallback;
+
+    public ResumingTransformer(RouteMatcher routeMatcher, Predicate<Throwable> predicate, Function<Throwable,
+            Mono<?>> fallback) {
+        this.routeMatcher = routeMatcher;
+        this.predicate = predicate;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
+        if (routeMatcher.matches(request)) {
+            return mono -> mono.onErrorResume(predicate, adaptFallback(fallback));
+        }
+        return mono -> mono;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Function<? super Throwable, ? extends Mono<? extends T>> adaptFallback(
+            Function<? super Throwable, ? extends Mono<?>> fallback) {
+        return (Function<? super Throwable, ? extends Mono<? extends T>>) fallback;
+    }
+}

--- a/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
@@ -17,6 +17,7 @@
 
 package discord4j.rest.response;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.rest.request.DiscordRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
@@ -27,6 +28,7 @@ import java.util.function.Predicate;
 /**
  * A {@link ResponseFunction} that is able to transform an error sequence into a custom response.
  */
+@Experimental
 public class ResumingTransformer implements ResponseFunction {
 
     private final RouteMatcher routeMatcher;

--- a/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.response;
+
+import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.RouteMatcher;
+import reactor.core.publisher.Mono;
+import reactor.retry.Retry;
+
+import java.util.function.Function;
+
+public class RetryingTransformer implements ResponseFunction {
+
+    private final RouteMatcher routeMatcher;
+    private final Retry<?> retryFactory;
+
+    public RetryingTransformer(RouteMatcher routeMatcher, Retry<?> retryFactory) {
+        this.routeMatcher = routeMatcher;
+        this.retryFactory = retryFactory;
+    }
+
+    @Override
+    public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
+        if (routeMatcher.matches(request)) {
+            return mono -> mono.retryWhen(retryFactory);
+        }
+        return mono -> mono;
+    }
+}

--- a/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
@@ -24,6 +24,9 @@ import reactor.retry.Retry;
 
 import java.util.function.Function;
 
+/**
+ * A {@link ResponseFunction} that is able to transform an error sequence into a retrying one.
+ */
 public class RetryingTransformer implements ResponseFunction {
 
     private final RouteMatcher routeMatcher;

--- a/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
@@ -17,17 +17,23 @@
 
 package discord4j.rest.response;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.rest.request.DiscordRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
 import reactor.retry.Retry;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 
 import java.util.function.Function;
 
 /**
  * A {@link ResponseFunction} that is able to transform an error sequence into a retrying one.
  */
+@Experimental
 public class RetryingTransformer implements ResponseFunction {
+
+    private static final Logger log = Loggers.getLogger(RetryingTransformer.class);
 
     private final RouteMatcher routeMatcher;
     private final Retry<?> retryFactory;
@@ -40,6 +46,7 @@ public class RetryingTransformer implements ResponseFunction {
     @Override
     public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
         if (routeMatcher.matches(request)) {
+            log.info("Enabling retry factory to {}", request);
             return mono -> mono.retryWhen(retryFactory);
         }
         return mono -> mono;

--- a/rest/src/main/java/discord4j/rest/response/package-info.java
+++ b/rest/src/main/java/discord4j/rest/response/package-info.java
@@ -14,23 +14,10 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
  */
-
-package discord4j.rest.request;
-
-import discord4j.rest.http.client.DiscordWebClient;
-
 /**
- * Factory used to produce {@link discord4j.rest.request.Router} instances dedicated to execute API requests.
+ * Components to manipulate and transform responses.
  */
-public interface RouterFactory {
+@NonNullApi
+package discord4j.rest.response;
 
-    /**
-     * Retrieve a {@link discord4j.rest.request.Router} configured to process API requests.
-     *
-     * @param webClient a web client to parameterize the Router creation
-     * @return a Router prepared to process API requests
-     */
-    Router getRouter(DiscordWebClient webClient);
-
-    Router getRouter(DiscordWebClient webClient, RouterOptions routerOptions);
-}
+import reactor.util.annotation.NonNullApi;

--- a/rest/src/main/java/discord4j/rest/route/Route.java
+++ b/rest/src/main/java/discord4j/rest/route/Route.java
@@ -17,7 +17,6 @@
 package discord4j.rest.route;
 
 import discord4j.rest.request.DiscordRequest;
-import discord4j.rest.util.RouteUtils;
 import io.netty.handler.codec.http.HttpMethod;
 import reactor.util.annotation.Nullable;
 
@@ -87,7 +86,7 @@ public class Route<T> {
      * @see discord4j.rest.request.DiscordRequest#exchange
      */
     public DiscordRequest<T> newRequest(Object... uriVars) {
-        return new DiscordRequest<>(this, RouteUtils.expand(getUriTemplate(), uriVars));
+        return new DiscordRequest<>(this, uriVars);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/route/Route.java
+++ b/rest/src/main/java/discord4j/rest/route/Route.java
@@ -61,10 +61,20 @@ public class Route<T> {
         return new Route<>(HttpMethod.DELETE, uri, responseType);
     }
 
+    /**
+     * Return the HTTP method for this route.
+     *
+     * @return the {@link HttpMethod} of this {@link Route}
+     */
     public HttpMethod getMethod() {
         return method;
     }
 
+    /**
+     * Return the route's response type. Can be {@link Void} if the {@link Route} has no response body.
+     *
+     * @return the response type of this {@link Route}
+     */
     public Class<T> getResponseType() {
         return responseType;
     }
@@ -80,6 +90,11 @@ public class Route<T> {
         return new DiscordRequest<>(this, RouteUtils.expand(getUriTemplate(), uriVars));
     }
 
+    /**
+     * Return the URI template that defines this route.
+     *
+     * @return a URI template, probably containing path parameters, that is defining this {@link Route}
+     */
     public String getUriTemplate() {
         return uriTemplate;
     }

--- a/rest/src/main/java/discord4j/rest/util/RouteUtils.java
+++ b/rest/src/main/java/discord4j/rest/util/RouteUtils.java
@@ -34,6 +34,9 @@ public class RouteUtils {
     }
 
     public static String expand(String template, Object... variables) {
+        if (variables.length == 0) {
+            return template;
+        }
         StringBuffer buf = new StringBuffer();
         Matcher matcher = PARAMETER_PATTERN.matcher(template);
         int index = 0;

--- a/rest/src/main/java/discord4j/rest/util/RouteUtils.java
+++ b/rest/src/main/java/discord4j/rest/util/RouteUtils.java
@@ -16,10 +16,12 @@
  */
 package discord4j.rest.util;
 
+import discord4j.common.annotations.Experimental;
 import reactor.util.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,6 +47,20 @@ public class RouteUtils {
         }
         matcher.appendTail(buf);
         return buf.toString();
+    }
+
+    @Experimental
+    public static Map<String, String> createVariableMap(String template, Object... variables) {
+        Map<String, String> variableMap = new LinkedHashMap<>();
+        if (variables.length == 0) {
+            return variableMap;
+        }
+        Matcher matcher = PARAMETER_PATTERN.matcher(template);
+        int index = 0;
+        while (matcher.find()) {
+            variableMap.put(matcher.group().replaceAll("[{}]", ""), variables[index++].toString());
+        }
+        return variableMap;
     }
 
     public static String expandQuery(String uri, @Nullable Map<String, ?> values) {

--- a/rest/src/test/java/discord4j/rest/RestTests.java
+++ b/rest/src/test/java/discord4j/rest/RestTests.java
@@ -28,7 +28,6 @@ import discord4j.rest.http.client.DiscordWebClient;
 import discord4j.rest.request.DefaultRouter;
 import discord4j.rest.request.Router;
 import discord4j.rest.service.ChannelService;
-import reactor.core.scheduler.Schedulers;
 import reactor.netty.http.client.HttpClient;
 
 public abstract class RestTests {
@@ -36,7 +35,7 @@ public abstract class RestTests {
     public static Router getRouter(String token, ObjectMapper mapper) {
         DiscordWebClient webClient = new DiscordWebClient(HttpClient.create().compress(true),
                 ExchangeStrategies.jackson(mapper), token);
-        return new DefaultRouter(webClient, Schedulers.elastic(), Schedulers.elastic());
+        return new DefaultRouter(webClient);
     }
 
     public static ObjectMapper getMapper(boolean ignoreUnknown) {


### PR DESCRIPTION
**Description:** Enable special handling of each HTTP request according to their response code.
**Justification:** Feature request. Opens up use cases to suppress expected errors for an easier to handle response.

Example usage:
```java
DiscordClient client = new DiscordClientBuilder(token)
		.setRouterOptions(RouterOptions.builder()
				// globally suppress any not found (404) error
				.onClientResponse(ResponseFunction.emptyIfNotFound())
				// wait 1 second and retry any server error (500)
				.onClientResponse(ResponseFunction.retryOnceOnErrorStatus(500))
				// bad requests (400) while adding reactions will be suppressed
				.onClientResponse(ResponseFunction.emptyOnErrorStatus(RouteMatcher.route(Routes.REACTION_CREATE), 400))
				// server error (500) while creating a message will be retried, with backoff, until it succeeds
				.onClientResponse(ResponseFunction.retryWhen(RouteMatcher.route(Routes.MESSAGE_CREATE),
						Retry.onlyIf(ClientException.isRetryContextStatusCode(500))
								.exponentialBackoffWithJitter(Duration.ofSeconds(2), Duration.ofSeconds(10))))
				.build())
		.build();
```