### PR TITLE
Add convenience methods for spoiler attachments

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Attachment.java
+++ b/core/src/main/java/discord4j/core/object/entity/Attachment.java
@@ -33,6 +33,7 @@ import java.util.OptionalInt;
  */
 public final class Attachment implements Entity {
 
+    /** The prefix of the name of files which are displayed as spoilers. **/
     public static final String SPOILER_PREFIX = "SPOILER_";
 
     /** The ServiceMediator associated to this object. */
@@ -116,6 +117,11 @@ public final class Attachment implements Entity {
         return (data.getWidth() == null) ? OptionalInt.empty() : OptionalInt.of(data.getWidth());
     }
 
+    /**
+     * Gets whether the attachment is a spoiler.
+     *
+     * @return {@code true} if the attachment is a spoiler, {@code false} otherwise.
+     */
     public boolean isSpoiler() {
         return getFilename().startsWith(SPOILER_PREFIX);
     }

--- a/core/src/main/java/discord4j/core/object/entity/Attachment.java
+++ b/core/src/main/java/discord4j/core/object/entity/Attachment.java
@@ -33,6 +33,8 @@ import java.util.OptionalInt;
  */
 public final class Attachment implements Entity {
 
+    public static final String SPOILER_PREFIX = "SPOILER_";
+
     /** The ServiceMediator associated to this object. */
     private final ServiceMediator serviceMediator;
 
@@ -112,6 +114,10 @@ public final class Attachment implements Entity {
      */
     public OptionalInt getWidth() {
         return (data.getWidth() == null) ? OptionalInt.empty() : OptionalInt.of(data.getWidth());
+    }
+
+    public boolean isSpoiler() {
+        return getFilename().startsWith(SPOILER_PREFIX);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.spec;
 
+import discord4j.core.object.entity.Attachment;
 import discord4j.core.object.util.Snowflake;
 import discord4j.rest.json.request.EmbedRequest;
 import discord4j.rest.json.request.MessageCreateRequest;
@@ -63,9 +64,13 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
     }
 
     public MessageCreateSpec addFile(String fileName, InputStream file) {
-        if (files == null) files = new ArrayList<>(1);
+        if (files == null) files = new ArrayList<>(1); // most common case is only 1 attachment per message
         files.add(Tuples.of(fileName, file));
         return this;
+    }
+
+    public MessageCreateSpec addFileSpoiler(String fileName, InputStream file) {
+        return addFile(Attachment.SPOILER_PREFIX + fileName, file);
     }
 
     @Override


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Add `MessageCreateSpec#addFileSpoiler()` and `Attachment#isSpoiler()` to deal with the `"SPOILER_"` file name prefix used for spoiler attachments.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
These are simply for convenience. You can see the implementations are incredibly simple and could be done by a user, but they're nice to have. 

#481 