### PR TITLE
Fix/immutable beans

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
@@ -112,6 +112,7 @@ class ChannelDispatchHandlers {
                                                 long guildId) {
         return guildStore
                 .find(guildId)
+                .map(GuildBean::new)
                 .doOnNext(guild -> guild.setChannels(ArrayUtil.add(guild.getChannels(), channel.getId())))
                 .flatMap(guild -> guildStore.save(guild.getId(), guild));
     }
@@ -188,6 +189,7 @@ class ChannelDispatchHandlers {
                                                      long guildId) {
         return guildStore
                 .find(guildId)
+                .map(GuildBean::new)
                 .doOnNext(guild -> guild.setChannels(ArrayUtil.remove(guild.getChannels(), channel.getId())))
                 .flatMap(guild -> guildStore.save(guild.getId(), guild));
     }

--- a/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
@@ -147,7 +147,7 @@ class MessageDispatchHandlers {
                             ReactionBean newExisting = new ReactionBean(oldExisting);
                             newExisting.setMe(me);
                             newExisting.setCount(oldExisting.getCount() + 1);
-                            ArrayUtil.replace(newBean.getReactions(), oldExisting, newExisting);
+                            newBean.setReactions(ArrayUtil.replace(oldBean.getReactions(), oldExisting, newExisting));
                         } else {
                             ReactionBean r = new ReactionBean(1, me, emojiId, emojiName, emojiAnimated);
                             newBean.setReactions(ArrayUtil.add(oldBean.getReactions(), r));
@@ -201,7 +201,7 @@ class MessageDispatchHandlers {
                             newExisting.setMe(false);
                         }
 
-                        ArrayUtil.replace(newBean.getReactions(), existing, newExisting);
+                        newBean.setReactions(ArrayUtil.replace(oldBean.getReactions(), existing, newExisting));
                     }
                     return newBean;
                 })

--- a/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
@@ -126,30 +126,35 @@ class MessageDispatchHandlers {
 
         Mono<Void> addToMessage = context.getServiceMediator().getStateHolder().getMessageStore()
                 .find(messageId)
-                .doOnNext(bean -> {
+                .map(oldBean -> {
                     boolean me = context.getServiceMediator().getStateHolder().getSelfId().get() == userId;
+                    MessageBean newBean = new MessageBean(oldBean);
 
-                    if (bean.getReactions() == null) {
+                    if (oldBean.getReactions() == null) {
                         ReactionBean r = new ReactionBean(1, me, emojiId, emojiName, emojiAnimated);
-                        bean.setReactions(new ReactionBean[] { r });
+                        newBean.setReactions(new ReactionBean[] { r });
                     } else {
                         int i;
-                        for (i = 0; i < bean.getReactions().length; i++) {
-                            ReactionBean r = bean.getReactions()[i];
+                        for (i = 0; i < oldBean.getReactions().length; i++) {
+                            ReactionBean r = oldBean.getReactions()[i];
                             if (Objects.equals(r.getEmojiId(), emojiId) && r.getEmojiName().equals(emojiName)) {
                                 break;
                             }
                         }
 
-                        if (i < bean.getReactions().length) {
-                            ReactionBean existing = bean.getReactions()[i];
-                            existing.setMe(me);
-                            existing.setCount(existing.getCount() + 1);
+                        if (i < oldBean.getReactions().length) {
+                            ReactionBean oldExisting = oldBean.getReactions()[i];
+                            ReactionBean newExisting = new ReactionBean(oldExisting);
+                            newExisting.setMe(me);
+                            newExisting.setCount(oldExisting.getCount() + 1);
+                            ArrayUtil.replace(newBean.getReactions(), oldExisting, newExisting);
                         } else {
                             ReactionBean r = new ReactionBean(1, me, emojiId, emojiName, emojiAnimated);
-                            bean.setReactions(ArrayUtil.add(bean.getReactions(), r));
+                            newBean.setReactions(ArrayUtil.add(oldBean.getReactions(), r));
                         }
                     }
+
+                    return newBean;
                 })
                 .flatMap(bean ->
                         context.getServiceMediator().getStateHolder().getMessageStore().save(bean.getId(), bean));
@@ -174,26 +179,31 @@ class MessageDispatchHandlers {
 
         Mono<Void> removeFromMessage = context.getServiceMediator().getStateHolder().getMessageStore()
                 .find(messageId)
-                .doOnNext(bean -> {
+                .map(oldBean -> {
                     int i;
                     // noinspection ConstantConditions reactions must be present if one is being removed
-                    for (i = 0; i < bean.getReactions().length; i++) {
-                        ReactionBean r = bean.getReactions()[i];
+                    for (i = 0; i < oldBean.getReactions().length; i++) {
+                        ReactionBean r = oldBean.getReactions()[i];
                         if (Objects.equals(r.getEmojiId(), emojiId) && r.getEmojiName().equals(emojiName)) {
                             break;
                         }
                     }
 
-                    ReactionBean existing = bean.getReactions()[i];
+                    MessageBean newBean = new MessageBean(oldBean);
+                    ReactionBean existing = oldBean.getReactions()[i];
                     if (existing.getCount() - 1 == 0) {
-                        bean.setReactions(ArrayUtil.remove(bean.getReactions(), existing));
+                        newBean.setReactions(ArrayUtil.remove(oldBean.getReactions(), existing));
                     } else {
-                        existing.setCount(existing.getCount() - 1);
+                        ReactionBean newExisting = new ReactionBean(existing);
+                        newExisting.setCount(existing.getCount() - 1);
 
                         if (context.getServiceMediator().getStateHolder().getSelfId().get() == userId) {
-                            existing.setMe(false);
+                            newExisting.setMe(false);
                         }
+
+                        ArrayUtil.replace(newBean.getReactions(), existing, newExisting);
                     }
+                    return newBean;
                 })
                 .flatMap(bean ->
                         context.getServiceMediator().getStateHolder().getMessageStore().save(bean.getId(), bean));
@@ -211,6 +221,7 @@ class MessageDispatchHandlers {
 
         Mono<Void> removeAllFromMessage = context.getServiceMediator().getStateHolder().getMessageStore()
                 .find(messageId)
+                .map(MessageBean::new)
                 .doOnNext(bean -> bean.setReactions(null))
                 .flatMap(bean ->
                         context.getServiceMediator().getStateHolder().getMessageStore().save(bean.getId(), bean));

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -144,6 +144,30 @@ public class BaseGuildBean implements Serializable {
         systemChannelId = response.getSystemChannelId();
     }
 
+    public BaseGuildBean(final BaseGuildBean toCopy) {
+        id = toCopy.getId();
+        name = toCopy.getName();
+        icon = toCopy.getIcon();
+        splash = toCopy.getSplash();
+        ownerId = toCopy.getOwnerId();
+        region = toCopy.getRegion();
+        afkChannelId = toCopy.getAfkChannelId();
+        afkTimeout = toCopy.getAfkTimeout();
+        embedChannelId = toCopy.getEmbedChannelId();
+        verificationLevel = toCopy.getVerificationLevel();
+        defaultMessageNotifications = toCopy.getDefaultMessageNotifications();
+        explicitContentFilter = toCopy.getExplicitContentFilter();
+
+        roles = Arrays.copyOf(toCopy.getRoles(), toCopy.getRoles().length);
+        emojis = Arrays.copyOf(toCopy.getEmojis(), toCopy.getEmojis().length);
+
+        features = toCopy.getFeatures();
+        mfaLevel = toCopy.getMfaLevel();
+        applicationId = toCopy.getApplicationId();
+        widgetChannelId = toCopy.getWidgetChannelId();
+        systemChannelId = toCopy.getSystemChannelId();
+    }
+
     public BaseGuildBean() {}
 
     public long getId() {

--- a/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
@@ -58,7 +58,7 @@ public final class GuildBean extends BaseGuildBean {
         this.large = toCopy.large;
         this.memberCount = toCopy.memberCount;
         this.members = Arrays.copyOf(toCopy.members, toCopy.members.length);
-        this.channels = Arrays.copyOf(toCopy.members, toCopy.members.length);
+        this.channels = Arrays.copyOf(toCopy.channels, toCopy.channels.length);
     }
 
     public GuildBean(final GuildBean toCopy) {
@@ -68,7 +68,7 @@ public final class GuildBean extends BaseGuildBean {
         this.large = toCopy.getLarge();
         this.memberCount = toCopy.getMemberCount();
         this.members = Arrays.copyOf(toCopy.members, toCopy.members.length);
-        this.channels = Arrays.copyOf(toCopy.members, toCopy.members.length);
+        this.channels = Arrays.copyOf(toCopy.channels, toCopy.channels.length);
     }
 
     public GuildBean() {}

--- a/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
@@ -57,8 +57,18 @@ public final class GuildBean extends BaseGuildBean {
         this.joinedAt = toCopy.joinedAt;
         this.large = toCopy.large;
         this.memberCount = toCopy.memberCount;
-        this.members = toCopy.members;
-        this.channels = toCopy.channels;
+        this.members = Arrays.copyOf(toCopy.members, toCopy.members.length);
+        this.channels = Arrays.copyOf(toCopy.members, toCopy.members.length);
+    }
+
+    public GuildBean(final GuildBean toCopy) {
+        super(toCopy);
+
+        this.joinedAt = toCopy.getJoinedAt();
+        this.large = toCopy.getLarge();
+        this.memberCount = toCopy.getMemberCount();
+        this.members = Arrays.copyOf(toCopy.members, toCopy.members.length);
+        this.channels = Arrays.copyOf(toCopy.members, toCopy.members.length);
     }
 
     public GuildBean() {}

--- a/core/src/main/java/discord4j/core/object/data/stored/MemberBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/MemberBean.java
@@ -51,6 +51,12 @@ public final class MemberBean implements Serializable {
         joinedAt = toCopy.getJoinedAt();
     }
 
+    public MemberBean(final MemberBean toCopy) {
+        nick = toCopy.getNick();
+        roles = Arrays.copyOf(toCopy.getRoles(), toCopy.getRoles().length);
+        joinedAt = toCopy.getJoinedAt();
+    }
+
     public MemberBean() {}
 
     @Nullable

--- a/core/src/main/java/discord4j/core/object/data/stored/MessageBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/MessageBean.java
@@ -124,11 +124,11 @@ public final class MessageBean implements Serializable {
         editedTimestamp = toCopy.editedTimestamp;
         tts = toCopy.tts;
         mentionEveryone = toCopy.mentionEveryone;
-        mentions = toCopy.mentions;
-        mentionRoles = toCopy.mentionRoles;
-        attachments = toCopy.attachments;
-        embeds = toCopy.embeds;
-        reactions = toCopy.reactions;
+        mentions = Arrays.copyOf(toCopy.mentions, toCopy.mentions.length);
+        mentionRoles = Arrays.copyOf(toCopy.mentionRoles, toCopy.mentionRoles.length);
+        attachments = Arrays.copyOf(toCopy.attachments, toCopy.attachments.length);
+        embeds = Arrays.copyOf(toCopy.embeds, toCopy.embeds.length);
+        reactions = Arrays.copyOf(toCopy.reactions, toCopy.reactions.length);
         pinned = toCopy.pinned;
         webhookId = toCopy.webhookId;
         type = toCopy.type;

--- a/core/src/main/java/discord4j/core/object/data/stored/ReactionBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/ReactionBean.java
@@ -48,6 +48,14 @@ public final class ReactionBean implements Serializable {
         this.emojiAnimated = emojiAnimated;
     }
 
+    public ReactionBean(final ReactionBean toCopy) {
+        this.count = toCopy.count;
+        this.me = toCopy.me;
+        this.emojiId = toCopy.emojiId;
+        this.emojiName = toCopy.emojiName;
+        this.emojiAnimated = toCopy.emojiAnimated;
+    }
+
     public ReactionBean() {}
 
     public int getCount() {

--- a/core/src/main/java/discord4j/core/util/ArrayUtil.java
+++ b/core/src/main/java/discord4j/core/util/ArrayUtil.java
@@ -17,6 +17,7 @@
 package discord4j.core.util;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Objects;
 
 public class ArrayUtil {
@@ -80,12 +81,14 @@ public class ArrayUtil {
         return ret;
     }
 
-    public static <T> void replace(T[] array, T old, T replacement) {
+    public static <T> T[] replace(T[] array, T old, T replacement) {
+        T[] copy = Arrays.copyOf(array, array.length);
         for (int i = 0; i < array.length; i++) {
             if (Objects.equals(array[i], old)) {
-                array[i] = replacement;
+                copy[i] = replacement;
             }
         }
+        return copy;
     }
 
     public static boolean contains(long[] array, long l) {

--- a/core/src/main/java/discord4j/core/util/ArrayUtil.java
+++ b/core/src/main/java/discord4j/core/util/ArrayUtil.java
@@ -17,6 +17,7 @@
 package discord4j.core.util;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 
 public class ArrayUtil {
 
@@ -77,6 +78,14 @@ public class ArrayUtil {
             ret[i] = array[i];
         }
         return ret;
+    }
+
+    public static <T> void replace(T[] array, T old, T replacement) {
+        for (int i = 0; i < array.length; i++) {
+            if (Objects.equals(array[i], old)) {
+                array[i] = replacement;
+            }
+        }
     }
 
     public static boolean contains(long[] array, long l) {


### PR DESCRIPTION
**Description:** Makes beans *effectively* immutable i.e., they only mutate when initially created in the dispatchers. After a bean is saved to the store and/or passed to the user in the form of an event, it should no longer be mutated at any point of its lifetime. Most beans and entities followed this well, but this PR fixes every instance of it.

**Justification:** Because immutable entities should be universal and it may also solve some race conditions or visibility bugs like #444