### PR TITLE
Add Member#isHigher(Member) and Member#isHigher(Snowflake)

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -327,7 +327,17 @@ public final class Member extends User {
     public Mono<Boolean> isHigher(Member member) {
     	Mono<Integer> getHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
     	Mono<Integer> getMemberHighestPosition = member.getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
-		return Mono.zip(getHighestPosition, getMemberHighestPosition, (p1, p2) -> p1 > p2);
+    	
+    	return getGuild().map(Guild::getOwnerId)
+    			.flatMap(ownerId -> {
+    				if(ownerId.equals(getId())) {
+    					return Mono.just(true);
+    				}
+    				if(ownerId.equals(member.getId())) {
+    					return Mono.just(false);
+    				}
+		    		return Mono.zip(getHighestPosition, getMemberHighestPosition, (p1, p2) -> p1 > p2);
+		    	});    	
 	}
     
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -314,50 +314,51 @@ public final class Member extends User {
                 .flatMap(ignored -> Mono.just(PermissionSet.all()))
                 .switchIfEmpty(Mono.zip(getEveryonePerms, getRolePerms, PermissionUtil::computeBasePermissions));
     }
-    
+
     /**
-	 * Requests to determine if this member is higher in the role hierarchy than the provided member.
-	 * This is determined by the positions of each of the members' highest roles.
-	 *
-	 * @param otherMember The member to compare in the role hierarchy with this member.
-	 * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the 
-	 * role hierarchy than the provided member, {@code false} otherwise. If an error is received, it is emitted 
-	 * through the {@code Mono}.
-	 */
+     * Requests to determine if this member is higher in the role hierarchy than the provided member.
+     * This is determined by the positions of each of the members' highest roles.
+     *
+     * @param otherMember The member to compare in the role hierarchy with this member.
+     * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the
+     * role hierarchy than the provided member, {@code false} otherwise. If an error is received, it is emitted
+     * through the {@code Mono}.
+     */
     public Mono<Boolean> isHigher(Member otherMember) {
-    	// A member cannot be higher in the role hierarchy than himself
-    	if(this.equals(otherMember)) {
-    		return Mono.just(false);
-    	}
-    	
-    	// getRoles() emits items in order based off their natural position, the "highest" role, if present, will be emitted last
-    	Mono<Integer> getThisHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
-    	Mono<Integer> getOtherHighestPosition = otherMember.getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
-    	
-    	return getGuild().map(Guild::getOwnerId)
-    			.flatMap(ownerId -> {
-    				if(ownerId.equals(getId())) {
-    					return Mono.just(true);
-    				}
-    				if(ownerId.equals(member.getId())) {
-    					return Mono.just(false);
-    				}
-		    		return Mono.zip(getThisHighestPosition, getOtherHighestPosition, (p1, p2) -> p1 > p2);
-		    	});    	
-	}
-    
+        // A member cannot be higher in the role hierarchy than himself
+        if (this.equals(otherMember)) {
+            return Mono.just(false);
+        }
+
+        // getRoles() emits items in order based off their natural position, the "highest" role, if present, will be
+        // emitted last
+        Mono<Integer> getThisHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
+        Mono<Integer> getOtherHighestPosition = otherMember.getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
+
+        return getGuild().map(Guild::getOwnerId)
+                .flatMap(ownerId -> {
+                    if (ownerId.equals(getId())) {
+                        return Mono.just(true);
+                    }
+                    if (ownerId.equals(otherMember.getId())) {
+                        return Mono.just(false);
+                    }
+                    return Mono.zip(getThisHighestPosition, getOtherHighestPosition, (p1, p2) -> p1 > p2);
+                });
+    }
+
     /**
-	 * Requests to determine if this member is higher in the role hierarchy than the member as represented 
-	 * by the supplied ID. This is determined by the positions of each of the members' highest roles.
-	 *
-	 * @param id The ID of the member to compare in the role hierarchy with this member.
-	 * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the role 
-	 * hierarchy than the member as represented by the supplied ID, {@code false} otherwise. If an error is received, 
-	 * it is emitted through the {@code Mono}.
-	 */
+     * Requests to determine if this member is higher in the role hierarchy than the member as represented
+     * by the supplied ID. This is determined by the positions of each of the members' highest roles.
+     *
+     * @param id The ID of the member to compare in the role hierarchy with this member.
+     * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the role
+     * hierarchy than the member as represented by the supplied ID, {@code false} otherwise. If an error is received,
+     * it is emitted through the {@code Mono}.
+     */
     public Mono<Boolean> isHigher(Snowflake id) {
-    	return getClient().getMemberById(getGuildId(), id).flatMap(this::isHigher);
-	}
+        return getClient().getMemberById(getGuildId(), id).flatMap(this::isHigher);
+    }
 
     /**
      * Requests to edit this member.

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -325,6 +325,10 @@ public final class Member extends User {
 	 * through the {@code Mono}.
 	 */
     public Mono<Boolean> isHigher(Member otherMember) {
+    	// A member cannot be higher in the role hierarchy than himself
+    	if(this.equals(otherMember)) {
+    		return Mono.just(false);
+    	}
     	
     	// getRoles() emits items in order based off their natural position, the "highest" role, if present, will be emitted last
     	Mono<Integer> getThisHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -316,12 +316,12 @@ public final class Member extends User {
     }
     
     /**
-	 * Requests to determine if this member is higher in the role hierarchy than member.
+	 * Requests to determine if this member is higher in the role hierarchy than the provided member.
 	 * This is determined by the positions of each of the members' highest roles.
 	 *
-	 * @param member The member who must be lower in the role hierarchy.
+	 * @param member The member to compare in the role hierarchy with this member.
 	 * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the 
-	 * role hierarchy than member, {@code false} otherwise. If an error is received, it is emitted 
+	 * role hierarchy than the provided member, {@code false} otherwise. If an error is received, it is emitted 
 	 * through the {@code Mono}.
 	 */
     public Mono<Boolean> isHigher(Member member) {
@@ -344,14 +344,13 @@ public final class Member extends User {
 	 * Requests to determine if this member is higher in the role hierarchy than the member as represented 
 	 * by the supplied ID. This is determined by the positions of each of the members' highest roles.
 	 *
-	 * @param id The ID of the member who must be lower in the role hierarchy.
+	 * @param id The ID of the member to compare in the role hierarchy with this member.
 	 * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the role 
 	 * hierarchy than the member as represented by the supplied ID, {@code false} otherwise. If an error is received, 
 	 * it is emitted through the {@code Mono}.
 	 */
     public Mono<Boolean> isHigher(Snowflake id) {
-    	return getGuild().flatMap(guild -> guild.getMemberById(id))
-    			.flatMap(this::isHigher);
+    	return getClient().getMemberById(getGuildId(), id).flatMap(this::isHigher);
 	}
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -319,14 +319,16 @@ public final class Member extends User {
 	 * Requests to determine if this member is higher in the role hierarchy than the provided member.
 	 * This is determined by the positions of each of the members' highest roles.
 	 *
-	 * @param member The member to compare in the role hierarchy with this member.
+	 * @param otherMember The member to compare in the role hierarchy with this member.
 	 * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the 
 	 * role hierarchy than the provided member, {@code false} otherwise. If an error is received, it is emitted 
 	 * through the {@code Mono}.
 	 */
-    public Mono<Boolean> isHigher(Member member) {
-    	Mono<Integer> getHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
-    	Mono<Integer> getMemberHighestPosition = member.getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
+    public Mono<Boolean> isHigher(Member otherMember) {
+    	
+    	// getRoles() emits items in order based off their natural position, the "highest" role, if present, will be emitted last
+    	Mono<Integer> getThisHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
+    	Mono<Integer> getOtherHighestPosition = otherMember.getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
     	
     	return getGuild().map(Guild::getOwnerId)
     			.flatMap(ownerId -> {
@@ -336,7 +338,7 @@ public final class Member extends User {
     				if(ownerId.equals(member.getId())) {
     					return Mono.just(false);
     				}
-		    		return Mono.zip(getHighestPosition, getMemberHighestPosition, (p1, p2) -> p1 > p2);
+		    		return Mono.zip(getThisHighestPosition, getOtherHighestPosition, (p1, p2) -> p1 > p2);
 		    	});    	
 	}
     

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -316,7 +316,8 @@ public final class Member extends User {
     }
 
     /**
-     * Requests to determine if this member is higher in the role hierarchy than the provided member.
+     * Requests to determine if this member is higher in the role hierarchy than the provided member or signal
+     * IllegalArgumentException if the provided member is in a different guild than this member.
      * This is determined by the positions of each of the members' highest roles.
      *
      * @param otherMember The member to compare in the role hierarchy with this member.
@@ -325,6 +326,10 @@ public final class Member extends User {
      * through the {@code Mono}.
      */
     public Mono<Boolean> isHigher(Member otherMember) {
+        if (!getGuildId().equals(otherMember.getGuildId())) {
+            return Mono.error(new IllegalArgumentException("The provided member is in a different guild."));
+        }
+
         // A member cannot be higher in the role hierarchy than himself
         if (this.equals(otherMember)) {
             return Mono.just(false);
@@ -349,7 +354,9 @@ public final class Member extends User {
 
     /**
      * Requests to determine if this member is higher in the role hierarchy than the member as represented
-     * by the supplied ID. This is determined by the positions of each of the members' highest roles.
+     * by the supplied ID or signal IllegalArgumentException if the member as represented by the supplied ID is in
+     * a different guild than this member.
+     * This is determined by the positions of each of the members' highest roles.
      *
      * @param id The ID of the member to compare in the role hierarchy with this member.
      * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the role


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** Add `Member#isHigher(Member)` and `Member#isHigher(Snowflake)`, two utility methods  to easily determine if a member is higher in the role hierarchy than another.
`Member#isHigher(Member)` has been tested with my bot in production and works as expected. The second one has not been tested but is largely based on the first one.

**Justification:** These are two very useful and non trivial methods to determine if a member can interact with another.