### PR TITLE
Improve PermissionSet functionality, docs, and tests

### DIFF
--- a/core/src/main/java/discord4j/core/object/util/PermissionSet.java
+++ b/core/src/main/java/discord4j/core/object/util/PermissionSet.java
@@ -100,8 +100,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
     /**
      * Performs a logical <b>AND</b> of this permission set with the other permission set.
      * <p>
-     * The resultant set is the <b>intersection</b> of this set and the other set. A permission is contained iff it was
-     * contained in both this set and the other set.
+     * The resultant set is the <b>intersection</b> of this set and the other set. A permission is contained if and only if it was
+     * contained in both this set and the other set. This is analogous to {@link Set#retainAll(java.util.Collection)}.
      * <pre>
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS);
@@ -120,8 +120,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
     /**
      * Performs a logical <b>OR</b> of this permission set with the other permission set.
      * <p>
-     * The resultant set is the <b>union</b> of this set and the other set. A permission is contained iff it was
-     * contained in either this set or the other set.
+     * The resultant set is the <b>union</b> of this set and the other set. A permission is contained if and only if it
+     * was contained in either this set or the other set. This is analogous to {@link Set#addAll(java.util.Collection)}.
      * <pre>
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS);
@@ -140,13 +140,13 @@ public final class PermissionSet extends AbstractSet<Permission> {
     /**
      * Performs a logical <b>XOR</b> of this permission set with the other permission set.
      * <p>
-     * The resultant set is the <b>symmetric difference</b> of this set and the other set. A permission is contained iff
-     * it was contained in <b>only</b> this set or contained in <b>only</b> the other set.
+     * The resultant set is the <b>symmetric difference</b> of this set and the other set. A permission is contained if
+     * and only if it was contained in <b>only</b> this set or contained in <b>only</b> the other set.
      * <pre>
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
      * PermissionSet set1 = PermissionSet.of(ATTACH_FILES, CONNECT);
-     * set0.xor(set1) = PermissionSet.of(Permission.KICK_MEMBERS, Permission.BAN_MEMBERS, Permission.CONNECT)
+     * set0.xor(set1) = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, CONNECT)
      * }
      * </pre>
      *
@@ -160,8 +160,9 @@ public final class PermissionSet extends AbstractSet<Permission> {
     /**
      * Performs a logical <b>AND NOT</b> of this permission set with the other permission set.
      * <p>
-     * The resultant set is the <b>relative complement</b> of this set and the other set. A permission is contained iff
-     * it was contained in this set and <b>not</b> contained in the other set.
+     * The resultant set is the <b>relative complement</b> of this set and the other set. A permission is contained if
+     * and only if it was contained in this set and <b>not</b> contained in the other set. This is analogous to
+     * {@link Set#removeAll(java.util.Collection)}.
      * <pre>
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
@@ -180,8 +181,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
     /**
      * Performs a logical <b>AND NOT</b> of this permission set with the other permission set.
      * <p>
-     * The resultant set is the <b>relative complement</b> of this set and the other set. A permission is contained iff
-     * it was contained in this set and <b>not</b> contained in the other set.
+     * The resultant set is the <b>relative complement</b> of this set and the other set. A permission is contained if
+     * and only if it was contained in this set and <b>not</b> contained in the other set.
      * <pre>
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
@@ -203,8 +204,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
     /**
      * Performs a logical <b>NOT</b> of this permission set.
      * <p>
-     * The resultant set is the <b>complement</b> of this set. A permission is contained iff it was <b>not</b>
-     * contained in this set.
+     * The resultant set is the <b>complement</b> of this set. A permission is contained if and only if it was
+     * <b>not</b> contained in this set.
      * <pre>
      * {@code
      * PermissionSet set = PermissionSet.none();

--- a/core/src/main/java/discord4j/core/object/util/PermissionSet.java
+++ b/core/src/main/java/discord4j/core/object/util/PermissionSet.java
@@ -18,7 +18,18 @@ package discord4j.core.object.util;
 
 import java.util.*;
 
-/** An <i>immutable</i> specialized {@link Set} implementation for use with the {@link Permission} type. */
+/**
+ * An <b>immutable</b>, specialized {@code Set<Permission>}.
+ *
+ * <p>
+ * This is a <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/doc-files/ValueBased.html">value-based</a>
+ * class; use of identity-sensitive operations (including reference equality
+ * ({@code ==}), identity hash code, or synchronization) on instances of
+ * {@code PermissionSet} may have unpredictable results and should be avoided.
+ * The {@code equals} method should be used for comparisons.
+ *
+ * @see <a href="https://discordapp.com/developers/docs/topics/permissions">Discord Permissions</a>
+ */
 public final class PermissionSet extends AbstractSet<Permission> {
 
     private static final long ALL_RAW = Arrays.stream(Permission.values())
@@ -87,52 +98,124 @@ public final class PermissionSet extends AbstractSet<Permission> {
     }
 
     /**
-     * Performs a logical AND of of this permission set with the other permission set.
+     * Performs a logical <b>AND</b> of this permission set with the other permission set.
+     * <p>
+     * The resultant set is the <b>intersection</b> of this set and the other set. A permission is contained iff it was
+     * contained in both this set and the other set.
+     * <pre>
+     * {@code
+     * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS);
+     * PermissionSet set1 = PermissionSet.of(KICK_MEMBERS);
+     * set0.and(set1) = PermissionSet.of(KICK_MEMBERS);
+     * }
+     * </pre>
      *
      * @param other The other permission set.
-     * @return A new permission set of this set AND the other set.
+     * @return The intersection of this set with the other set.
      */
     public PermissionSet and(PermissionSet other) {
         return PermissionSet.of(this.rawValue & other.rawValue);
     }
 
     /**
-     * Performs a logical OR of this permission set with the other permission set.
+     * Performs a logical <b>OR</b> of this permission set with the other permission set.
+     * <p>
+     * The resultant set is the <b>union</b> of this set and the other set. A permission is contained iff it was
+     * contained in either this set or the other set.
+     * <pre>
+     * {@code
+     * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS);
+     * PermissionSet set1 = PermissionSet.of(BAN_MEMBERS);
+     * set0.and(set1) = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS);
+     * }
+     * </pre>
      *
      * @param other The other permission set.
-     * @return A new permission set of this set OR the other set.
+     * @return The union of this set with the other set.
      */
     public PermissionSet or(PermissionSet other) {
         return PermissionSet.of(this.rawValue | other.rawValue);
     }
 
     /**
-     * Performs a logical NOT of this permission set.
-     *
-     * @return A new permission set representing this set's complement.
-     */
-    public PermissionSet not() {
-        return PermissionSet.of(~this.rawValue);
-    }
-
-    /**
-     * Performs a logical XOR of this permission set with the other permission set.
+     * Performs a logical <b>XOR</b> of this permission set with the other permission set.
+     * <p>
+     * The resultant set is the <b>symmetric difference</b> of this set and the other set. A permission is contained iff
+     * it was contained in <b>only</b> this set or contained in <b>only</b> the other set.
+     * <pre>
+     * {@code
+     * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
+     * PermissionSet set1 = PermissionSet.of(ATTACH_FILES, CONNECT);
+     * set0.xor(set1) = PermissionSet.of(Permission.KICK_MEMBERS, Permission.BAN_MEMBERS, Permission.CONNECT)
+     * }
+     * </pre>
      *
      * @param other The other permission set.
-     * @return A new permission set of this set XOR the other set.
+     * @return The symmetric difference of this set with the other set.
      */
     public PermissionSet xor(PermissionSet other) {
         return PermissionSet.of(this.rawValue ^ other.rawValue);
     }
 
     /**
-     * Subtracts the contents of the given permission set from this permission set.
+     * Performs a logical <b>AND NOT</b> of this permission set with the other permission set.
+     * <p>
+     * The resultant set is the <b>relative complement</b> of this set and the other set. A permission is contained iff
+     * it was contained in this set and <b>not</b> contained in the other set.
+     * <pre>
+     * {@code
+     * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
+     * PermissionSet set1 = PermissionSet.of(BAN_MEMBERS, ATTACH_FILES, CONNECT);
+     * set0.andNot(set1) = PermissionSet.of(KICK_MEMBERS)
+     * }
+     * </pre>
      *
      * @param other The other permission set.
-     * @return A new permission set with the contents of the other set removed.
+     * @return The relative complement of this set with the other set.
      */
+    public PermissionSet andNot(PermissionSet other) {
+        return PermissionSet.of(this.rawValue & (~other.rawValue));
+    }
+
+    /**
+     * Performs a logical <b>AND NOT</b> of this permission set with the other permission set.
+     * <p>
+     * The resultant set is the <b>relative complement</b> of this set and the other set. A permission is contained iff
+     * it was contained in this set and <b>not</b> contained in the other set.
+     * <pre>
+     * {@code
+     * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
+     * PermissionSet set1 = PermissionSet.of(BAN_MEMBERS, ATTACH_FILES, CONNECT);
+     * set0.andNot(set1) = PermissionSet.of(KICK_MEMBERS)
+     * }
+     * </pre>
+     *
+     * @param other The other permission set.
+     * @return The relative complement of this set with the other set.
+     *
+     * @deprecated Use {@link PermissionSet#andNot(PermissionSet)} instead.
+     */
+    @Deprecated
     public PermissionSet subtract(PermissionSet other) {
         return PermissionSet.of(this.rawValue & (~other.rawValue));
+    }
+
+    /**
+     * Performs a logical <b>NOT</b> of this permission set.
+     * <p>
+     * The resultant set is the <b>complement</b> of this set. A permission is contained iff it was <b>not</b>
+     * contained in this set.
+     * <pre>
+     * {@code
+     * PermissionSet set = PermissionSet.none();
+     * set.not() = PermissionSet.all()
+     * }
+     * </pre>
+     *
+     * @return The complement of this set.
+     */
+    public PermissionSet not() {
+        return PermissionSet.of(~this.rawValue & ALL_RAW); // mask with ALL_RAW so undefined perms aren't flipped
     }
 
     /**
@@ -170,6 +253,24 @@ public final class PermissionSet extends AbstractSet<Permission> {
     @Override
     public int size() {
         return Long.bitCount(rawValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PermissionSet that = (PermissionSet) o;
+        return rawValue == that.rawValue;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(rawValue);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/util/PermissionSet.java
+++ b/core/src/main/java/discord4j/core/object/util/PermissionSet.java
@@ -106,7 +106,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS);
      * PermissionSet set1 = PermissionSet.of(KICK_MEMBERS);
-     * set0.and(set1) = PermissionSet.of(KICK_MEMBERS);
+     *
+     * set0.and(set1) = PermissionSet.of(KICK_MEMBERS)
      * }
      * </pre>
      *
@@ -126,7 +127,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS);
      * PermissionSet set1 = PermissionSet.of(BAN_MEMBERS);
-     * set0.and(set1) = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS);
+     *
+     * set0.or(set1) = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS)
      * }
      * </pre>
      *
@@ -146,6 +148,7 @@ public final class PermissionSet extends AbstractSet<Permission> {
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
      * PermissionSet set1 = PermissionSet.of(ATTACH_FILES, CONNECT);
+     *
      * set0.xor(set1) = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, CONNECT)
      * }
      * </pre>
@@ -167,6 +170,7 @@ public final class PermissionSet extends AbstractSet<Permission> {
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
      * PermissionSet set1 = PermissionSet.of(BAN_MEMBERS, ATTACH_FILES, CONNECT);
+     *
      * set0.andNot(set1) = PermissionSet.of(KICK_MEMBERS)
      * }
      * </pre>
@@ -187,7 +191,8 @@ public final class PermissionSet extends AbstractSet<Permission> {
      * {@code
      * PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
      * PermissionSet set1 = PermissionSet.of(BAN_MEMBERS, ATTACH_FILES, CONNECT);
-     * set0.andNot(set1) = PermissionSet.of(KICK_MEMBERS)
+     *
+     * set0.subtract(set1) = PermissionSet.of(KICK_MEMBERS)
      * }
      * </pre>
      *
@@ -209,6 +214,7 @@ public final class PermissionSet extends AbstractSet<Permission> {
      * <pre>
      * {@code
      * PermissionSet set = PermissionSet.none();
+     *
      * set.not() = PermissionSet.all()
      * }
      * </pre>

--- a/core/src/test/java/discord4j/core/object/util/PermissionSetTest.java
+++ b/core/src/test/java/discord4j/core/object/util/PermissionSetTest.java
@@ -18,8 +18,8 @@ package discord4j.core.object.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static discord4j.core.object.util.Permission.*;
+import static org.junit.Assert.*;
 
 public class PermissionSetTest {
 
@@ -37,29 +37,59 @@ public class PermissionSetTest {
 
     @Test
     public void testCustom() {
-        PermissionSet permSet = PermissionSet.of(Permission.ADD_REACTIONS, Permission.MANAGE_ROLES);
+        PermissionSet permSet = PermissionSet.of(ADD_REACTIONS, MANAGE_ROLES);
         assertEquals(2, permSet.size());
-        assertTrue(permSet.contains(Permission.ADD_REACTIONS));
-        assertTrue(permSet.contains(Permission.MANAGE_ROLES));
-    }
-
-    @Test
-    public void testOr() {
-        PermissionSet set0 = PermissionSet.of(Permission.KICK_MEMBERS);
-        PermissionSet set1 = PermissionSet.of(Permission.BAN_MEMBERS);
-        PermissionSet result = set0.or(set1);
-
-        assertEquals(2, result.size());
-        assertEquals(PermissionSet.of(Permission.KICK_MEMBERS, Permission.BAN_MEMBERS), result);
+        assertTrue(permSet.contains(ADD_REACTIONS));
+        assertTrue(permSet.contains(MANAGE_ROLES));
+        assertFalse(permSet.contains(BAN_MEMBERS));
     }
 
     @Test
     public void testAnd() {
-        PermissionSet set0 = PermissionSet.of(Permission.KICK_MEMBERS, Permission.BAN_MEMBERS);
-        PermissionSet set1 = PermissionSet.of(Permission.KICK_MEMBERS);
+        PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS);
+        PermissionSet set1 = PermissionSet.of(KICK_MEMBERS);
         PermissionSet result = set0.and(set1);
 
         assertEquals(1, result.size());
-        assertEquals(PermissionSet.of(Permission.KICK_MEMBERS), result);
+        assertEquals(PermissionSet.of(KICK_MEMBERS), result);
+    }
+
+    @Test
+    public void testOr() {
+        PermissionSet set0 = PermissionSet.of(KICK_MEMBERS);
+        PermissionSet set1 = PermissionSet.of(BAN_MEMBERS);
+        PermissionSet result = set0.or(set1);
+
+        assertEquals(2, result.size());
+        assertEquals(PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS), result);
+    }
+
+    @Test
+    public void testXor() {
+        PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
+        PermissionSet set1 = PermissionSet.of(ATTACH_FILES, CONNECT);
+        PermissionSet result = set0.xor(set1);
+
+        assertEquals(3, result.size());
+        assertEquals(PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, CONNECT), result);
+    }
+
+    @Test
+    public void testAndNot() {
+        PermissionSet set0 = PermissionSet.of(KICK_MEMBERS, BAN_MEMBERS, ATTACH_FILES);
+        PermissionSet set1 = PermissionSet.of(BAN_MEMBERS, ATTACH_FILES, CONNECT);
+        PermissionSet result = set0.andNot(set1);
+
+        assertEquals(1, result.size());
+        assertEquals(PermissionSet.of(KICK_MEMBERS), result);
+    }
+
+    @Test
+    public void testNot() {
+        PermissionSet set = PermissionSet.none();
+        PermissionSet result = set.not();
+
+        assertEquals(Permission.values().length, result.size());
+        assertEquals(PermissionSet.all(), result);
     }
 }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
* Add `PermissionSet#andNot(PermissionSet)`
* Deprecate `PermissionSet#subtract(PermissionSet)` (replaced by `andNot`)
* Improve docs and add examples (taken from tests)
* Add tests for all `PermissionSet` operations
* Fix behavior of `PermissionSet#not()`
* Improve `equals()` and `hashCode()` by providing our own implementation.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
Discussion in the guild led to the decision to replace `subtract` with `andNot` because it isn't clear why there is "subtract" but not "add." These names are consistent with the JDK's `BitSet` which is essentially what `PermissionSet` is.

Improved docs and tests are always nice.

`PermissionSet#not()` previously allowed the bits for undefined permissions to be flipped to true resulting in a set with size larger than max (e.g., `PermissionSet.none().not()` would have a size of `64` when it should be `29`).

`equals()` and `hashCode()` previously used the default implementation provided by `AbstractSet` which, while functioning, is not performant when we can simply check based on `rawValue`.