### PR TITLE
Add Member#getHighestRole()

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -31,6 +31,7 @@ import discord4j.core.util.PermissionUtil;
 import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.math.MathFlux;
 import reactor.util.annotation.Nullable;
 
 import java.awt.Color;
@@ -97,6 +98,20 @@ public final class Member extends User {
     public Flux<Role> getRoles() {
         return Flux.fromIterable(getRoleIds()).flatMap(id -> getClient().getRoleById(getGuildId(), id))
                 .sort(Comparator.comparing(Role::getRawPosition).thenComparing(Role::getId));
+    }
+
+    /**
+     * Requests to retrieve the user's highest guild role.
+     * <p>
+     * The highest role is defined to be the role with the highest position, based on Discord's ordering. This is the
+     * role that appears at the <b>top</b> in Discord's UI.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the user's highest {@link Role role}. If an error
+     * is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Role> getHighestRole() {
+        return MathFlux.max(Flux.fromIterable(getRoleIds()).flatMap(id -> getClient().getRoleById(getGuildId(), id)),
+                            Comparator.comparing(Role::getRawPosition).thenComparing(Role::getId));
     }
 
     /**


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Add `Member#getHighestRole()`.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
This is a useful method (can be used in methods like `Member#getColor()` and `Member#hasHigherRoles()` in #504) which is more performant than the current technique of `getRoles().last()`. 

It makes sense why it should be more performant, but just for fun, I tried to do a little [benchmark](https://gist.github.com/GrandPanda/9ffef86df8a6a5eff91bc96b25ea669c). 
