### PR TITLE
Add Member#hasHigherRoles

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -338,6 +338,9 @@ public final class Member extends User {
 
         return getGuild().map(Guild::getOwnerId)
                 .flatMap(ownerId -> {
+                    if (ownerId.equals(getId())) {
+                        return Mono.just(true);
+                    }
                     if (ownerId.equals(otherMember.getId())) {
                         return Mono.just(false);
                     }
@@ -371,8 +374,8 @@ public final class Member extends User {
      * If an error is received it is emitted through the {@code Mono}.
      */
     public Mono<Boolean> hasHigherRoles(List<Role> otherRoles) {
-        for(Role role : otherRoles) {
-            if(!role.getGuildId().equals(getGuildId())) {
+        for (Role role : otherRoles) {
+            if (!role.getGuildId().equals(getGuildId())) {
                 return Mono.error(new IllegalArgumentException("The provided roles are from a different guild."));
             }
         }
@@ -383,13 +386,7 @@ public final class Member extends User {
         Mono<Integer> getOtherHighestPosition = Flux.fromIterable(otherRoles).flatMap(Role::getPosition)
                 .defaultIfEmpty(0).last();
 
-        return getGuild().map(Guild::getOwnerId)
-                .flatMap(ownerId -> {
-                    if (ownerId.equals(getId())) {
-                        return Mono.just(true);
-                    }
-                    return Mono.zip(getThisHighestPosition, getOtherHighestPosition, (p1, p2) -> p1 > p2);
-                });
+        return Mono.zip(getThisHighestPosition, getOtherHighestPosition, (p1, p2) -> p1 > p2);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -31,6 +31,7 @@ import discord4j.core.util.PermissionUtil;
 import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.math.MathFlux;
 import reactor.util.annotation.Nullable;
 
 import java.awt.Color;
@@ -381,11 +382,10 @@ public final class Member extends User {
             }
         }
 
-        // getRoles() emits items in order based off their natural position, the "highest" role, if present, will be
-        // emitted last
-        Mono<Integer> getThisHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();
-        Mono<Integer> getOtherHighestPosition = Flux.fromIterable(otherRoles).flatMap(Role::getPosition)
-                .defaultIfEmpty(0).last();
+        Mono<Integer> getThisHighestPosition = MathFlux.max(getRoles().flatMap(Role::getPosition))
+                .defaultIfEmpty(0);
+        Mono<Integer> getOtherHighestPosition = MathFlux.max(Flux.fromIterable(otherRoles).flatMap(Role::getPosition))
+                .defaultIfEmpty(0);
 
         return Mono.zip(getThisHighestPosition, getOtherHighestPosition, (p1, p2) -> p1 > p2);
     }

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -376,7 +376,8 @@ public final class Member extends User {
     public Mono<Boolean> hasHigherRoles(List<Role> otherRoles) {
         for (Role role : otherRoles) {
             if (!role.getGuildId().equals(getGuildId())) {
-                return Mono.error(new IllegalArgumentException("The provided roles are from a different guild."));
+                return Mono.error(new IllegalArgumentException("The provided role with ID " + role.getId().asString()
+                        + " is from a different guild."));
             }
         }
 

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -373,7 +373,7 @@ public final class Member extends User {
      * highest role is greater than the highest position of the provided roles, {@code false} otherwise.
      * If an error is received it is emitted through the {@code Mono}.
      */
-    public Mono<Boolean> hasHigherRoles(List<Role> otherRoles) {
+    public Mono<Boolean> hasHigherRoles(Iterable<Role> otherRoles) {
         for (Role role : otherRoles) {
             if (!role.getGuildId().equals(getGuildId())) {
                 return Mono.error(new IllegalArgumentException("The provided role with ID " + role.getId().asString()

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -362,7 +362,8 @@ public final class Member extends User {
 
     /**
      * Requests to determine if the position of this member's highest role is greater than the highest position of the
-     * provided roles.
+     * provided roles or signal IllegalArgumentException if the provided roles are from a different guild than this
+     * member.
      *
      * @param otherRoles The list of roles to compare in the role hierarchy with this member's roles.
      * @return A {@link Mono} where, upon successful completion, emits {@code true} if the position of this member's
@@ -370,6 +371,12 @@ public final class Member extends User {
      * If an error is received it is emitted through the {@code Mono}.
      */
     public Mono<Boolean> hasHigherRoles(List<Role> otherRoles) {
+        for(Role role : otherRoles) {
+            if(!role.getGuildId().equals(getGuildId())) {
+                return Mono.error(new IllegalArgumentException("The provided roles are from a different guild."));
+            }
+        }
+
         // getRoles() emits items in order based off their natural position, the "highest" role, if present, will be
         // emitted last
         Mono<Integer> getThisHighestPosition = getRoles().flatMap(Role::getPosition).defaultIfEmpty(0).last();

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -382,8 +382,7 @@ public final class Member extends User {
             }
         }
 
-        Mono<Integer> getThisHighestPosition = MathFlux.max(getRoles().flatMap(Role::getPosition))
-                .defaultIfEmpty(0);
+        Mono<Integer> getThisHighestPosition = getHighestRole().flatMap(Role::getPosition).defaultIfEmpty(0);
         Mono<Integer> getOtherHighestPosition = MathFlux.max(Flux.fromIterable(otherRoles).flatMap(Role::getPosition))
                 .defaultIfEmpty(0);
 


### PR DESCRIPTION
**Description:** Add the method `Member#hasHigherRoles` to determine if the position of the member's highest role is greater than the highest position of the provided roles.

**Justification:** The permission `Manage Roles` from Discord allows to create new roles and to edit/delete roles lower than the member's highest role. This method allows to easily determine if the bot can actually add/remove a list of roles from another member.

**Concerns:**
- ~~This method cannot check if the provided roles come from the same guild as the member.~~
- ~~The guild is requested two times if the method `Member#isHigher(Member)` is used, I don't know if it can be optimized.~~
- ~~`Member#getRoles` emits items in order based off their natural position but is it conserved when using `Flux#collectList` and then `Flux#fromIterable` ?~~