### PR TITLE
Remove Duplicate Disclaimer in `ReconnectStartEvent`

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectFailEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectFailEvent.java
@@ -8,23 +8,6 @@
  *
  * Discord4J is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/*
- * This file is part of Discord4J.
- *
- * Discord4J is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Discord4J is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License for more details.
  *


### PR DESCRIPTION
**Description:** Removes the duplicated D4J disclaimer at the top of the file.

**Justification:** It's there two times,

And I'll take my contributor role thank you very much :)
/s