### PR TITLE
Change ChannelCreate, MessageDelete and TypingStart to use Nullable Long

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
@@ -59,7 +59,7 @@ class ChannelDispatchHandlers {
         ServiceMediator serviceMediator = context.getServiceMediator();
         DiscordClient client = serviceMediator.getClient();
         GatewayChannelResponse channel = context.getDispatch().getChannel();
-        long guildId = context.getDispatch().getGuildId();
+        Long guildId = context.getDispatch().getGuildId();
         TextChannelBean bean = new TextChannelBean(channel, guildId);
 
         Mono<TextChannelCreateEvent> saveChannel = serviceMediator.getStateHolder().getTextChannelStore()
@@ -82,7 +82,7 @@ class ChannelDispatchHandlers {
         ServiceMediator serviceMediator = context.getServiceMediator();
         DiscordClient client = serviceMediator.getClient();
         GatewayChannelResponse channel = context.getDispatch().getChannel();
-        long guildId = context.getDispatch().getGuildId();
+        Long guildId = context.getDispatch().getGuildId();
         VoiceChannelBean bean = new VoiceChannelBean(channel, guildId);
 
         Mono<VoiceChannelCreateEvent> saveChannel = serviceMediator.getStateHolder().getVoiceChannelStore()
@@ -97,7 +97,7 @@ class ChannelDispatchHandlers {
         ServiceMediator serviceMediator = context.getServiceMediator();
         DiscordClient client = serviceMediator.getClient();
         GatewayChannelResponse channel = context.getDispatch().getChannel();
-        long guildId = context.getDispatch().getGuildId();
+        Long guildId = context.getDispatch().getGuildId();
         CategoryBean bean = new CategoryBean(channel, guildId);
 
         Mono<CategoryCreateEvent> saveChannel = serviceMediator.getStateHolder().getCategoryStore()

--- a/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
@@ -59,7 +59,7 @@ class ChannelDispatchHandlers {
         ServiceMediator serviceMediator = context.getServiceMediator();
         DiscordClient client = serviceMediator.getClient();
         GatewayChannelResponse channel = context.getDispatch().getChannel();
-        Long guildId = context.getDispatch().getGuildId();
+        long guildId = context.getDispatch().getGuildId();
         TextChannelBean bean = new TextChannelBean(channel, guildId);
 
         Mono<TextChannelCreateEvent> saveChannel = serviceMediator.getStateHolder().getTextChannelStore()
@@ -82,7 +82,7 @@ class ChannelDispatchHandlers {
         ServiceMediator serviceMediator = context.getServiceMediator();
         DiscordClient client = serviceMediator.getClient();
         GatewayChannelResponse channel = context.getDispatch().getChannel();
-        Long guildId = context.getDispatch().getGuildId();
+        long guildId = context.getDispatch().getGuildId();
         VoiceChannelBean bean = new VoiceChannelBean(channel, guildId);
 
         Mono<VoiceChannelCreateEvent> saveChannel = serviceMediator.getStateHolder().getVoiceChannelStore()
@@ -97,7 +97,7 @@ class ChannelDispatchHandlers {
         ServiceMediator serviceMediator = context.getServiceMediator();
         DiscordClient client = serviceMediator.getClient();
         GatewayChannelResponse channel = context.getDispatch().getChannel();
-        Long guildId = context.getDispatch().getGuildId();
+        long guildId = context.getDispatch().getGuildId();
         CategoryBean bean = new CategoryBean(channel, guildId);
 
         Mono<CategoryCreateEvent> saveChannel = serviceMediator.getStateHolder().getCategoryStore()

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/ChannelCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/ChannelCreate.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import discord4j.common.jackson.UnsignedJson;
 import discord4j.gateway.json.response.GatewayChannelResponse;
+import reactor.util.annotation.Nullable;
 
 public class ChannelCreate implements Dispatch {
 
@@ -27,13 +28,14 @@ public class ChannelCreate implements Dispatch {
     private GatewayChannelResponse channel;
     @JsonProperty("guild_id")
     @UnsignedJson
-    private long guildId;
+    @Nullable
+    private Long guildId;
 
     public GatewayChannelResponse getChannel() {
         return channel;
     }
 
-    public long getGuildId() {
+    public Long getGuildId() {
         return guildId;
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/ChannelCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/ChannelCreate.java
@@ -35,6 +35,7 @@ public class ChannelCreate implements Dispatch {
         return channel;
     }
 
+    @Nullable
     public Long getGuildId() {
         return guildId;
     }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/MessageDelete.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/MessageDelete.java
@@ -40,6 +40,7 @@ public class MessageDelete implements Dispatch {
         return channelId;
     }
 
+    @Nullable
     public Long getGuildId() {
         return guildId;
     }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/MessageDelete.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/MessageDelete.java
@@ -18,6 +18,7 @@ package discord4j.gateway.json.dispatch;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
+import reactor.util.annotation.Nullable;
 
 public class MessageDelete implements Dispatch {
 
@@ -28,7 +29,8 @@ public class MessageDelete implements Dispatch {
     private long channelId;
     @JsonProperty("guild_id")
     @UnsignedJson
-    private long guildId;
+    @Nullable
+    private Long guildId;
 
     public long getId() {
         return id;
@@ -38,7 +40,7 @@ public class MessageDelete implements Dispatch {
         return channelId;
     }
 
-    public long getGuildId() {
+    public Long getGuildId() {
         return guildId;
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/TypingStart.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/TypingStart.java
@@ -38,6 +38,7 @@ public class TypingStart implements Dispatch {
         return channelId;
     }
 
+    @Nullable
     public Long getGuildId() {
         return guildId;
     }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/TypingStart.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/TypingStart.java
@@ -18,6 +18,7 @@ package discord4j.gateway.json.dispatch;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
+import reactor.util.annotation.Nullable;
 
 public class TypingStart implements Dispatch {
 
@@ -26,7 +27,8 @@ public class TypingStart implements Dispatch {
     private long channelId;
     @JsonProperty("guild_id")
     @UnsignedJson
-    private long guildId;
+    @Nullable
+    private Long guildId;
     @JsonProperty("user_id")
     @UnsignedJson
     private long userId;
@@ -36,7 +38,7 @@ public class TypingStart implements Dispatch {
         return channelId;
     }
 
-    public long getGuildId() {
+    public Long getGuildId() {
         return guildId;
     }
 


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Expands on 522bb7755f53d97b078bbc89d38ef9aac98c3b6a to replace all possible problems with a primitive long representing an optional property.
**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
Fixes potential issues with `guildId` being set to `0` in a DM channel, as non null is assumed to mean guild exists in other places.