### PR TITLE
Add missing documentation to events.

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
@@ -57,6 +57,7 @@ public class PresenceUpdateEvent extends Event {
 
     /**
      * Gets the Snowflake ID of the Guild containing the User whose presence has been updated.
+     *
      * @return The ID of the Guild involved.
      */
     public Snowflake getGuildId() {
@@ -65,39 +66,44 @@ public class PresenceUpdateEvent extends Event {
 
     /**
      * Gets the Guild containing the User whose presence has been updated.
-     * @return The Guild involved.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the old version of the User that was updated. This may not be available if Users are not stored.
-     * @return The old version of the user.
+     * Gets the old version of the User that was updated, if present. This may not be available if Users are not stored.
+     *
+     * @return The old version of the user, if present.
      */
     public Optional<User> getOldUser() {
         return Optional.ofNullable(oldUser);
     }
 
     /**
-     * Gets the User's new username. This may not exist if the user's username has not been changed.
-     * @return The user's new username.
+     * Gets the User's new username, if present. This may not exist if the user's username has not been changed.
+     *
+     * @return The user's new username, if present.
      */
     public Optional<String> getNewUsername() {
         return Optional.ofNullable(user.get("username")).map(JsonNode::asText);
     }
 
     /**
-     * Gets the User's new discriminator. This may not exist if the user's discriminator has not been changed.
-     * @return The user's new discriminator.
+     * Gets the User's new discriminator, if present. This may not exist if the user's discriminator has not been changed.
+     *
+     * @return The user's new discriminator, if present.
      */
     public Optional<String> getNewDiscriminator() {
         return Optional.ofNullable(user.get("discriminator")).map(JsonNode::asText);
     }
 
     /**
-     * Gets the User's new avatar. This may not exist if the user's discriminator has not been changed.
-     * @return The user's new avatar.
+     * Gets the User's new avatar, if present. This may not exist if the user's discriminator has not been changed.
+     *
+     * @return The user's new avatar, if present.
      */
     public Optional<String> getNewAvatar() {
         return Optional.ofNullable(user.get("avatar"))
@@ -107,6 +113,7 @@ public class PresenceUpdateEvent extends Event {
 
     /**
      * Gets the Snowflake ID of the user whose presence has been changed in this event.
+     *
      * @return The ID of the user involved.
      */
     public Snowflake getUserId() {
@@ -114,16 +121,18 @@ public class PresenceUpdateEvent extends Event {
     }
 
     /**
-     * Gets the User whose presence has been changed in this event.
-     * @return The user involved.
+     * Requests to retrieve the User whose presence has been changed in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in this event. If an error is received, it is emitted through the Mono.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
     /**
-     * Gets the Member object of the User involved in this event.
-     * @return The Member involved.
+     * Requests to retrieve the Member object of the User involved in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Member involved in this event. If an error is received, it is emitted through the Mono.
      */
     public Mono<Member> getMember() {
         return getClient().getMemberById(getGuildId(), getUserId());
@@ -131,6 +140,7 @@ public class PresenceUpdateEvent extends Event {
 
     /**
      * Gets the current, new version of the presence.
+     *
      * @return The current, new version of the presence.
      */
     public Presence getCurrent() {
@@ -138,8 +148,9 @@ public class PresenceUpdateEvent extends Event {
     }
 
     /**
-     * Gets the old version of the presence that was changed. This may not be available if presence are not stored.
-     * @return The old version of the presence.
+     * Gets the old version of the presence that was changed, if present. This may not be available if presence are not stored.
+     *
+     * @return The old version of the presence, if present.
      */
     public Optional<Presence> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
@@ -32,6 +32,8 @@ import java.util.Optional;
  * Dispatched when a user's presence changes.
  * <p>
  * The old presence may not be present if presences are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#presence-update">Presence Update</a>
  */
@@ -53,48 +55,92 @@ public class PresenceUpdateEvent extends Event {
         this.old = old;
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild containing the User whose presence has been updated.
+     * @return The ID of the Guild involved.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild containing the User whose presence has been updated.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the old version of the User that was updated. This may not be available if Users are not stored.
+     * @return The old version of the user.
+     */
     public Optional<User> getOldUser() {
         return Optional.ofNullable(oldUser);
     }
 
+    /**
+     * Gets the User's new username. This may not exist if the user's username has not been changed.
+     * @return The user's new username.
+     */
     public Optional<String> getNewUsername() {
         return Optional.ofNullable(user.get("username")).map(JsonNode::asText);
     }
 
+    /**
+     * Gets the User's new discriminator. This may not exist if the user's discriminator has not been changed.
+     * @return The user's new discriminator.
+     */
     public Optional<String> getNewDiscriminator() {
         return Optional.ofNullable(user.get("discriminator")).map(JsonNode::asText);
     }
 
+    /**
+     * Gets the User's new avatar. This may not exist if the user's discriminator has not been changed.
+     * @return The user's new avatar.
+     */
     public Optional<String> getNewAvatar() {
         return Optional.ofNullable(user.get("avatar"))
                 .filter(node -> !node.isNull())
                 .map(JsonNode::asText);
     }
 
+    /**
+     * Gets the Snowflake ID of the user whose presence has been changed in this event.
+     * @return The ID of the user involved.
+     */
     public Snowflake getUserId() {
         return Snowflake.of(user.get("id").asText());
     }
 
+    /**
+     * Gets the User whose presence has been changed in this event.
+     * @return The user involved.
+     */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
+    /**
+     * Gets the Member object of the User involved in this event.
+     * @return The Member involved.
+     */
     public Mono<Member> getMember() {
         return getClient().getMemberById(getGuildId(), getUserId());
     }
 
+    /**
+     * Gets the current, new version of the presence.
+     * @return The current, new version of the presence.
+     */
     public Presence getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the presence that was changed. This may not be available if presence are not stored.
+     * @return The old version of the presence.
+     */
     public Optional<Presence> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  * <p>
  * The old presence may not be present if presences are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#presence-update">Presence Update</a>
  */
@@ -56,52 +56,56 @@ public class PresenceUpdateEvent extends Event {
     }
 
     /**
-     * Gets the Snowflake ID of the Guild containing the User whose presence has been updated.
+     * Gets the {@link Snowflake} ID of the {@link Guild} containing the {@link User} whose presence has been updated.
      *
-     * @return The ID of the Guild involved.
+     * @return The ID of the {@link Guild} involved.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Gets the Guild containing the User whose presence has been updated.
+     * Gets the {@link Guild} containing the {@link User} whose presence has been updated.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved in the event.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the old version of the User that was updated, if present. This may not be available if Users are not stored.
+     * Gets the old version of the {@link User} that was updated, if present.
+     * This may not be available if {@code Users} are not stored.
      *
-     * @return The old version of the user, if present.
+     * @return The old version of the {@link User}, if present.
      */
     public Optional<User> getOldUser() {
         return Optional.ofNullable(oldUser);
     }
 
     /**
-     * Gets the User's new username, if present. This may not exist if the user's username has not been changed.
+     * Gets the {@link User}'s new username, if present. This may not exist if the {@code user}'s username has not
+     * been changed.
      *
-     * @return The user's new username, if present.
+     * @return The {@link User}'s new username, if present.
      */
     public Optional<String> getNewUsername() {
         return Optional.ofNullable(user.get("username")).map(JsonNode::asText);
     }
 
     /**
-     * Gets the User's new discriminator, if present. This may not exist if the user's discriminator has not been changed.
+     * Gets the {@link User}'s new discriminator, if present.
+     * This may not exist if the {@code User}'s discriminator has not been changed.
      *
-     * @return The user's new discriminator, if present.
+     * @return The {@link User}'s new discriminator, if present.
      */
     public Optional<String> getNewDiscriminator() {
         return Optional.ofNullable(user.get("discriminator")).map(JsonNode::asText);
     }
 
     /**
-     * Gets the User's new avatar, if present. This may not exist if the user's discriminator has not been changed.
+     * Gets the {@link User}'s new avatar, if present. This may not exist if the {@code User}'s discriminator has not
+     * been changed.
      *
      * @return The user's new avatar, if present.
      */
@@ -112,45 +116,48 @@ public class PresenceUpdateEvent extends Event {
     }
 
     /**
-     * Gets the Snowflake ID of the user whose presence has been changed in this event.
+     * Gets the {@link Snowflake} ID of the {@link User} whose presence has been updated in this event.
      *
-     * @return The ID of the user involved.
+     * @return The ID of the {@link User} whose presence has been updated.
      */
     public Snowflake getUserId() {
         return Snowflake.of(user.get("id").asText());
     }
 
     /**
-     * Requests to retrieve the User whose presence has been changed in this event.
+     * Requests to retrieve the {@link User} whose presence has been changed in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in this event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User} involved in this event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
     /**
-     * Requests to retrieve the Member object of the User involved in this event.
+     * Requests to retrieve the {@link Member} object of the {@link User} involved in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Member involved in this event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Member} involved in this event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Member> getMember() {
         return getClient().getMemberById(getGuildId(), getUserId());
     }
 
     /**
-     * Gets the current, new version of the presence.
+     * Gets the current, new version of the {@link Presence}.
      *
-     * @return The current, new version of the presence.
+     * @return The current, new version of the {@link Presence}.
      */
     public Presence getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the presence that was changed, if present. This may not be available if presence are not stored.
+     * Gets the old version of the {@link Presence} that was changed, if present.
+     * This may not be available if {@code Presence} are not stored.
      *
-     * @return The old version of the presence, if present.
+     * @return The old version of the {@link Presence}, if present.
      */
     public Optional<Presence> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 
 /**
  * Dispatched when a user is updated.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#user-update">User Update</a>
  */
@@ -38,10 +40,18 @@ public class UserUpdateEvent extends Event {
         this.old = old;
     }
 
+    /**
+     * Gets the current, new version of the User that has been updated in this event.
+     * @return The current version of the User involved.
+     */
     public User getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the User that has been updated in this event. This may not be available if Users are not stored.
+     * @return The old version of the User involved.
+     */
     public Optional<User> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
@@ -42,6 +42,7 @@ public class UserUpdateEvent extends Event {
 
     /**
      * Gets the current, new version of the User that has been updated in this event.
+     *
      * @return The current version of the User involved.
      */
     public User getCurrent() {
@@ -49,8 +50,9 @@ public class UserUpdateEvent extends Event {
     }
 
     /**
-     * Gets the old version of the User that has been updated in this event. This may not be available if Users are not stored.
-     * @return The old version of the User involved.
+     * Gets the old version of the User that has been updated in this event, if present. This may not be available if Users are not stored.
+     *
+     * @return The old version of the User involved, if present.
      */
     public Optional<User> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 /**
  * Dispatched when a user is updated.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#user-update">User Update</a>
  */
@@ -41,18 +41,19 @@ public class UserUpdateEvent extends Event {
     }
 
     /**
-     * Gets the current, new version of the User that has been updated in this event.
+     * Gets the current, new version of the {@link User} that has been updated in this event.
      *
-     * @return The current version of the User involved.
+     * @return The current version of the {@link User} updated in this event.
      */
     public User getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the User that has been updated in this event, if present. This may not be available if Users are not stored.
+     * Gets the old version of the {@link User} that has been updated in this event, if present.
+     * This may not be available if {@code Users} are not stored.
      *
-     * @return The old version of the User involved, if present.
+     * @return The old version of the {@link User} that has been updated in this event, if present.
      */
     public Optional<User> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/VoiceServerUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceServerUpdateEvent.java
@@ -45,6 +45,7 @@ public class VoiceServerUpdateEvent extends Event {
 
     /**
      * Gets the voice connection token for the guild.
+     *
      * @return The voice connection token.
      */
     public String getToken() {
@@ -53,6 +54,7 @@ public class VoiceServerUpdateEvent extends Event {
 
     /**
      * Gets the Snowflake ID of the guild whose voice server has been updated in this event.
+     *
      * @return The ID of the guild involved.
      */
     public Snowflake getGuildId() {
@@ -60,8 +62,9 @@ public class VoiceServerUpdateEvent extends Event {
     }
 
     /**
-     * Gets the Guild whose voice server has been updated in this event.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild whose voice server has been updated in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild whose voice server has been updated. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -69,6 +72,7 @@ public class VoiceServerUpdateEvent extends Event {
 
     /**
      * Gets the voice server host's endpoint URL.
+     *
      * @return The void server host's endpoint URL.
      */
     @Nullable

--- a/core/src/main/java/discord4j/core/event/domain/VoiceServerUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceServerUpdateEvent.java
@@ -24,6 +24,8 @@ import reactor.util.annotation.Nullable;
 
 /**
  * Dispatched when initially connecting to a voice channel.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#voice-server-update">Voice Server Update</a>
  */
@@ -41,18 +43,34 @@ public class VoiceServerUpdateEvent extends Event {
         this.endpoint = endpoint;
     }
 
+    /**
+     * Gets the voice connection token for the guild.
+     * @return The voice connection token.
+     */
     public String getToken() {
         return token;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild whose voice server has been updated in this event.
+     * @return The ID of the guild involved.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild whose voice server has been updated in this event.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the voice server host's endpoint URL.
+     * @return The void server host's endpoint URL.
+     */
     @Nullable
     public String getEndpoint() {
         return endpoint;

--- a/core/src/main/java/discord4j/core/event/domain/VoiceServerUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceServerUpdateEvent.java
@@ -53,7 +53,7 @@ public class VoiceServerUpdateEvent extends Event {
     }
 
     /**
-     * Gets the Snowflake ID of the guild whose voice server has been updated in this event.
+     * Gets the {@link Snowflake} ID of the guild whose voice server has been updated in this event.
      *
      * @return The ID of the guild involved.
      */
@@ -62,9 +62,11 @@ public class VoiceServerUpdateEvent extends Event {
     }
 
     /**
-     * Requests to retrieve the Guild whose voice server has been updated in this event.
+     * Requests to retrieve the {@link Guild} whose voice server has been updated in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild whose voice server has been updated. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} whose voice server has been
+     * updated.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
@@ -46,6 +46,7 @@ public class VoiceStateUpdateEvent extends Event {
 
     /**
      * Gets the current, new, VoiceState that has been updated in this event.
+     *
      * @return The current VoiceState.
      */
     public VoiceState getCurrent() {
@@ -53,8 +54,9 @@ public class VoiceStateUpdateEvent extends Event {
     }
 
     /**
-     * Gets the old VoiceState that has been updated in this event. This may not be available if VoiceStates are not stored.
-     * @return The old VoiceState.
+     * Gets the old VoiceState that has been updated in this event, if present. This may not be available if VoiceStates are not stored.
+     *
+     * @return The old VoiceState, if present.
      */
     public Optional<VoiceState> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  * <p>
  * The old voice state may not be present if voice states are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#voice-state-update">Voice State Update</a>
  */
@@ -45,18 +45,19 @@ public class VoiceStateUpdateEvent extends Event {
     }
 
     /**
-     * Gets the current, new, VoiceState that has been updated in this event.
+     * Gets the current, new, {@link VoiceState} that has been updated in this event.
      *
-     * @return The current VoiceState.
+     * @return The current {@link VoiceState}.
      */
     public VoiceState getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old VoiceState that has been updated in this event, if present. This may not be available if VoiceStates are not stored.
+     * Gets the old {@link VoiceState} that has been updated in this event, if present.
+     * This may not be available if {@code VoiceStates} are not stored.
      *
-     * @return The old VoiceState, if present.
+     * @return The old {@link VoiceState}, if present.
      */
     public Optional<VoiceState> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
@@ -28,6 +28,8 @@ import java.util.Optional;
  * This change can include the change of any property in {@link discord4j.core.object.VoiceState VoiceState}.
  * <p>
  * The old voice state may not be present if voice states are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#voice-state-update">Voice State Update</a>
  */
@@ -42,10 +44,18 @@ public class VoiceStateUpdateEvent extends Event {
         this.old = old;
     }
 
+    /**
+     * Gets the current, new, VoiceState that has been updated in this event.
+     * @return The current VoiceState.
+     */
     public VoiceState getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old VoiceState that has been updated in this event. This may not be available if VoiceStates are not stored.
+     * @return The old VoiceState.
+     */
     public Optional<VoiceState> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/WebhooksUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/WebhooksUpdateEvent.java
@@ -26,6 +26,8 @@ import reactor.core.publisher.Mono;
  * Dispatched when a webhook is updated in a guild.
  * <p>
  * Discord does not send any information about what was actually updated. This is simply a notification of SOME update.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#webhooks-update">Webhooks Update</a>
  */
@@ -40,18 +42,34 @@ public class WebhooksUpdateEvent extends Event {
         this.channelId = channelId;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild that had a webhook updated in this event.
+     * @return The ID of the guild involved.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild that had a webhook updated in this event.
+     * @return The ID of the guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the Snowflake ID of the channel the webhook belongs to.
+     * @return The ID of the channel involved.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the TextChannel the webhook belongs to.
+     * @return The TextChannel involved.
+     */
     public Mono<TextChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(TextChannel.class);
     }

--- a/core/src/main/java/discord4j/core/event/domain/WebhooksUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/WebhooksUpdateEvent.java
@@ -44,6 +44,7 @@ public class WebhooksUpdateEvent extends Event {
 
     /**
      * Gets the Snowflake ID of the guild that had a webhook updated in this event.
+     *
      * @return The ID of the guild involved.
      */
     public Snowflake getGuildId() {
@@ -51,8 +52,9 @@ public class WebhooksUpdateEvent extends Event {
     }
 
     /**
-     * Gets the Guild that had a webhook updated in this event.
-     * @return The ID of the guild involved.
+     * Requests to retrieve the Guild that had a webhook updated in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event. If an error is
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -60,6 +62,7 @@ public class WebhooksUpdateEvent extends Event {
 
     /**
      * Gets the Snowflake ID of the channel the webhook belongs to.
+     *
      * @return The ID of the channel involved.
      */
     public Snowflake getChannelId() {
@@ -67,8 +70,9 @@ public class WebhooksUpdateEvent extends Event {
     }
 
     /**
-     * Gets the TextChannel the webhook belongs to.
-     * @return The TextChannel involved.
+     * Requests to retrieve the TextChannel the webhook belongs to.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the TextChannel involved in the event. If an error is received, it is emitted through the Mono.
      */
     public Mono<TextChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(TextChannel.class);

--- a/core/src/main/java/discord4j/core/event/domain/WebhooksUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/WebhooksUpdateEvent.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Mono;
  * <p>
  * Discord does not send any information about what was actually updated. This is simply a notification of SOME update.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#webhooks-update">Webhooks Update</a>
  */
@@ -43,7 +43,7 @@ public class WebhooksUpdateEvent extends Event {
     }
 
     /**
-     * Gets the Snowflake ID of the guild that had a webhook updated in this event.
+     * Gets the {@link Snowflake} ID of the guild that had a webhook updated in this event.
      *
      * @return The ID of the guild involved.
      */
@@ -52,16 +52,17 @@ public class WebhooksUpdateEvent extends Event {
     }
 
     /**
-     * Requests to retrieve the Guild that had a webhook updated in this event.
+     * Requests to retrieve the {@link Guild} that had a webhook updated in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved in the event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the Snowflake ID of the channel the webhook belongs to.
+     * Gets the {@link Snowflake} ID of the channel the webhook belongs to.
      *
      * @return The ID of the channel involved.
      */
@@ -70,9 +71,10 @@ public class WebhooksUpdateEvent extends Event {
     }
 
     /**
-     * Requests to retrieve the TextChannel the webhook belongs to.
+     * Requests to retrieve the {@link TextChannel} the webhook belongs to.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the TextChannel involved in the event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel} involved in the event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<TextChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(TextChannel.class);

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryCreateEvent.java
@@ -22,7 +22,7 @@ import discord4j.core.object.entity.Category;
 /**
  * Dispatched when a {@link Category} is created in a guild.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-create">Channel Create</a>
  */
@@ -36,9 +36,9 @@ public class CategoryCreateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the Category that was created in this event.
+     * Gets the {@link Category} that was created in this event.
      *
-     * @return The category created.
+     * @return The {@link Category} created.
      */
     public Category getCategory() {
         return category;

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryCreateEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.Category;
 
 /**
  * Dispatched when a {@link Category} is created in a guild.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-create">Channel Create</a>
  */
@@ -33,6 +35,10 @@ public class CategoryCreateEvent extends ChannelEvent {
         this.category = category;
     }
 
+    /**
+     * Gets the Category that was created in this event.
+     * @return The category created.
+     */
     public Category getCategory() {
         return category;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryCreateEvent.java
@@ -37,6 +37,7 @@ public class CategoryCreateEvent extends ChannelEvent {
 
     /**
      * Gets the Category that was created in this event.
+     *
      * @return The category created.
      */
     public Category getCategory() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryDeleteEvent.java
@@ -37,6 +37,7 @@ public class CategoryDeleteEvent extends ChannelEvent {
 
     /**
      * Gets the Category that was deleted in this event.
+     *
      * @return The deleted Category.
      */
     public Category getCategory() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryDeleteEvent.java
@@ -36,9 +36,9 @@ public class CategoryDeleteEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the Category that was deleted in this event.
+     * Gets the {@link Category} that was deleted in this event.
      *
-     * @return The deleted Category.
+     * @return The deleted {@link Category}.
      */
     public Category getCategory() {
         return category;

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryDeleteEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.Category;
 
 /**
  * Dispatched when a {@link Category} is deleted in a guild.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -33,6 +35,10 @@ public class CategoryDeleteEvent extends ChannelEvent {
         this.category = category;
     }
 
+    /**
+     * Gets the Category that was deleted in this event.
+     * @return The deleted Category.
+     */
     public Category getCategory() {
         return category;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryUpdateEvent.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * <p>
  * The old category may not be present if categories are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-update">Channel Update</a>
  */
@@ -43,18 +43,19 @@ public class CategoryUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Get the current, new, version of the Category that has been updated in this event.
+     * Get the current, new, version of the {@link Category} that has been updated in this event.
      *
-     * @return The current version of the updated Category.
+     * @return The current version of the updated {@link Category}.
      */
     public Category getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the Category that has been updated in this event, if present. This may not be available if Categories are not stored.
+     * Gets the old version of the {@link Category} that has been updated in this event, if present.
+     * This may not be available if {@code Categories} are not stored.
      *
-     * @return The old version of the updated Category, if present.
+     * @return The old version of the updated {@link Category}, if present.
      */
     public Optional<Category> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryUpdateEvent.java
@@ -44,6 +44,7 @@ public class CategoryUpdateEvent extends ChannelEvent {
 
     /**
      * Get the current, new, version of the Category that has been updated in this event.
+     *
      * @return The current version of the updated Category.
      */
     public Category getCurrent() {
@@ -51,8 +52,9 @@ public class CategoryUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the old version of the Category that has been updated in this event. This may not be available if Categories are not stored.
-     * @return The old version of the updated Category
+     * Gets the old version of the Category that has been updated in this event, if present. This may not be available if Categories are not stored.
+     *
+     * @return The old version of the updated Category, if present.
      */
     public Optional<Category> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/channel/CategoryUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/CategoryUpdateEvent.java
@@ -26,6 +26,8 @@ import java.util.Optional;
  * Dispatched when a {@link Category} is updated in a guild.
  * <p>
  * The old category may not be present if categories are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-update">Channel Update</a>
  */
@@ -40,10 +42,18 @@ public class CategoryUpdateEvent extends ChannelEvent {
         this.old = old;
     }
 
+    /**
+     * Get the current, new, version of the Category that has been updated in this event.
+     * @return The current version of the updated Category.
+     */
     public Category getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the Category that has been updated in this event. This may not be available if Categories are not stored.
+     * @return The old version of the updated Category
+     */
     public Optional<Category> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 
 /**
  * Dispatched when a message is pinned or unpinned in a message channel.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-pins-update">Channel Pins Update</a>
  */
@@ -41,14 +43,26 @@ public class PinsUpdateEvent extends ChannelEvent {
         this.lastPinTimestamp = lastPinTimestamp;
     }
 
+    /**
+     * Gets the Snowflake ID of the Channel the pinned/unpinned message is in.
+     * @return the ID of the channel involved.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel the pinned/unpinned message is in.
+     * @return The MessageChannel involved.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * Gets the ISO8601 timestamp of when the last pinned message was pinned. This is NOT the timestamp of when the message was created.
+     * @return The timestamp of the when the last pinned message was pinned.
+     */
     public Optional<Instant> getLastPinTimestamp() {
         return Optional.ofNullable(lastPinTimestamp);
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
@@ -44,26 +44,32 @@ public class PinsUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the Channel the pinned/unpinned message is in.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the pinned/unpinned
+     * {@link discord4j.core.object.entity.Message} is in.
      *
-     * @return the ID of the channel involved.
+     * @return the ID of the {@link MessageChannel} involved.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel the pinned/unpinned message is in.
+     * Requests to retrieve the {@link MessageChannel} the pinned/unpinned
+     * {@link discord4j.core.object.entity.Message} is in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel involved. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} involved.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the ISO8601 timestamp of when the last pinned message was pinned, if present. This is NOT the timestamp of when the message was created.
-     * @return The timestamp of the when the last pinned message was pinned, if present.
+     * Gets the ISO8601 timestamp of when the last pinned {@link discord4j.core.object.entity.Message} w
+     * as pinned, if present. This is NOT the timestamp of when the {@code Message} was created.
+     * 
+     * @return The timestamp of the when the last pinned {@link discord4j.core.object.entity.Message} was pinned,
+     * if present.
      */
     public Optional<Instant> getLastPinTimestamp() {
         return Optional.ofNullable(lastPinTimestamp);

--- a/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
@@ -45,6 +45,7 @@ public class PinsUpdateEvent extends ChannelEvent {
 
     /**
      * Gets the Snowflake ID of the Channel the pinned/unpinned message is in.
+     *
      * @return the ID of the channel involved.
      */
     public Snowflake getChannelId() {
@@ -52,16 +53,17 @@ public class PinsUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the MessageChannel the pinned/unpinned message is in.
-     * @return The MessageChannel involved.
+     * Requests to retrieve the MessageChannel the pinned/unpinned message is in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel involved. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the ISO8601 timestamp of when the last pinned message was pinned. This is NOT the timestamp of when the message was created.
-     * @return The timestamp of the when the last pinned message was pinned.
+     * Gets the ISO8601 timestamp of when the last pinned message was pinned, if present. This is NOT the timestamp of when the message was created.
+     * @return The timestamp of the when the last pinned message was pinned, if present.
      */
     public Optional<Instant> getLastPinTimestamp() {
         return Optional.ofNullable(lastPinTimestamp);

--- a/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelCreateEvent.java
@@ -37,6 +37,7 @@ public class PrivateChannelCreateEvent extends ChannelEvent {
 
     /**
      * Gets the PrivateChannel that was created in this event.
+     *
      * @return The PrivateChannel that was created.
      */
     public PrivateChannel getChannel() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelCreateEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.PrivateChannel;
 
 /**
  * Dispatched when a {@link PrivateChannel} is created.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-create">Channel Create</a>
  */
@@ -33,6 +35,10 @@ public class PrivateChannelCreateEvent extends ChannelEvent {
         this.channel = channel;
     }
 
+    /**
+     * Gets the PrivateChannel that was created in this event.
+     * @return The PrivateChannel that was created.
+     */
     public PrivateChannel getChannel() {
         return channel;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelCreateEvent.java
@@ -36,9 +36,9 @@ public class PrivateChannelCreateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the PrivateChannel that was created in this event.
+     * Gets the {@link PrivateChannel} that was created in this event.
      *
-     * @return The PrivateChannel that was created.
+     * @return The {@link PrivateChannel} that was created.
      */
     public PrivateChannel getChannel() {
         return channel;

--- a/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelDeleteEvent.java
@@ -36,9 +36,9 @@ public class PrivateChannelDeleteEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the PrivateChannel that was deleted in this event.
+     * Gets the {@link PrivateChannel} that was deleted in this event.
      *
-     * @return The PrivateChannel that was deleted.
+     * @return The {@link PrivateChannel} that was deleted.
      */
     public PrivateChannel getChannel() {
         return channel;

--- a/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelDeleteEvent.java
@@ -21,6 +21,10 @@ import discord4j.core.object.entity.PrivateChannel;
 
 /**
  * TODO what does this mean?
+ * <p>
+ * This event is dispatched by Discord.
+ *
+ * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
 public class PrivateChannelDeleteEvent extends ChannelEvent {
 
@@ -31,6 +35,10 @@ public class PrivateChannelDeleteEvent extends ChannelEvent {
         this.channel = channel;
     }
 
+    /**
+     * Gets the PrivateChannel that was deleted in this event.
+     * @return The PrivateChannel that was deleted.
+     */
     public PrivateChannel getChannel() {
         return channel;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PrivateChannelDeleteEvent.java
@@ -37,6 +37,7 @@ public class PrivateChannelDeleteEvent extends ChannelEvent {
 
     /**
      * Gets the PrivateChannel that was deleted in this event.
+     *
      * @return The PrivateChannel that was deleted.
      */
     public PrivateChannel getChannel() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelCreateEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.TextChannel;
 
 /**
  * Dispatched when a {@link TextChannel} is created in a guild.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-create">Channel Create</a>
  */
@@ -33,6 +35,10 @@ public class TextChannelCreateEvent extends ChannelEvent {
         this.channel = channel;
     }
 
+    /**
+     * Gets the TextChannel that was created in this event.
+     * @return The newly created TextChannel.
+     */
     public TextChannel getChannel() {
         return channel;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelCreateEvent.java
@@ -36,9 +36,9 @@ public class TextChannelCreateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the TextChannel that was created in this event.
+     * Gets the {@link TextChannel} that was created in this event.
      *
-     * @return The newly created TextChannel.
+     * @return The newly created {@link TextChannel}.
      */
     public TextChannel getChannel() {
         return channel;

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelCreateEvent.java
@@ -37,6 +37,7 @@ public class TextChannelCreateEvent extends ChannelEvent {
 
     /**
      * Gets the TextChannel that was created in this event.
+     *
      * @return The newly created TextChannel.
      */
     public TextChannel getChannel() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelDeleteEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.TextChannel;
 
 /**
  * Dispatched when a {@link TextChannel} is deleted in a guild.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -33,6 +35,10 @@ public class TextChannelDeleteEvent extends ChannelEvent {
         this.channel = channel;
     }
 
+    /**
+     * Gets the TextChannel that was deleted in this event.
+     * @return The deleted TextChannel.
+     */
     public TextChannel getChannel() {
         return channel;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelDeleteEvent.java
@@ -37,6 +37,7 @@ public class TextChannelDeleteEvent extends ChannelEvent {
 
     /**
      * Gets the TextChannel that was deleted in this event.
+     *
      * @return The deleted TextChannel.
      */
     public TextChannel getChannel() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelDeleteEvent.java
@@ -22,7 +22,7 @@ import discord4j.core.object.entity.TextChannel;
 /**
  * Dispatched when a {@link TextChannel} is deleted in a guild.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -36,9 +36,9 @@ public class TextChannelDeleteEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the TextChannel that was deleted in this event.
+     * Gets the {@link TextChannel} that was deleted in this event.
      *
-     * @return The deleted TextChannel.
+     * @return The {@link TextChannel} TextChannel.
      */
     public TextChannel getChannel() {
         return channel;

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelUpdateEvent.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * <p>
  * The old text channel may not be present if text channels are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-update">Channel Update</a>
  */
@@ -43,18 +43,19 @@ public class TextChannelUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the current, new version of the TextChannel that was updated in this event.
+     * Gets the current, new version of the {@link TextChannel} that was updated in this event.
      *
-     * @return The current version of the updated TextChannel.
+     * @return The current version of the updated {@link TextChannel}.
      */
     public TextChannel getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the TextChannel that was updated in this event, if present. This may not be available if TextChannels are not stored.
+     * Gets the old version of the {@link TextChannel} that was updated in this event, if present.
+     * This may not be available if {@code TextChannels} are not stored.
      *
-     * @return The old version of the updated TextChannel, if present.
+     * @return The old version of the updated {@link TextChannel}, if present.
      */
     public Optional<TextChannel> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelUpdateEvent.java
@@ -26,6 +26,8 @@ import java.util.Optional;
  * Dispatched when a {@link TextChannel} is updated in a guild.
  * <p>
  * The old text channel may not be present if text channels are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-update">Channel Update</a>
  */
@@ -40,10 +42,18 @@ public class TextChannelUpdateEvent extends ChannelEvent {
         this.old = old;
     }
 
+    /**
+     * Gets the current, new version of the TextChannel that was updated in this event.
+     * @return The current version of the updated TextChannel.
+     */
     public TextChannel getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the TextChannel that was updated in this event. This may not be available if TextChannels are not stored.
+     * @return The old version of the updated TextChannel.
+     */
     public Optional<TextChannel> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/TextChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TextChannelUpdateEvent.java
@@ -44,6 +44,7 @@ public class TextChannelUpdateEvent extends ChannelEvent {
 
     /**
      * Gets the current, new version of the TextChannel that was updated in this event.
+     *
      * @return The current version of the updated TextChannel.
      */
     public TextChannel getCurrent() {
@@ -51,8 +52,9 @@ public class TextChannelUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the old version of the TextChannel that was updated in this event. This may not be available if TextChannels are not stored.
-     * @return The old version of the updated TextChannel.
+     * Gets the old version of the TextChannel that was updated in this event, if present. This may not be available if TextChannels are not stored.
+     *
+     * @return The old version of the updated TextChannel, if present.
      */
     public Optional<TextChannel> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
@@ -27,7 +27,7 @@ import java.time.Instant;
 /**
  * Dispatched when a user starts typing in a message channel.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#typing-start">Typing Start</a>
  */
@@ -45,45 +45,47 @@ public class TypingStartEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the channel the user has started typing in.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the user has started typing in.
      *
-     * @return the ID of the channel the user is typing in.
+     * @return the ID of the {@link MessageChannel} the {@link User} is typing in.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel the user has started typing in.
+     * Requests to retrieve the {@link MessageChannel} the user has started typing in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel the user has started typing in. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} the {@link User} has
+     * started typing in. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the Snowflake ID of the User who has started typing in this event.
+     * Gets the {@link Snowflake} ID of the {@link User} who has started typing in this event.
      *
-     * @return The ID of the User who has started typing.
+     * @return The ID of the {@link User} who has started typing.
      */
     public Snowflake getUserId() {
         return Snowflake.of(userId);
     }
 
     /**
-     * Requests to retrieve the User who has started typing in this event.
+     * Requests to retrieve the {@link User} who has started typing in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the User that has started typing. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User} that has started typing.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
     /**
-     * Gets the time at which the user started typing in this event.
+     * Gets the time at which the {@link User} started typing in this event.
      *
-     * @return The time at which the user starting typing.
+     * @return The time at which the {@link User} starting typing.
      */
     public Instant getStartTime() {
         return startTime;

--- a/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
@@ -26,6 +26,8 @@ import java.time.Instant;
 
 /**
  * Dispatched when a user starts typing in a message channel.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#typing-start">Typing Start</a>
  */
@@ -42,22 +44,42 @@ public class TypingStartEvent extends ChannelEvent {
         this.startTime = startTime;
     }
 
+    /**
+     * Gets the Snowflake ID of the channel the user has started typing in.
+     * @return the ID of the channel the user is typing in.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel the user has started typing in.
+     * @return The MessageChannel the user is typing in.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * Gets the Snowflake ID of the User who has started typing in this event.
+     * @return The ID of the User who has started typing.
+     */
     public Snowflake getUserId() {
         return Snowflake.of(userId);
     }
 
+    /**
+     * Gets the User who has started typing in this event.
+     * @return The User who has started typing.
+     */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
+    /**
+     * Gets the time at which the user started typing in this event.
+     * @return The time at which the user starting typing.
+     */
     public Instant getStartTime() {
         return startTime;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
@@ -46,6 +46,7 @@ public class TypingStartEvent extends ChannelEvent {
 
     /**
      * Gets the Snowflake ID of the channel the user has started typing in.
+     *
      * @return the ID of the channel the user is typing in.
      */
     public Snowflake getChannelId() {
@@ -53,8 +54,9 @@ public class TypingStartEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the MessageChannel the user has started typing in.
-     * @return The MessageChannel the user is typing in.
+     * Requests to retrieve the MessageChannel the user has started typing in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel the user has started typing in. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
@@ -62,6 +64,7 @@ public class TypingStartEvent extends ChannelEvent {
 
     /**
      * Gets the Snowflake ID of the User who has started typing in this event.
+     *
      * @return The ID of the User who has started typing.
      */
     public Snowflake getUserId() {
@@ -69,8 +72,9 @@ public class TypingStartEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the User who has started typing in this event.
-     * @return The User who has started typing.
+     * Requests to retrieve the User who has started typing in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the User that has started typing. If an error is received, it is emitted through the Mono.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
@@ -78,6 +82,7 @@ public class TypingStartEvent extends ChannelEvent {
 
     /**
      * Gets the time at which the user started typing in this event.
+     *
      * @return The time at which the user starting typing.
      */
     public Instant getStartTime() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelCreateEvent.java
@@ -37,6 +37,7 @@ public class VoiceChannelCreateEvent extends ChannelEvent {
 
     /**
      * Gets the VoiceChannel that was created in this event.
+     *
      * @return The newly created VoiceChannel.
      */
     public VoiceChannel getChannel() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelCreateEvent.java
@@ -22,7 +22,7 @@ import discord4j.core.object.entity.VoiceChannel;
 /**
  * Dispatched when a {@link VoiceChannel} is created in a guild.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-create">Channel Create</a>
  */
@@ -36,9 +36,9 @@ public class VoiceChannelCreateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the VoiceChannel that was created in this event.
+     * Gets the {@link VoiceChannel} that was created in this event.
      *
-     * @return The newly created VoiceChannel.
+     * @return The newly created {@link VoiceChannel}.
      */
     public VoiceChannel getChannel() {
         return channel;

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelCreateEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.VoiceChannel;
 
 /**
  * Dispatched when a {@link VoiceChannel} is created in a guild.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-create">Channel Create</a>
  */
@@ -33,6 +35,10 @@ public class VoiceChannelCreateEvent extends ChannelEvent {
         this.channel = channel;
     }
 
+    /**
+     * Gets the VoiceChannel that was created in this event.
+     * @return The newly created VoiceChannel.
+     */
     public VoiceChannel getChannel() {
         return channel;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelDeleteEvent.java
@@ -37,6 +37,7 @@ public class VoiceChannelDeleteEvent extends ChannelEvent {
 
     /**
      * Gets the VoiceChannel that has been deleted in this event.
+     *
      * @return The deleted VoiceChannel.
      */
     public VoiceChannel getChannel() {

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelDeleteEvent.java
@@ -22,7 +22,7 @@ import discord4j.core.object.entity.VoiceChannel;
 /**
  * Dispatched when a {@link VoiceChannel} is deleted in a guild.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -36,9 +36,9 @@ public class VoiceChannelDeleteEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the VoiceChannel that has been deleted in this event.
+     * Gets the {@link VoiceChannel} that has been deleted in this event.
      *
-     * @return The deleted VoiceChannel.
+     * @return The deleted {@link VoiceChannel}.
      */
     public VoiceChannel getChannel() {
         return channel;

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelDeleteEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.object.entity.VoiceChannel;
 
 /**
  * Dispatched when a {@link VoiceChannel} is deleted in a guild.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -33,6 +35,10 @@ public class VoiceChannelDeleteEvent extends ChannelEvent {
         this.channel = channel;
     }
 
+    /**
+     * Gets the VoiceChannel that has been deleted in this event.
+     * @return The deleted VoiceChannel.
+     */
     public VoiceChannel getChannel() {
         return channel;
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelUpdateEvent.java
@@ -44,6 +44,7 @@ public class VoiceChannelUpdateEvent extends ChannelEvent {
 
     /**
      * Gets the current, new, version of the VoiceChannel that was updated in this event.
+     *
      * @return The current version of the updated VoiceChannel
      */
     public VoiceChannel getCurrent() {
@@ -51,8 +52,9 @@ public class VoiceChannelUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the old version of the VoiceChannel that was updated in this event. This may not be available if VoiceChannels are not stored.
-     * @return The old version of the updated VoiceChannel.
+     * Gets the old version of the VoiceChannel that was updated in this event, if present. This may not be available if VoiceChannels are not stored.
+     *
+     * @return The old version of the updated VoiceChannel, if present.
      */
     public Optional<VoiceChannel> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelUpdateEvent.java
@@ -26,6 +26,8 @@ import java.util.Optional;
  * Dispatched when a {@link VoiceChannel} is deleted in a guild.
  * <p>
  * The old category may not be present if voice channels are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -40,10 +42,18 @@ public class VoiceChannelUpdateEvent extends ChannelEvent {
         this.old = old;
     }
 
+    /**
+     * Gets the current, new, version of the VoiceChannel that was updated in this event.
+     * @return The current version of the updated VoiceChannel
+     */
     public VoiceChannel getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the VoiceChannel that was updated in this event. This may not be available if VoiceChannels are not stored.
+     * @return The old version of the updated VoiceChannel.
+     */
     public Optional<VoiceChannel> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/VoiceChannelUpdateEvent.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * <p>
  * The old category may not be present if voice channels are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#channel-delete">Channel Delete</a>
  */
@@ -43,18 +43,19 @@ public class VoiceChannelUpdateEvent extends ChannelEvent {
     }
 
     /**
-     * Gets the current, new, version of the VoiceChannel that was updated in this event.
+     * Gets the current, new, version of the {@link VoiceChannel} that was updated in this event.
      *
-     * @return The current version of the updated VoiceChannel
+     * @return The current version of the updated {@link VoiceChannel}
      */
     public VoiceChannel getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the VoiceChannel that was updated in this event, if present. This may not be available if VoiceChannels are not stored.
+     * Gets the old version of the {@link VoiceChannel} that was updated in this event, if present.
+     * This may not be available if {@code VoiceChannels} are not stored.
      *
-     * @return The old version of the updated VoiceChannel, if present.
+     * @return The old version of the updated {@link VoiceChannel}, if present.
      */
     public Optional<VoiceChannel> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/guild/BanEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/BanEvent.java
@@ -41,27 +41,28 @@ public class BanEvent extends GuildEvent {
     }
 
     /**
-     * Gets the User that has been banned from the Guild.
+     * Gets the {@link User} that has been banned from the {@link Guild}.
      *
-     * @return The User that has been banned.
+     * @return The {@link User} that has been banned.
      */
     public User getUser() {
         return user;
     }
 
     /**
-     * Gets the Snowflake ID of the guild in this event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} in this event.
      *
-     * @return The Snowflake ID of the guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild the User was banned from.
+     * Requests to retrieve the {@link Guild} the {@link User} was banned from.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in this event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved in this event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/BanEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/BanEvent.java
@@ -42,6 +42,7 @@ public class BanEvent extends GuildEvent {
 
     /**
      * Gets the User that has been banned from the Guild.
+     *
      * @return The User that has been banned.
      */
     public User getUser() {
@@ -50,6 +51,7 @@ public class BanEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the guild in this event.
+     *
      * @return The Snowflake ID of the guild.
      */
     public Snowflake getGuildId() {
@@ -57,8 +59,9 @@ public class BanEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild involved in this event.
-     * @return The Guild involved in this event.
+     * Requests to retrieve the Guild the User was banned from.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in this event. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/BanEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/BanEvent.java
@@ -24,6 +24,8 @@ import reactor.core.publisher.Mono;
 
 /**
  * Dispatched when a user is banned from a guild.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-ban-add">Guild Ban Add</a>
  */
@@ -38,14 +40,26 @@ public class BanEvent extends GuildEvent {
         this.guildId = guildId;
     }
 
+    /**
+     * Gets the User that has been banned from the Guild.
+     * @return The User that has been banned.
+     */
     public User getUser() {
         return user;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild in this event.
+     * @return The Snowflake ID of the guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild involved in this event.
+     * @return The Guild involved in this event.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/EmojisUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/EmojisUpdateEvent.java
@@ -27,6 +27,8 @@ import java.util.Set;
 /**
  * Dispatched when an emoji is added/deleted/or edited in a guild. The {@link #emojis} set includes ALL emojis of the
  * guild.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-emojis-update">Guild Emojis Update</a>
  */
@@ -41,14 +43,26 @@ public class EmojisUpdateEvent extends GuildEvent {
         this.emojis = emojis;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild involved in the event.
+     * @return The Snowflake ID of the guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild involved in the event.
+     * @return The Guild involved in the event.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets a list of ALL emojis of the Guild.
+     * @return A list of ALL emojis of the Guild.
+     */
     public Set<GuildEmoji> getEmojis() {
         return emojis;
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/EmojisUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/EmojisUpdateEvent.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * Dispatched when an emoji is added/deleted/or edited in a guild. The {@link #emojis} set includes ALL emojis of the
  * guild.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-emojis-update">Guild Emojis Update</a>
  */
@@ -44,27 +44,28 @@ public class EmojisUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the guild involved in the event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event.
      *
-     * @return The Snowflake ID of the guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild whose emojis have been updated.
+     * Requests to retrieve the {@link Guild} whose emojis have been updated.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets a list of ALL emojis of the Guild.
+     * Gets a list of ALL emojis of the {@link Guild}.
      *
-     * @return A list of ALL emojis of the Guild.
+     * @return A list of ALL emojis of the {@link com.sun.media.sound.WaveExtensibleFileReader.GUID}.
      */
     public Set<GuildEmoji> getEmojis() {
         return emojis;

--- a/core/src/main/java/discord4j/core/event/domain/guild/EmojisUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/EmojisUpdateEvent.java
@@ -45,6 +45,7 @@ public class EmojisUpdateEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the guild involved in the event.
+     *
      * @return The Snowflake ID of the guild.
      */
     public Snowflake getGuildId() {
@@ -52,8 +53,9 @@ public class EmojisUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild involved in the event.
-     * @return The Guild involved in the event.
+     * Requests to retrieve the Guild whose emojis have been updated.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -61,6 +63,7 @@ public class EmojisUpdateEvent extends GuildEvent {
 
     /**
      * Gets a list of ALL emojis of the Guild.
+     *
      * @return A list of ALL emojis of the Guild.
      */
     public Set<GuildEmoji> getEmojis() {

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildCreateEvent.java
@@ -44,6 +44,7 @@ public class GuildCreateEvent extends GuildEvent {
 
     /**
      * Gets the guild that has become available in this event.
+     *
      * @return The guild that has become available.
      */
     public Guild getGuild() {

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildCreateEvent.java
@@ -43,9 +43,9 @@ public class GuildCreateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the guild that has become available in this event.
+     * Gets the {@link Guild} that has become available in this event.
      *
-     * @return The guild that has become available.
+     * @return The {@link Guild} that has become available.
      */
     public Guild getGuild() {
         return guild;

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildCreateEvent.java
@@ -28,6 +28,8 @@ import discord4j.core.object.entity.Guild;
  *     be dispatched), this event will be dispatched as guilds become available again.</li>
  *     <li>When the bot is added to a guild.</li>
  * </ol>
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-create">Guild Create</a>
  */
@@ -40,6 +42,10 @@ public class GuildCreateEvent extends GuildEvent {
         this.guild = guild;
     }
 
+    /**
+     * Gets the guild that has become available in this event.
+     * @return The guild that has become available.
+     */
     public Guild getGuild() {
         return guild;
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildDeleteEvent.java
@@ -29,6 +29,8 @@ import java.util.Optional;
  *     <li>The bot is kicked from or leaves a guild.</li>
  *     <li>A guild becomes unavailable during an outage. In this scenario, {@link #unavailable} will be true.</li>
  * </ol>
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-delete">Guild Delete</a>
  */
@@ -45,14 +47,26 @@ public class GuildDeleteEvent extends GuildEvent {
         this.unavailable = unavailable;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild that is involved in the event.
+     * @return The ID of the guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets an Optional of the Guild involved in this event.
+     * @return The Guild involved in this event.
+     */
     public Optional<Guild> getGuild() {
         return Optional.ofNullable(guild);
     }
 
+    /**
+     * Gets whether or not the Guild is now unavailable.
+     * @return Whether or not the Guild is unavailable.
+     */
     public boolean isUnavailable() {
         return unavailable;
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildDeleteEvent.java
@@ -49,6 +49,7 @@ public class GuildDeleteEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the guild that is involved in the event.
+     *
      * @return The ID of the guild.
      */
     public Snowflake getGuildId() {
@@ -56,8 +57,9 @@ public class GuildDeleteEvent extends GuildEvent {
     }
 
     /**
-     * Gets an Optional of the Guild involved in this event.
-     * @return The Guild involved in this event.
+     * Gets the Guild involved in this event, if present.
+     *
+     * @return The Guild involved in this event, if present.
      */
     public Optional<Guild> getGuild() {
         return Optional.ofNullable(guild);
@@ -65,6 +67,7 @@ public class GuildDeleteEvent extends GuildEvent {
 
     /**
      * Gets whether or not the Guild is now unavailable.
+     *
      * @return Whether or not the Guild is unavailable.
      */
     public boolean isUnavailable() {

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildDeleteEvent.java
@@ -48,27 +48,27 @@ public class GuildDeleteEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the guild that is involved in the event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} that is involved in the event.
      *
-     * @return The ID of the guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Gets the Guild involved in this event, if present.
+     * Gets the {@link Guild} involved in this event, if present.
      *
-     * @return The Guild involved in this event, if present.
+     * @return The {@link Guild} involved in this event, if present.
      */
     public Optional<Guild> getGuild() {
         return Optional.ofNullable(guild);
     }
 
     /**
-     * Gets whether or not the Guild is now unavailable.
+     * Gets whether or not the {@link Guild} is now unavailable.
      *
-     * @return Whether or not the Guild is unavailable.
+     * @return Whether or not the {@link Guild} is unavailable.
      */
     public boolean isUnavailable() {
         return unavailable;

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildUpdateEvent.java
@@ -44,6 +44,7 @@ public class GuildUpdateEvent extends GuildEvent {
 
     /**
      * Gets the current version of the Guild involved in this event.
+     *
      * @return The current Guild involved in this event.
      */
     public Guild getCurrent() {
@@ -51,8 +52,9 @@ public class GuildUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the old version of the Guild involved in this event. This may not be available if guilds are not stored.
-     * @return The old Guild involved in this event.
+     * Gets the old version of the Guild involved in this event, if present. This may not be available if guilds are not stored.
+     *
+     * @return The old Guild involved in this event, if present.
      */
     public Optional<Guild> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildUpdateEvent.java
@@ -43,18 +43,19 @@ public class GuildUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the current version of the Guild involved in this event.
+     * Gets the current version of the {@link Guild} involved in this event.
      *
-     * @return The current Guild involved in this event.
+     * @return The current {@link Guild} involved in this event.
      */
     public Guild getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the Guild involved in this event, if present. This may not be available if guilds are not stored.
+     * Gets the old version of the {@link Guild} involved in this event, if present.
+     * This may not be available if {@code Guild} are not stored.
      *
-     * @return The old Guild involved in this event, if present.
+     * @return The old {@link Guild} involved in this event, if present.
      */
     public Optional<Guild> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/guild/GuildUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/GuildUpdateEvent.java
@@ -26,6 +26,8 @@ import java.util.Optional;
  * Dispatched when a guild is updated.
  * <p>
  * The old guild may not be present if guilds are not stored.
+ * <p>
+ * This event is Dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-update">Guild Update</a>
  */
@@ -40,10 +42,18 @@ public class GuildUpdateEvent extends GuildEvent {
         this.old = old;
     }
 
+    /**
+     * Gets the current version of the Guild involved in this event.
+     * @return The current Guild involved in this event.
+     */
     public Guild getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the Guild involved in this event. This may not be available if guilds are not stored.
+     * @return The old Guild involved in this event.
+     */
     public Optional<Guild> getOld() {
         return Optional.ofNullable(old);
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/IntegrationsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/IntegrationsUpdateEvent.java
@@ -40,6 +40,7 @@ public class IntegrationsUpdateEvent extends GuildEvent {
 
     /**
      * The Snowflake ID of the Guild involved in this event.
+     *
      * @return The Snowflake ID of the guild.
      */
     public Snowflake getGuildId() {
@@ -47,8 +48,9 @@ public class IntegrationsUpdateEvent extends GuildEvent {
     }
 
     /**
-     * The Guild involved in this event.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild whose integrations have been updated.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/IntegrationsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/IntegrationsUpdateEvent.java
@@ -23,6 +23,8 @@ import reactor.core.publisher.Mono;
 
 /**
  * Dispatched when guild integrations are updated.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-integrations-update">Guild Integrations
  * Update</a>
@@ -36,10 +38,18 @@ public class IntegrationsUpdateEvent extends GuildEvent {
         this.guildId = guildId;
     }
 
+    /**
+     * The Snowflake ID of the Guild involved in this event.
+     * @return The Snowflake ID of the guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * The Guild involved in this event.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/IntegrationsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/IntegrationsUpdateEvent.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 /**
  * Dispatched when guild integrations are updated.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-integrations-update">Guild Integrations
  * Update</a>
@@ -39,18 +39,19 @@ public class IntegrationsUpdateEvent extends GuildEvent {
     }
 
     /**
-     * The Snowflake ID of the Guild involved in this event.
+     * The {@link Snowflake} ID of the {@link Guild} involved in this event.
      *
-     * @return The Snowflake ID of the guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild whose integrations have been updated.
+     * Requests to retrieve the {@link Guild} whose integrations have been updated.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved in the event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
@@ -46,6 +46,7 @@ public class MemberChunkEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the guild involved in this event.
+     *
      * @return The Snowflake ID of the guild.
      */
     public Snowflake getGuildId() {
@@ -53,8 +54,9 @@ public class MemberChunkEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild involved in the event.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild involved in the event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -63,6 +65,7 @@ public class MemberChunkEvent extends GuildEvent {
     /**
      * Gets a list of Members that have been streamed to the client in this event.
      * This may not contain all members of the guild.
+     *
      * @return The list of Members streamed to the client in this event.
      */
     public Set<Member> getMembers() {

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
@@ -45,28 +45,29 @@ public class MemberChunkEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the guild involved in this event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in this event.
      *
-     * @return The Snowflake ID of the guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild involved in the event.
+     * Requests to retrieve the {@link Guild} involved in the event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved in the event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved in the event.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets a list of Members that have been streamed to the client in this event.
-     * This may not contain all members of the guild.
+     * Gets a list of {@code Members} that have been streamed to the client in this event.
+     * This may not contain all {@code Members} of the {@link Guild}.
      *
-     * @return The list of Members streamed to the client in this event.
+     * @return The list of {@code Members} streamed to the client in this event.
      */
     public Set<Member> getMembers() {
         return members;

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
@@ -28,6 +28,8 @@ import java.util.Set;
  * Dispatched as members are streamed to the client from Discord.
  * <p>
  * By default, all members in all connected guilds are requested on startup.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-members-chunk">Guild Members Chunk</a>
  */
@@ -42,14 +44,27 @@ public class MemberChunkEvent extends GuildEvent {
         this.members = members;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild involved in this event.
+     * @return The Snowflake ID of the guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild involved in the event.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets a list of Members that have been streamed to the client in this event.
+     * This may not contain all members of the guild.
+     * @return The list of Members streamed to the client in this event.
+     */
     public Set<Member> getMembers() {
         return members;
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberJoinEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberJoinEvent.java
@@ -24,6 +24,8 @@ import reactor.core.publisher.Mono;
 
 /**
  * Dispatched when a user joins a guild.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-member-add">Guild Member Add</a>
  */
@@ -38,14 +40,26 @@ public class MemberJoinEvent extends GuildEvent {
         this.guildId = guildId;
     }
 
+    /**
+     * Gets the member that has joined the Guild in this event.
+     * @return The Member that has joined
+     */
     public Member getMember() {
         return member;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild the member has joined in this event.
+     * @return The ID of the guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild the member has joined in this event.
+     * @return The guild the member has joined
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberJoinEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberJoinEvent.java
@@ -41,27 +41,28 @@ public class MemberJoinEvent extends GuildEvent {
     }
 
     /**
-     * Gets the member that has joined the Guild in this event.
+     * Gets the {@link Member} that has joined the {@link Guild} in this event.
      *
-     * @return The Member that has joined
+     * @return The {@link Member} that has joined
      */
     public Member getMember() {
         return member;
     }
 
     /**
-     * Gets the Snowflake ID of the guild the member has joined in this event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Member} has joined in this event.
      *
-     * @return The ID of the guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild the member has joined in this event.
+     * Requests to retrieve the {@link Guild} the {@link Member} has joined in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild the member has joined. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} the {@link Member} has joined.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberJoinEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberJoinEvent.java
@@ -42,6 +42,7 @@ public class MemberJoinEvent extends GuildEvent {
 
     /**
      * Gets the member that has joined the Guild in this event.
+     *
      * @return The Member that has joined
      */
     public Member getMember() {
@@ -50,6 +51,7 @@ public class MemberJoinEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the guild the member has joined in this event.
+     *
      * @return The ID of the guild.
      */
     public Snowflake getGuildId() {
@@ -57,8 +59,9 @@ public class MemberJoinEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild the member has joined in this event.
-     * @return The guild the member has joined
+     * Requests to retrieve the Guild the member has joined in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild the member has joined. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberLeaveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberLeaveEvent.java
@@ -31,6 +31,8 @@ import java.util.Optional;
  * <p>
  * Discord does not differentiate between a user leaving on their own and being kicked. Except through audit logs, it is
  * not possible to tell the difference between these.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-member-remove">Guild Member Remove</a>
  */
@@ -48,18 +50,34 @@ public class MemberLeaveEvent extends GuildEvent {
         this.member = member;
     }
 
+    /**
+     * Gets the User that has left the Guild in this event.
+     * @return The User that has left the Guild
+     */
     public User getUser() {
         return user;
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild that the User has left in this event.
+     * @return The ID of the Guild.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild that the User has left in this event.
+     * @return The Guild that the user has left.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the Member object of the User that has left the Guild in this event.
+     * @return The Member object of the User that has left the Guild.
+     */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberLeaveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberLeaveEvent.java
@@ -52,6 +52,7 @@ public class MemberLeaveEvent extends GuildEvent {
 
     /**
      * Gets the User that has left the Guild in this event.
+     *
      * @return The User that has left the Guild
      */
     public User getUser() {
@@ -60,6 +61,7 @@ public class MemberLeaveEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the Guild that the User has left in this event.
+     *
      * @return The ID of the Guild.
      */
     public Snowflake getGuildId() {
@@ -67,16 +69,18 @@ public class MemberLeaveEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild that the User has left in this event.
-     * @return The Guild that the user has left.
+     * Requests to retrieve the Guild that the User has left in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild that the user has left. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the Member object of the User that has left the Guild in this event.
-     * @return The Member object of the User that has left the Guild.
+     * Gets the Member object of the User that has left the Guild in this event, if present.
+     *
+     * @return The Member object of the User that has left the Guild, if present.
      */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberLeaveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberLeaveEvent.java
@@ -51,36 +51,37 @@ public class MemberLeaveEvent extends GuildEvent {
     }
 
     /**
-     * Gets the User that has left the Guild in this event.
+     * Gets the {@link User} that has left the {@link Guild} in this event.
      *
-     * @return The User that has left the Guild
+     * @return The {@link User} that has left the {@link Guild}
      */
     public User getUser() {
         return user;
     }
 
     /**
-     * Gets the Snowflake ID of the Guild that the User has left in this event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} that the {@link User} has left in this event.
      *
-     * @return The ID of the Guild.
+     * @return The ID of the {@link Guild}.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild that the User has left in this event.
+     * Requests to retrieve the {@link Guild} that the {@link User} has left in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild that the user has left. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} that the {@link User} has left.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the Member object of the User that has left the Guild in this event, if present.
+     * Gets the {@link Member} object of the {@link User} that has left the {@link Guild} in this event, if present.
      *
-     * @return The Member object of the User that has left the Guild, if present.
+     * @return The {@link Member} object of the {@link User} that has left the {@link Guild}, if present.
      */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -59,54 +59,57 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the Guild involved in the event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event.
      *
-     * @return The ID of the Guild involved.
+     * @return The ID of the {@link Guild} involved.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild involved in the event.
+     * Requests to retrieve the {@link Guild} involved in the event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild involved. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the Snowflake ID of the Member involved in the event.
+     * Gets the {@link Snowflake} ID of the {@link Member} involved in the event.
      *
-     * @return The ID of the Member involved.
+     * @return The ID of the {@link Member} involved.
      */
     public Snowflake getMemberId() {
         return Snowflake.of(memberId);
     }
 
     /**
-     * Requests to retrieve the Member involved in the event.
+     * Requests to retrieve the {@link Member} involved in the event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Member that has been updated. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Member} that has been updated.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Member> getMember() {
         return getClient().getMemberById(getGuildId(), getMemberId());
     }
 
     /**
-     * Gets the old version of the Member involved in the event, if present. This may not be available if Members are not stored.
+     * Gets the old version of the {@link Member} involved in the event, if present.
+     * This may not be available if {@code Members} are not stored.
      *
-     * @return the old version of the Member involved, if present.
+     * @return the old version of the {@link Member} involved, if present.
      */
     public Optional<Member> getOld() {
         return Optional.ofNullable(old);
     }
 
     /**
-     * Gets a list of Snowflake IDs of roles the Member is currently assigned.
+     * Gets a list of {@link Snowflake} IDs of roles the {@link Member} is currently assigned.
      *
-     * @return The IDs of the roles the Member is assigned.
+     * @return The IDs of the roles the {@link Member} is assigned.
      */
     public Set<Snowflake> getCurrentRoles() {
         return Arrays.stream(currentRoles)
@@ -115,9 +118,9 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the current nickname of the Member involved in this event, if present.
+     * Gets the current nickname of the {@link Member} involved in this event, if present.
      *
-     * @return The current nickname, if any, of the Member involved, if present.
+     * @return The current nickname, if any, of the {@link Member} involved, if present.
      */
     public Optional<String> getCurrentNickname() {
         return Optional.ofNullable(currentNickname);

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 
 /**
  * Dispatched when a user's nickname or roles change in a guild.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-member-update">Guild Member Update</a>
  */
@@ -56,32 +58,60 @@ public class MemberUpdateEvent extends GuildEvent {
         this.currentNickname = currentNickname;
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild involved in the event.
+     * @return The ID of the Guild involved.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild involved in the event.
+     * @return The guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the Snowflake ID of the Member involved in the event.
+     * @return The ID of the Member involved.
+     */
     public Snowflake getMemberId() {
         return Snowflake.of(memberId);
     }
 
+    /**
+     * Gets the Member involved in the event.
+     * @return The Member involved.
+     */
     public Mono<Member> getMember() {
         return getClient().getMemberById(getGuildId(), getMemberId());
     }
 
+    /**
+     * Gets the old version of the Member involved in the event. This may not be available if Members are not stored.
+     * @return the old version of the Member involved.
+     */
     public Optional<Member> getOld() {
         return Optional.ofNullable(old);
     }
 
+    /**
+     * Gets a list of Snowflake IDs of roles the Member is currently assigned.
+     * @return The IDs of the roles the Member is assigned.
+     */
     public Set<Snowflake> getCurrentRoles() {
         return Arrays.stream(currentRoles)
                 .mapToObj(Snowflake::of)
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Gets the current nickname of the Member involved in this event.
+     * @return The current nickname, if any, of the Member involved.
+     */
     public Optional<String> getCurrentNickname() {
         return Optional.ofNullable(currentNickname);
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -60,6 +60,7 @@ public class MemberUpdateEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the Guild involved in the event.
+     *
      * @return The ID of the Guild involved.
      */
     public Snowflake getGuildId() {
@@ -67,8 +68,9 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild involved in the event.
-     * @return The guild involved.
+     * Requests to retrieve the Guild involved in the event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild involved. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -76,6 +78,7 @@ public class MemberUpdateEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the Member involved in the event.
+     *
      * @return The ID of the Member involved.
      */
     public Snowflake getMemberId() {
@@ -83,16 +86,18 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Member involved in the event.
-     * @return The Member involved.
+     * Requests to retrieve the Member involved in the event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Member that has been updated. If an error is received, it is emitted through the Mono.
      */
     public Mono<Member> getMember() {
         return getClient().getMemberById(getGuildId(), getMemberId());
     }
 
     /**
-     * Gets the old version of the Member involved in the event. This may not be available if Members are not stored.
-     * @return the old version of the Member involved.
+     * Gets the old version of the Member involved in the event, if present. This may not be available if Members are not stored.
+     *
+     * @return the old version of the Member involved, if present.
      */
     public Optional<Member> getOld() {
         return Optional.ofNullable(old);
@@ -100,6 +105,7 @@ public class MemberUpdateEvent extends GuildEvent {
 
     /**
      * Gets a list of Snowflake IDs of roles the Member is currently assigned.
+     *
      * @return The IDs of the roles the Member is assigned.
      */
     public Set<Snowflake> getCurrentRoles() {
@@ -109,8 +115,9 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets the current nickname of the Member involved in this event.
-     * @return The current nickname, if any, of the Member involved.
+     * Gets the current nickname of the Member involved in this event, if present.
+     *
+     * @return The current nickname, if any, of the Member involved, if present.
      */
     public Optional<String> getCurrentNickname() {
         return Optional.ofNullable(currentNickname);

--- a/core/src/main/java/discord4j/core/event/domain/guild/UnbanEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/UnbanEvent.java
@@ -24,6 +24,8 @@ import reactor.core.publisher.Mono;
 
 /**
  * Dispatched when a user is unbanned from a guild.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-ban-remove">Guild Ban Remove</a>
  */
@@ -38,14 +40,26 @@ public class UnbanEvent extends GuildEvent {
         this.guildId = guildId;
     }
 
+    /**
+     * Gets the User that has been unbanned in this event.
+     * @return The User that has been unbanned.
+     */
     public User getUser() {
         return user;
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild the Member was unbanned from.
+     * @return The ID of the Guild involved.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild the Member was unbanned from.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }

--- a/core/src/main/java/discord4j/core/event/domain/guild/UnbanEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/UnbanEvent.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 /**
  * Dispatched when a user is unbanned from a guild.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-ban-remove">Guild Ban Remove</a>
  */
@@ -41,16 +41,16 @@ public class UnbanEvent extends GuildEvent {
     }
 
     /**
-     * Gets the User that has been unbanned in this event.
+     * Gets the {@link User} that has been unbanned in this event.
      *
-     * @return The User that has been unbanned.
+     * @return The {@link User} that has been unbanned.
      */
     public User getUser() {
         return user;
     }
 
     /**
-     * Gets the Snowflake ID of the Guild the Member was unbanned from.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link User} was unbanned from.
      *
      * @return The ID of the Guild involved.
      */
@@ -61,7 +61,8 @@ public class UnbanEvent extends GuildEvent {
     /**
      * Requests to retrieve the Guild the Member was unbanned from.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild the Member was unbanned from. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} the {@link User} was
+     * unbanned from. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/guild/UnbanEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/UnbanEvent.java
@@ -42,6 +42,7 @@ public class UnbanEvent extends GuildEvent {
 
     /**
      * Gets the User that has been unbanned in this event.
+     *
      * @return The User that has been unbanned.
      */
     public User getUser() {
@@ -50,6 +51,7 @@ public class UnbanEvent extends GuildEvent {
 
     /**
      * Gets the Snowflake ID of the Guild the Member was unbanned from.
+     *
      * @return The ID of the Guild involved.
      */
     public Snowflake getGuildId() {
@@ -57,8 +59,9 @@ public class UnbanEvent extends GuildEvent {
     }
 
     /**
-     * Gets the Guild the Member was unbanned from.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild the Member was unbanned from.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild the Member was unbanned from. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ConnectEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ConnectEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.DiscordClient;
 
 /**
  * Indicates that a gateway connection is successful.
+ * <p>
+ * This event is dispatched by Discord4J.
  */
 public class ConnectEvent extends GatewayLifecycleEvent {
 

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/DisconnectEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/DisconnectEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.DiscordClient;
 
 /**
  * Indicates that a gateway connection is disconnected.
+ * <p>
+ * This event is dispatched by Discord4J.
  */
 public class DisconnectEvent extends GatewayLifecycleEvent {
 

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReadyEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReadyEvent.java
@@ -60,21 +60,23 @@ public class ReadyEvent extends GatewayLifecycleEvent {
     }
 
     /**
-     * Gets the bot user.
+     * Gets the bot {@link User}.
      *
-     * @return The bot user.
+     * @return The bot {@link User}.
      */
     public User getSelf() {
         return self;
     }
 
     /**
-     * Gets a set of Unavailable Guilds. These guilds have not yet been provided via GuildCreate events
+     * Gets a set of Unavailable {@link Guild}. These {@code Guilds} have not yet been provided via a
+     * {@link discord4j.core.event.domain.guild.GuildCreateEvent}
      *
      *
-     * @see <a href="https://discordapp.com/developers/docs/resources/guild#unavailable-guild-object">Unavailable Guild Object</a>
+     * @see <a href="https://discordapp.com/developers/docs/resources/guild#unavailable-guild-object">
+     *     Unavailable Guild Object</a>
      *
-     * @return A set of unavailable guilds.
+     * @return A set of unavailable {@code Guilds}.
      */
     public Set<Guild> getGuilds() {
         return guilds;
@@ -90,7 +92,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
     }
 
     /**
-     * Gets the trace provided by Discord. Used for debugging - The guilds the user is in.
+     * Gets the trace provided by Discord. Used for debugging - The {@code Guilds} the user is in.
      *
      * @return The trace provided by Discord.
      */
@@ -112,16 +114,17 @@ public class ReadyEvent extends GatewayLifecycleEvent {
         }
 
         /**
-         * Gets the Snowflake ID of the guild.
+         * Gets the {@link Snowflake} ID of the guild.
          *
-         * @return the Snowflake ID of the guild.
+         * @return the {@link Snowflake} ID of the guild.
          */
         public Snowflake getId() {
             return Snowflake.of(id);
         }
 
         /**
-         * Whether or not the Guild has been made available via a {@link discord4j.core.event.domain.guild.GuildCreateEvent}
+         * Whether or not the Guild has been made available via a
+         * {@link discord4j.core.event.domain.guild.GuildCreateEvent}
          *
          * @return Whether or not the Guild has been made available yet.
          */

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReadyEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReadyEvent.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 /**
  * Dispatched when an initial connection to the Discord gateway has been established.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#ready">Ready</a>
  */
@@ -48,26 +50,52 @@ public class ReadyEvent extends GatewayLifecycleEvent {
         this.trace = trace;
     }
 
+    /**
+     * Gets the gateway protocol version being used. Ex. 6.
+     * @return The gateway protocol version being used.
+     */
     public int getGatewayVersion() {
         return gatewayVersion;
     }
 
+    /**
+     * Gets the bot user.
+     * @return The bot user.
+     */
     public User getSelf() {
         return self;
     }
 
+    /**
+     * Gets a set of Unavailable Guilds. These guilds have not yet been provided via GuildCreate events
+     *
+     *
+     * @see <a href="https://discordapp.com/developers/docs/resources/guild#unavailable-guild-object">Unavailable Guild Object</a>
+     * @return A set of unavailable guilds.
+     */
     public Set<Guild> getGuilds() {
         return guilds;
     }
 
+    /**
+     * Gets the current session ID of the connection.
+     * @return the session ID of the connection
+     */
     public String getSessionId() {
         return sessionId;
     }
 
+    /**
+     * Gets the trace provided by Discord. Used for debugging - The guilds the user is in.
+     * @return The trace provided by Discord.
+     */
     public String[] getTrace() {
         return trace;
     }
 
+    /**
+     * An incomplete Guild provided by Discord upon the ready event
+     */
     public static class Guild {
 
         private final long id;
@@ -78,10 +106,18 @@ public class ReadyEvent extends GatewayLifecycleEvent {
             this.available = available;
         }
 
+        /**
+         * Gets the Snowflake ID of the guild.
+         * @return the Snowflake ID of the guild.
+         */
         public Snowflake getId() {
             return Snowflake.of(id);
         }
 
+        /**
+         * Whether or not the Guild has been made available via a {@link discord4j.core.event.domain.guild.GuildCreateEvent}
+         * @return Whether or not the Guild has been made available yet.
+         */
         public boolean isAvailable() {
             return available;
         }

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReadyEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReadyEvent.java
@@ -52,6 +52,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the gateway protocol version being used. Ex. 6.
+     *
      * @return The gateway protocol version being used.
      */
     public int getGatewayVersion() {
@@ -60,6 +61,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the bot user.
+     *
      * @return The bot user.
      */
     public User getSelf() {
@@ -71,6 +73,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
      *
      *
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#unavailable-guild-object">Unavailable Guild Object</a>
+     *
      * @return A set of unavailable guilds.
      */
     public Set<Guild> getGuilds() {
@@ -79,6 +82,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the current session ID of the connection.
+     *
      * @return the session ID of the connection
      */
     public String getSessionId() {
@@ -87,6 +91,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the trace provided by Discord. Used for debugging - The guilds the user is in.
+     *
      * @return The trace provided by Discord.
      */
     public String[] getTrace() {
@@ -108,6 +113,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
 
         /**
          * Gets the Snowflake ID of the guild.
+         *
          * @return the Snowflake ID of the guild.
          */
         public Snowflake getId() {
@@ -116,6 +122,7 @@ public class ReadyEvent extends GatewayLifecycleEvent {
 
         /**
          * Whether or not the Guild has been made available via a {@link discord4j.core.event.domain.guild.GuildCreateEvent}
+         *
          * @return Whether or not the Guild has been made available yet.
          */
         public boolean isAvailable() {

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectEvent.java
@@ -21,6 +21,8 @@ import discord4j.core.DiscordClient;
 
 /**
  * Indicates that a gateway connection has correctly reconnected.
+ * <p>
+ * This event is dispatched by Discord4J.
  */
 public class ReconnectEvent extends GatewayLifecycleEvent {
 
@@ -31,6 +33,10 @@ public class ReconnectEvent extends GatewayLifecycleEvent {
         this.currentAttempt = currentAttempt;
     }
 
+    /**
+     * Gets the current reconnect attempt.
+     * @return The current reconnect attempt.
+     */
     public int getCurrentAttempt() {
         return currentAttempt;
     }

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectEvent.java
@@ -35,6 +35,7 @@ public class ReconnectEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the current reconnect attempt.
+     *
      * @return The current reconnect attempt.
      */
     public int getCurrentAttempt() {

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectFailEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectFailEvent.java
@@ -39,6 +39,8 @@ import discord4j.core.DiscordClient;
 /**
  * Indicates that a reconnection attempt has failed and a new attempt should be scheduled, in that case, this event
  * will be followed by a {@link ReconnectStartEvent}.
+ * <p>
+ * This event is dispatched by Discord4J.
  */
 public class ReconnectFailEvent extends GatewayLifecycleEvent {
 
@@ -49,6 +51,10 @@ public class ReconnectFailEvent extends GatewayLifecycleEvent {
         this.currentAttempt = currentAttempt;
     }
 
+    /**
+     * Gets the current reconnect attempt.
+     * @return The current reconnect attempt.
+     */
     public int getCurrentAttempt() {
         return currentAttempt;
     }

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectFailEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectFailEvent.java
@@ -53,6 +53,7 @@ public class ReconnectFailEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the current reconnect attempt.
+     *
      * @return The current reconnect attempt.
      */
     public int getCurrentAttempt() {

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectStartEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ReconnectStartEvent.java
@@ -15,23 +15,6 @@
  * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*
- * This file is part of Discord4J.
- *
- * Discord4J is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Discord4J is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
- */
-
 package discord4j.core.event.domain.lifecycle;
 
 import discord4j.core.DiscordClient;
@@ -39,6 +22,8 @@ import discord4j.core.DiscordClient;
 /**
  * Indicates that a gateway connection is starting a reconnect attempt. Can be followed by {@link ReconnectEvent} if
  * successful, or {@link ReconnectFailEvent} if not.
+ * <p>
+ * This event is dispatched by Discord4J.
  */
 public class ReconnectStartEvent extends GatewayLifecycleEvent {
 

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ResumeEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ResumeEvent.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 
 /**
  * Dispatched when the gateway connection is successfully resumed.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#resumed">Resumed</a>
  */
@@ -34,6 +36,10 @@ public class ResumeEvent extends GatewayLifecycleEvent {
         this.trace = trace;
     }
 
+    /**
+     * Gets the trace of the event. Used for debugging - the guilds the user is in.
+     * @return The trace provided by Discord, containing the guild the user is in.
+     */
     public String[] getTrace() {
         return trace;
     }

--- a/core/src/main/java/discord4j/core/event/domain/lifecycle/ResumeEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/lifecycle/ResumeEvent.java
@@ -38,6 +38,7 @@ public class ResumeEvent extends GatewayLifecycleEvent {
 
     /**
      * Gets the trace of the event. Used for debugging - the guilds the user is in.
+     *
      * @return The trace provided by Discord, containing the guild the user is in.
      */
     public String[] getTrace() {

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageBulkDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageBulkDeleteEvent.java
@@ -32,6 +32,8 @@ import java.util.stream.Collectors;
  * <p>
  * Corresponding {@link discord4j.core.event.domain.message.MessageDeleteEvent message deletes} are NOT dispatched for
  * messages included in this event.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-delete-bulk">Message Delete Bulk</a>
  */
@@ -51,28 +53,52 @@ public class MessageBulkDeleteEvent extends MessageEvent {
         this.messages = messages;
     }
 
+    /**
+     * Gets a list of Snowflake IDs of the messages that were deleted.
+     * @return a list of IDs of the messages that were deleted.
+     */
     public Set<Snowflake> getMessageIds() {
         return Arrays.stream(messageIds)
                 .mapToObj(Snowflake::of)
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Gets a list of Messages there were deleted in this event.
+     * @return a list of Messages that were deleted.
+     */
     public Set<Message> getMessages() {
         return messages;
     }
 
+    /**
+     * Gets the Snowflake ID of the Channel the messages were deleted in.
+     * @return The ID of the channel that the messages were deleted in.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel representation of the channel the messages were deleted in.
+     * @return The MessageChannel the messages were deleted in.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild the messages were deleted in.
+     * @return The ID of the Guild the messages were deleted in.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild the messages were deleted in.
+     * @return The Guild the messages were deleted in.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageBulkDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageBulkDeleteEvent.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * Corresponding {@link discord4j.core.event.domain.message.MessageDeleteEvent message deletes} are NOT dispatched for
  * messages included in this event.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-delete-bulk">Message Delete Bulk</a>
  */
@@ -54,7 +54,7 @@ public class MessageBulkDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets a list of Snowflake IDs of the messages that were deleted.
+     * Gets a list of {@link Snowflake} IDs of the messages that were deleted.
      *
      * @return a list of IDs of the messages that were deleted.
      */
@@ -65,45 +65,48 @@ public class MessageBulkDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets a list of Messages there were deleted in this event.
+     * Gets a list of {@link Message} objects there were deleted in this event.
      *
-     * @return a list of Messages that were deleted.
+     * @return a list of {@link Message} objects that were deleted.
      */
     public Set<Message> getMessages() {
         return messages;
     }
 
     /**
-     * Gets the Snowflake ID of the Channel the messages were deleted in.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the messages were deleted in.
      *
-     * @return The ID of the channel that the messages were deleted in.
+     * @return The ID of the {@link MessageChannel} that the messages were deleted in.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel representation of the channel the messages were deleted in.
+     * Requests to retrieve the {@link MessageChannel} representation of the {@code Channel} the messages were deleted
+     * in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel the messages were deleted from. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} the messages
+     * were deleted from. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the Snowflake ID of the Guild the messages were deleted in.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the messages were deleted in.
      *
-     * @return The ID of the Guild the messages were deleted in.
+     * @return The ID of the {@link Guild} the messages were deleted in.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild the messages were deleted in.
+     * Requests to retrieve the {@link Guild} the messages were deleted in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild the messages where deleted from. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} the messages
+     * where deleted from. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageBulkDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageBulkDeleteEvent.java
@@ -55,6 +55,7 @@ public class MessageBulkDeleteEvent extends MessageEvent {
 
     /**
      * Gets a list of Snowflake IDs of the messages that were deleted.
+     *
      * @return a list of IDs of the messages that were deleted.
      */
     public Set<Snowflake> getMessageIds() {
@@ -65,6 +66,7 @@ public class MessageBulkDeleteEvent extends MessageEvent {
 
     /**
      * Gets a list of Messages there were deleted in this event.
+     *
      * @return a list of Messages that were deleted.
      */
     public Set<Message> getMessages() {
@@ -73,6 +75,7 @@ public class MessageBulkDeleteEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the Channel the messages were deleted in.
+     *
      * @return The ID of the channel that the messages were deleted in.
      */
     public Snowflake getChannelId() {
@@ -80,8 +83,9 @@ public class MessageBulkDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets the MessageChannel representation of the channel the messages were deleted in.
-     * @return The MessageChannel the messages were deleted in.
+     * Requests to retrieve the MessageChannel representation of the channel the messages were deleted in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel the messages were deleted from. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
@@ -89,6 +93,7 @@ public class MessageBulkDeleteEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the Guild the messages were deleted in.
+     *
      * @return The ID of the Guild the messages were deleted in.
      */
     public Snowflake getGuildId() {
@@ -96,8 +101,9 @@ public class MessageBulkDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Guild the messages were deleted in.
-     * @return The Guild the messages were deleted in.
+     * Requests to retrieve the Guild the messages were deleted in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild the messages where deleted from. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageCreateEvent.java
@@ -52,6 +52,7 @@ public class MessageCreateEvent extends MessageEvent {
 
     /**
      * Gets the message that was created in this event.
+     *
      * @return The Message that was created.
      */
     public Message getMessage() {
@@ -59,24 +60,27 @@ public class MessageCreateEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the guild the Message was created in. This may not be available if the message was sent in a private channel.
-     * @return The ID of the guild containing the message.
+     * Gets the Snowflake ID of the guild the Message was created in, if present. This may not be available if the message was sent in a private channel.
+     *
+     * @return The ID of the guild containing the message, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Gets the guild the Message was created in. This may not be available if the message was sent in a private channel.
-     * @return The guild containing the message.
+     * Requests to retrieve the guild the Message was created in, if present. This may not be available if the message was sent in a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild the message was created in, if present. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**
-     * Gets the Member who has sent the message created in this event. This may not be available if the message was sent in a private channel.
-     * @return The Member who has sent the message created in this event.
+     * Gets the Member who has sent the message created in this event, if present. This may not be available if the message was sent in a private channel.
+     *
+     * @return The Member who has sent the message created in this event, if present.
      */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageCreateEvent.java
@@ -30,6 +30,8 @@ import java.util.Optional;
  * Dispatched when a message is sent in a message channel.
  * <p>
  * {@link #guildId} and {@link #member} may not be present if the message was sent in a private channel.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-create">Message Create</a>
  */
@@ -48,18 +50,34 @@ public class MessageCreateEvent extends MessageEvent {
         this.member = member;
     }
 
+    /**
+     * Gets the message that was created in this event.
+     * @return The Message that was created.
+     */
     public Message getMessage() {
         return message;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild the Message was created in. This may not be available if the message was sent in a private channel.
+     * @return The ID of the guild containing the message.
+     */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
+    /**
+     * Gets the guild the Message was created in. This may not be available if the message was sent in a private channel.
+     * @return The guild containing the message.
+     */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
+    /**
+     * Gets the Member who has sent the message created in this event. This may not be available if the message was sent in a private channel.
+     * @return The Member who has sent the message created in this event.
+     */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageCreateEvent.java
@@ -51,36 +51,40 @@ public class MessageCreateEvent extends MessageEvent {
     }
 
     /**
-     * Gets the message that was created in this event.
+     * Gets the {@link Message} that was created in this event.
      *
-     * @return The Message that was created.
+     * @return The {@link Message} that was created.
      */
     public Message getMessage() {
         return message;
     }
 
     /**
-     * Gets the Snowflake ID of the guild the Message was created in, if present. This may not be available if the message was sent in a private channel.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Message} was created in, if present.
+     * This may not be available if the {@code Message} was sent in a private channel.
      *
-     * @return The ID of the guild containing the message, if present.
+     * @return The ID of the {@link Guild} containing the {@link Message}, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Requests to retrieve the guild the Message was created in, if present. This may not be available if the message was sent in a private channel.
+     * Requests to retrieve the {@link Guild} the {@link Message} was created in, if present.
+     * This may not be available if the {@code Message} was sent in a private channel.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild the message was created in, if present. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} the message was created in,
+     * if present. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**
-     * Gets the Member who has sent the message created in this event, if present. This may not be available if the message was sent in a private channel.
+     * Gets the {@link Member} who has sent the {@link Message} created in this event, if present.
+     * This may not be available if the {@code Message} was sent in a private channel.
      *
-     * @return The Member who has sent the message created in this event, if present.
+     * @return The {@link Member} who has sent the {@link Message} created in this event, if present.
      */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
@@ -50,6 +50,7 @@ public class MessageDeleteEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the message that was deleted.
+     *
      * @return The ID of the deleted message.
      */
     public Snowflake getMessageId() {
@@ -57,8 +58,9 @@ public class MessageDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Message that was deleted in this event. This may not be available if messages are not stored.
-     * @return The deleted message.
+     * Gets the Message that was deleted in this event, if present. This may not be available if messages are not stored.
+     *
+     * @return The deleted message, if present.
      */
     public Optional<Message> getMessage() {
         return Optional.ofNullable(message);
@@ -66,6 +68,7 @@ public class MessageDeleteEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the channel the message was deleted from.
+     *
      * @return The ID of the channel that the message was deleted from.
      */
     public Snowflake getChannelId() {
@@ -73,8 +76,9 @@ public class MessageDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets the MessageChannel the Message was deleted from.
-     * @return The MessageChannel the Message was deleted from.
+     * Requests to retrieve the MessageChannel the Message was deleted from.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel the message was deleted in. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
@@ -49,36 +49,38 @@ public class MessageDeleteEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the message that was deleted.
+     * Gets the {@link Snowflake} ID of the {@link Message} that was deleted.
      *
-     * @return The ID of the deleted message.
+     * @return The ID of the deleted {@link Message}.
      */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
     /**
-     * Gets the Message that was deleted in this event, if present. This may not be available if messages are not stored.
+     * Gets the {@link Message} that was deleted in this event, if present.
+     * This may not be available if {@code Messages} are not stored.
      *
-     * @return The deleted message, if present.
+     * @return The deleted {@link Message}, if present.
      */
     public Optional<Message> getMessage() {
         return Optional.ofNullable(message);
     }
 
     /**
-     * Gets the Snowflake ID of the channel the message was deleted from.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the {@link Message} was deleted from.
      *
-     * @return The ID of the channel that the message was deleted from.
+     * @return The ID of the {@link MessageChannel} that the {@link Message} was deleted from.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel the Message was deleted from.
+     * Requests to retrieve the {@link MessageChannel} the {@link Message} was deleted from.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel the message was deleted in. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} the
+     * {@link Message} was deleted in. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
@@ -29,6 +29,8 @@ import java.util.Optional;
  * Dispatched when a message is deleted.
  * <p>
  * The deleted message may not be present if messages are not stored.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-delete">Message Delete</a>
  */
@@ -46,18 +48,34 @@ public class MessageDeleteEvent extends MessageEvent {
         this.message = message;
     }
 
+    /**
+     * Gets the Snowflake ID of the message that was deleted.
+     * @return The ID of the deleted message.
+     */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
+    /**
+     * Gets the Message that was deleted in this event. This may not be available if messages are not stored.
+     * @return The deleted message.
+     */
     public Optional<Message> getMessage() {
         return Optional.ofNullable(message);
     }
 
+    /**
+     * Gets the Snowflake ID of the channel the message was deleted from.
+     * @return The ID of the channel that the message was deleted from.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel the Message was deleted from.
+     * @return The MessageChannel the Message was deleted from.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageUpdateEvent.java
@@ -70,99 +70,103 @@ public class MessageUpdateEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the message that has been updated in this event.
+     * Gets the {@link Snowflake} ID of the {@link Message} that has been updated in this event.
      *
-     * @return THe ID of the message.
+     * @return THe ID of the {@link Message}.
      */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
     /**
-     * Requests to retrieve the Message that has been updated in this event.
+     * Requests to retrieve the {@link Message} that has been updated in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Message that was updated. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Message} that was updated.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the channel containing the updated Message.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} containing the updated {@link Message}.
      *
-     * @return The ID of the channel containing the updated Message.
+     * @return The ID of the {@link MessageChannel} containing the updated {@link Message}.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the Channel containing the updated Message in this event.
+     * Requests to retrieve the {@link MessageChannel} containing the updated {@link Message} in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing the
+     * {@link Message}. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * The Snowflake ID of the Guild containing the updated Message in this event, if present.
+     * The {@link Snowflake} ID of the {@link Guild} containing the updated {@link Message} in this event, if present.
      *
-     * @return The ID of the guild containing the updated Message, if present.
+     * @return The ID of the {@link Guild} containing the updated {@link Message}, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Request to retrieve the Guild containing the updated Message in this event.
+     * Request to retrieve the {@link Guild} containing the updated {@link Message} in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the updated message. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the updated
+     * {@link Message}. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**
-     * Gets the old version of the updated Message, if present. This may not be available if messages are not stored.
+     * Gets the old version of the updated {@link Message}, if present.
+     * This may not be available if {@code Messages} are not stored.
      *
-     * @return The old version of the updated Message, if present.
+     * @return The old version of the updated {@link Message}, if present.
      */
     public Optional<Message> getOld() {
         return Optional.ofNullable(old);
     }
 
     /**
-     * Gets whether or not the content of the message has been changed in this event.
+     * Gets whether or not the content of the {@link Message} has been changed in this event.
      *
-     * @return Whether or not the content of the message has been changed.
+     * @return Whether or not the content of the {@link Message} has been changed.
      */
     public boolean isContentChanged() {
         return contentChanged;
     }
 
     /**
-     * Gets the current, new, version of the message's content in this event, if present.
+     * Gets the current, new, version of the {@link Message}'s content in this event, if present.
      *
-     * @return The current version of the Message's content, if present.
+     * @return The current version of the {@link Message}'s content, if present.
      */
     public Optional<String> getCurrentContent() {
         return Optional.ofNullable(currentContent);
     }
 
     /**
-     * Gets whether or not the embed in the message has been changed in this event.
+     * Gets whether or not the {@link Embed} in the {@link Message} has been changed in this event.
      *
-     * @return Whether or not the embed in the message has been changed.
+     * @return Whether or not the {@link Embed} in the {@link Message} has been changed.
      */
     public boolean isEmbedsChanged() {
         return embedsChanged;
     }
 
     /**
-     * Gets the current, new, version of the message's embed in this event.
+     * Gets the current, new, version of the {@link Message}'s {@link Embed} in this event.
      *
-     * @return The current version of the Message's embed.
+     * @return The current version of the {@link Message}'s {@link Embed}.
      */
     public List<Embed> getCurrentEmbeds() {
         return currentEmbeds;

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageUpdateEvent.java
@@ -34,6 +34,8 @@ import java.util.Optional;
  * This event includes both normal message editing as well as the following behavior regarding embeds:
  * When a message with a link is sent, it does not initially contain its embed. When Discord creates the embed, this
  * event is fired with it added to the embeds list.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-update">Message Update</a>
  */
@@ -67,46 +69,90 @@ public class MessageUpdateEvent extends MessageEvent {
         this.currentEmbeds = currentEmbeds;
     }
 
+    /**
+     * Gets the Snowflake ID of the message that has been updated in this event.
+     * @return THe ID of the message.
+     */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
+    /**
+     * Gets the Message that has been updated in this event.
+     * @return The message that has been updated.
+     */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
+    /**
+     * Gets the Snowflake ID of the channel containing the updated Message.
+     * @return The ID of the channel containing the updated Message.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the Channel containing the updated Message in this event.
+     * @return The Channel containing the updated Message.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * The Snowflake ID of the Guild containing the updated Message in this event.
+     * @return The ID of the guild containing the updated Message.
+     */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
+    /**
+     * Gets the Guild containing the updated Message in this event.
+     * @return The Guild containing the updated Message.
+     */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
+    /**
+     * Gets the old version of the updated Message. This may not be available if messages are not stored.
+     * @return The old version of the updated Message.
+     */
     public Optional<Message> getOld() {
         return Optional.ofNullable(old);
     }
 
+    /**
+     * gets whether or not the content of the message has been changed in this event.
+     * @return Whether or not the content of the message has been changed.
+     */
     public boolean isContentChanged() {
         return contentChanged;
     }
 
+    /**
+     * Gets the current, new, version of the message's content in this event.
+     * @return The current version of the Message's content.
+     */
     public Optional<String> getCurrentContent() {
         return Optional.ofNullable(currentContent);
     }
 
+    /**
+     * Gets whether or not the embed in the message has been changed in this event.
+     * @return Whether or not the embed in the message has been changed.
+     */
     public boolean isEmbedsChanged() {
         return embedsChanged;
     }
 
+    /**
+     * Gets the current, new, version of the message's embed in this event.
+     * @return The current version of the Message's embed.
+     */
     public List<Embed> getCurrentEmbeds() {
         return currentEmbeds;
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageUpdateEvent.java
@@ -71,6 +71,7 @@ public class MessageUpdateEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the message that has been updated in this event.
+     *
      * @return THe ID of the message.
      */
     public Snowflake getMessageId() {
@@ -78,8 +79,9 @@ public class MessageUpdateEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Message that has been updated in this event.
-     * @return The message that has been updated.
+     * Requests to retrieve the Message that has been updated in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Message that was updated. If an error is received, it is emitted through the Mono.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
@@ -87,6 +89,7 @@ public class MessageUpdateEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the channel containing the updated Message.
+     *
      * @return The ID of the channel containing the updated Message.
      */
     public Snowflake getChannelId() {
@@ -94,39 +97,44 @@ public class MessageUpdateEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Channel containing the updated Message in this event.
-     * @return The Channel containing the updated Message.
+     * Requests to retrieve the Channel containing the updated Message in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * The Snowflake ID of the Guild containing the updated Message in this event.
-     * @return The ID of the guild containing the updated Message.
+     * The Snowflake ID of the Guild containing the updated Message in this event, if present.
+     *
+     * @return The ID of the guild containing the updated Message, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Gets the Guild containing the updated Message in this event.
-     * @return The Guild containing the updated Message.
+     * Request to retrieve the Guild containing the updated Message in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the updated message. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**
-     * Gets the old version of the updated Message. This may not be available if messages are not stored.
-     * @return The old version of the updated Message.
+     * Gets the old version of the updated Message, if present. This may not be available if messages are not stored.
+     *
+     * @return The old version of the updated Message, if present.
      */
     public Optional<Message> getOld() {
         return Optional.ofNullable(old);
     }
 
     /**
-     * gets whether or not the content of the message has been changed in this event.
+     * Gets whether or not the content of the message has been changed in this event.
+     *
      * @return Whether or not the content of the message has been changed.
      */
     public boolean isContentChanged() {
@@ -134,8 +142,9 @@ public class MessageUpdateEvent extends MessageEvent {
     }
 
     /**
-     * Gets the current, new, version of the message's content in this event.
-     * @return The current version of the Message's content.
+     * Gets the current, new, version of the message's content in this event, if present.
+     *
+     * @return The current version of the Message's content, if present.
      */
     public Optional<String> getCurrentContent() {
         return Optional.ofNullable(currentContent);
@@ -143,6 +152,7 @@ public class MessageUpdateEvent extends MessageEvent {
 
     /**
      * Gets whether or not the embed in the message has been changed in this event.
+     *
      * @return Whether or not the embed in the message has been changed.
      */
     public boolean isEmbedsChanged() {
@@ -151,6 +161,7 @@ public class MessageUpdateEvent extends MessageEvent {
 
     /**
      * Gets the current, new, version of the message's embed in this event.
+     *
      * @return The current version of the Message's embed.
      */
     public List<Embed> getCurrentEmbeds() {

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
@@ -32,6 +32,8 @@ import java.util.Optional;
  * Dispatched when a reaction is added to a message.
  * <p>
  * {@link #guildId} may not be present if the message was in a private channel.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-reaction-add">Message Reaction Add</a>
  */
@@ -54,38 +56,74 @@ public class ReactionAddEvent extends MessageEvent {
         this.emoji = emoji;
     }
 
+    /**
+     * Gets the Snowflake ID of the User who added a reaction in this event.
+     * @return The Id of the User who added a reaction.
+     */
     public Snowflake getUserId() {
         return Snowflake.of(userId);
     }
 
+    /**
+     * The User who added a reaction in this event.
+     * @return The user who added a reaction.
+     */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
+    /**
+     * Gets the Snowflake ID of the channel the message and reaction are in.
+     * @return The ID of the channel involved.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel the message and reaction are in.
+     * @return The MessageChannel involved.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * Gets the Snowflake ID of the message the reaction was added to in this event.
+     * @return The ID of the message the reaction was added to.
+     */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
+    /**
+     * Gets the Message the reaction was added to in this event.
+     * @return The Message the reaction was added to.
+     */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild containing the Message and Reaction. This may not be available if the reaction is to a message in a private channel.
+     * @return The ID of the guild involved in the event.
+     */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
+    /**
+     * Gets the Guild containing the Message and reaction. This may not be available if the reaction is to a message in a private channel.
+     * @return The Guild involved in this event.
+     */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
+    /**
+     * Gets the ReactionEmoji that was added to the Message in this event.
+     * @return The emoji added to the message as a reaction.
+     */
     public ReactionEmoji getEmoji() {
         return emoji;
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
@@ -58,6 +58,7 @@ public class ReactionAddEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the User who added a reaction in this event.
+     *
      * @return The Id of the User who added a reaction.
      */
     public Snowflake getUserId() {
@@ -65,8 +66,9 @@ public class ReactionAddEvent extends MessageEvent {
     }
 
     /**
-     * The User who added a reaction in this event.
-     * @return The user who added a reaction.
+     * Requests to retrieve the User who added a reaction in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the User that has added the reaction. If an error is received, it is emitted through the Mono.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
@@ -74,6 +76,7 @@ public class ReactionAddEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the channel the message and reaction are in.
+     *
      * @return The ID of the channel involved.
      */
     public Snowflake getChannelId() {
@@ -81,8 +84,9 @@ public class ReactionAddEvent extends MessageEvent {
     }
 
     /**
-     * Gets the MessageChannel the message and reaction are in.
-     * @return The MessageChannel involved.
+     * Requests to retrieve the MessageChannel the message and reaction are in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message in the event. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
@@ -90,6 +94,7 @@ public class ReactionAddEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the message the reaction was added to in this event.
+     *
      * @return The ID of the message the reaction was added to.
      */
     public Snowflake getMessageId() {
@@ -97,24 +102,27 @@ public class ReactionAddEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Message the reaction was added to in this event.
-     * @return The Message the reaction was added to.
+     * Request to retrieve the Message the reaction was added to in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Message the reaction was added to. If an error is received, it is emitted through the Mono.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the Guild containing the Message and Reaction. This may not be available if the reaction is to a message in a private channel.
-     * @return The ID of the guild involved in the event.
+     * Gets the Snowflake ID of the Guild containing the Message and Reaction, if present. This may not be available if the reaction is to a message in a private channel.
+     *
+     * @return The ID of the guild involved in the event, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Gets the Guild containing the Message and reaction. This may not be available if the reaction is to a message in a private channel.
-     * @return The Guild involved in this event.
+     * Request to retrieve the Guild containing the Message and reaction, if present. This may not be available if the reaction is to a message in a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the message involved, if present. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
@@ -122,6 +130,7 @@ public class ReactionAddEvent extends MessageEvent {
 
     /**
      * Gets the ReactionEmoji that was added to the Message in this event.
+     *
      * @return The emoji added to the message as a reaction.
      */
     public ReactionEmoji getEmoji() {

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  * <p>
  * {@link #guildId} may not be present if the message was in a private channel.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-reaction-add">Message Reaction Add</a>
  */
@@ -57,81 +57,87 @@ public class ReactionAddEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the User who added a reaction in this event.
+     * Gets the {@link Snowflake} ID of the {@link User} who added a reaction in this event.
      *
-     * @return The Id of the User who added a reaction.
+     * @return The Id of the {@link User} who added a reaction.
      */
     public Snowflake getUserId() {
         return Snowflake.of(userId);
     }
 
     /**
-     * Requests to retrieve the User who added a reaction in this event.
+     * Requests to retrieve the {@link User} who added a reaction in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the User that has added the reaction. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User} that has added the reaction.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
     /**
-     * Gets the Snowflake ID of the channel the message and reaction are in.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the {@link Message} and reaction are in.
      *
-     * @return The ID of the channel involved.
+     * @return The ID of the {@link MessageChannel} involved.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel the message and reaction are in.
+     * Requests to retrieve the {@link MessageChannel} the {@link Message} and reaction are in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message in the event. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing
+     * the {@link Message} in the event. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the Snowflake ID of the message the reaction was added to in this event.
+     * Gets the {@link Snowflake} ID of the {@link Message} the reaction was added to in this event.
      *
-     * @return The ID of the message the reaction was added to.
+     * @return The ID of the {@link Message} the reaction was added to.
      */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
     /**
-     * Request to retrieve the Message the reaction was added to in this event.
+     * Request to retrieve the {@link Message} the reaction was added to in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Message the reaction was added to. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Message} the reaction was added to.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the Guild containing the Message and Reaction, if present. This may not be available if the reaction is to a message in a private channel.
+     * Gets the {@link Snowflake} ID of the {@link Guild} containing the {@link Message} and Reaction, if present.
+     * This may not be available if the reaction is to a {@code Message} in a private channel.
      *
-     * @return The ID of the guild involved in the event, if present.
+     * @return The ID of the {@link Guild} involved in the event, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Request to retrieve the Guild containing the Message and reaction, if present. This may not be available if the reaction is to a message in a private channel.
+     * Request to retrieve the {@link Guild} containing the {@link Message} and reaction, if present.
+     * This may not be available if the reaction is to a {@code Message} in a private channel.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the message involved, if present. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the {@link Message}
+     * involved, if present. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**
-     * Gets the ReactionEmoji that was added to the Message in this event.
+     * Gets the {@link ReactionEmoji} that was added to the {@link Message} in this event.
      *
-     * @return The emoji added to the message as a reaction.
+     * @return The {@code Emoji} added to the {@link Message} as a reaction.
      */
     public ReactionEmoji getEmoji() {
         return emoji;

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
@@ -54,54 +54,60 @@ public class ReactionRemoveAllEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the channel containing the Message and the removed Reactions.
+     * Gets the {@link Snowflake} ID of the channel containing the {@link Message} and the removed Reactions.
      *
-     * @return The ID of the channel involved.
+     * @return The ID of the {@link MessageChannel} involved.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel containing the Message and the removed reactions.
+     * Requests to retrieve the {@link MessageChannel} containing the {@link Message} and the removed reactions.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message involved. If an error is received, it is emitted through the Mono
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing the message
+     * involved. If an error is received, it is emitted through the {@code Mono}
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the Snowflake ID of the message the reactions were removed from in this event.
+     * Gets the {@link Snowflake} ID of the {@link Message} the reactions were removed from in this event.
      *
-     * @return The ID of the message involved.
+     * @return The ID of the {@link Message} involved.
      */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
     /**
-     * Requests to retrieve the Message the reactions were removed from in this event.
+     * Requests to retrieve the {@link Message} the reactions were removed from in this event.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Message the reactions were removed from. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Message} the reactions were
+     * removed from. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the Guild containing the Message the reactions were removed from, if present. This may not be available if the message was sent in a private channel.
+     * Gets the {@link Snowflake} ID of the {@link Guild} containing the {@link Message} the
+     * reactions were removed from, if present.
+     * This may not be available if the {@code Message} was sent in a private channel.
      *
-     * @return The ID of the Guild containing the message involved, if present.
+     * @return The ID of the {@link Guild} containing the {@link Message} involved, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Request to retrieve the Guild containing the Message the reactions were removed from, if present. This may not if the message was sent in a private channel.
+     * Request to retrieve the {@link Guild} containing the {@link Message} the reactions were removed from, if present.
+     * This may not if the {@code Message} was sent in a private channel.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the message involved, if present. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing
+     * the {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
@@ -33,6 +33,8 @@ import java.util.Optional;
  * <p>
  * Corresponding {@link discord4j.core.event.domain.message.ReactionRemoveEvent reactions removes} are NOT dispatched
  * for messages included in this event.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-reaction-remove-all">Message Reaction
  * Remove All</a>
@@ -51,26 +53,50 @@ public class ReactionRemoveAllEvent extends MessageEvent {
         this.guildId = guildId;
     }
 
+    /**
+     * Gets the Snowflake ID of the channel containing the Message and the removed Reactions.
+     * @return The ID of the channel involved.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel containing the Message and the removed reactions.
+     * @return The channel involved.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * Gets the Snowflake ID of the message the reactions were removed from in this event.
+     * @return The ID of the message involved.
+     */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
+    /**
+     * Gets the Message the reactions were removed from in this event.
+     * @return The message involved.
+     */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild containing the Message the reactions were removed from. This may not be available if the message was sent in a private channel.
+     * @return The ID of the Guild containing the message involved.
+     */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
+    /**
+     * Gets the Guild containing the Message the reactions were removed from. This may not if the message was sent in a private channel.
+     * @return The Guild containing the message involved.
+     */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
@@ -55,6 +55,7 @@ public class ReactionRemoveAllEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the channel containing the Message and the removed Reactions.
+     *
      * @return The ID of the channel involved.
      */
     public Snowflake getChannelId() {
@@ -62,8 +63,9 @@ public class ReactionRemoveAllEvent extends MessageEvent {
     }
 
     /**
-     * Gets the MessageChannel containing the Message and the removed reactions.
-     * @return The channel involved.
+     * Requests to retrieve the MessageChannel containing the Message and the removed reactions.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message involved. If an error is received, it is emitted through the Mono
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
@@ -71,6 +73,7 @@ public class ReactionRemoveAllEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the message the reactions were removed from in this event.
+     *
      * @return The ID of the message involved.
      */
     public Snowflake getMessageId() {
@@ -78,24 +81,27 @@ public class ReactionRemoveAllEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Message the reactions were removed from in this event.
-     * @return The message involved.
+     * Requests to retrieve the Message the reactions were removed from in this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Message the reactions were removed from. If an error is received, it is emitted through the Mono.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the Guild containing the Message the reactions were removed from. This may not be available if the message was sent in a private channel.
-     * @return The ID of the Guild containing the message involved.
+     * Gets the Snowflake ID of the Guild containing the Message the reactions were removed from, if present. This may not be available if the message was sent in a private channel.
+     *
+     * @return The ID of the Guild containing the message involved, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Gets the Guild containing the Message the reactions were removed from. This may not if the message was sent in a private channel.
-     * @return The Guild containing the message involved.
+     * Request to retrieve the Guild containing the Message the reactions were removed from, if present. This may not if the message was sent in a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the message involved, if present. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
@@ -32,6 +32,8 @@ import java.util.Optional;
  * Dispatched when a reaction is removed on a message.
  * <p>
  * {@link #guildId} may not be present if the message was in a private channel.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#message-reaction-remove">Message Reaction
  * Remove</a>
@@ -55,38 +57,74 @@ public class ReactionRemoveEvent extends MessageEvent {
         this.emoji = emoji;
     }
 
+    /**
+     * Gets the Snowflake ID of the User who's reaction has been removed.
+     * @return The ID of the User who's reaction has been removed.
+     */
     public Snowflake getUserId() {
         return Snowflake.of(userId);
     }
 
+    /**
+     * Gets the Uer who's reaction has been removed.
+     * @return The ID of the User who's reaction has been removed.
+     */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
+    /**
+     * Gets the Snowflake ID of the channel containing the message the reaction was removed from.
+     * @return The ID of the channel involved.
+     */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
+    /**
+     * Gets the MessageChannel containing the message the reaction was removed from.
+     * @return The channel containing the message involved.
+     */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
+    /**
+     * Gets the Snowflake ID of the message the reaction was removed from.
+     * @return The ID of the message involved.
+     */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
+    /**
+     * Gets the Message the reaction was removed from.
+     * @return The message the reaction was removed from.
+     */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild the message involved is in. This may not be available if the message was sent in a private channel.
+     * @return The ID of the guild involved.
+     */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
+    /**
+     * Gets the Guild the message involved is in. This may not be available if the message was sent in a private channel.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
+    /**
+     * The ReactionEmoji that was removed from a message.
+     * @return The emoji that has been removed.
+     */
     public ReactionEmoji getEmoji() {
         return emoji;
     }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
@@ -58,81 +58,88 @@ public class ReactionRemoveEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the User who's reaction has been removed.
+     * Gets the {@link Snowflake} ID of the {@link User} who's reaction has been removed.
      *
-     * @return The ID of the User who's reaction has been removed.
+     * @return The ID of the {@link User} who's reaction has been removed.
      */
     public Snowflake getUserId() {
         return Snowflake.of(userId);
     }
 
     /**
-     * Requests to retrieve the User who's reaction has been removed.
+     * Requests to retrieve the {@link User} who's reaction has been removed.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the User who's reaction has been removed. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User} who's reaction has been removed.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
     }
 
     /**
-     * Gets the Snowflake ID of the channel containing the message the reaction was removed from.
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} containing the {@link Message} the reaction
+     * was removed from.
      *
-     * @return The ID of the channel involved.
+     * @return The ID of the {@link MessageChannel} involved.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
     }
 
     /**
-     * Requests to retrieve the MessageChannel containing the message the reaction was removed from.
+     * Requests to retrieve the {@link MessageChannel} containing the {@link Message} the reaction was removed from.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message involved. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing the
+     * {@link Message} involved. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
     }
 
     /**
-     * Gets the Snowflake ID of the message the reaction was removed from.
+     * Gets the {@link Snowflake} ID of the {@link Message} the reaction was removed from.
      *
-     * @return The ID of the message involved.
+     * @return The ID of the {@link Message} involved.
      */
     public Snowflake getMessageId() {
         return Snowflake.of(messageId);
     }
 
     /**
-     * Requests to retrieve the Message the reaction was removed from.
+     * Requests to retrieve the {@link Message} the reaction was removed from.
      *
-     * @return A {@link Mono} where, upon completion, emits the Message the reaction was removed from. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon completion, emits the {@link Message} the reaction was removed from.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the Guild the message involved is in, if present. This may not be available if the message was sent in a private channel.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Message} involved is in, if present.
+     * This may not be available if the {@code Message} was sent in a private channel.
      *
-     * @return The ID of the guild involved, if present.
+     * @return The ID of the {@link Guild} involved, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Requests to retrieve the Guild the message involved is in, if present. This may not be available if the message was sent in a private channel.
+     * Requests to retrieve the {@link Guild} the {@link Message} involved is in, if present.
+     * This may not be available if the {@code Message} was sent in a private channel.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the Message involved, if present. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the
+     * {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**
-     * The ReactionEmoji that was removed from a message.
+     * The {@link ReactionEmoji} that was removed from a message.
      *
-     * @return The emoji that has been removed.
+     * @return The {@code Emoji} that has been removed.
      */
     public ReactionEmoji getEmoji() {
         return emoji;

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
@@ -59,6 +59,7 @@ public class ReactionRemoveEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the User who's reaction has been removed.
+     *
      * @return The ID of the User who's reaction has been removed.
      */
     public Snowflake getUserId() {
@@ -66,8 +67,9 @@ public class ReactionRemoveEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Uer who's reaction has been removed.
-     * @return The ID of the User who's reaction has been removed.
+     * Requests to retrieve the User who's reaction has been removed.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the User who's reaction has been removed. If an error is received, it is emitted through the Mono.
      */
     public Mono<User> getUser() {
         return getClient().getUserById(getUserId());
@@ -75,6 +77,7 @@ public class ReactionRemoveEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the channel containing the message the reaction was removed from.
+     *
      * @return The ID of the channel involved.
      */
     public Snowflake getChannelId() {
@@ -82,8 +85,9 @@ public class ReactionRemoveEvent extends MessageEvent {
     }
 
     /**
-     * Gets the MessageChannel containing the message the reaction was removed from.
-     * @return The channel containing the message involved.
+     * Requests to retrieve the MessageChannel containing the message the reaction was removed from.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the MessageChannel containing the message involved. If an error is received, it is emitted through the Mono.
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
@@ -91,6 +95,7 @@ public class ReactionRemoveEvent extends MessageEvent {
 
     /**
      * Gets the Snowflake ID of the message the reaction was removed from.
+     *
      * @return The ID of the message involved.
      */
     public Snowflake getMessageId() {
@@ -98,24 +103,27 @@ public class ReactionRemoveEvent extends MessageEvent {
     }
 
     /**
-     * Gets the Message the reaction was removed from.
-     * @return The message the reaction was removed from.
+     * Requests to retrieve the Message the reaction was removed from.
+     *
+     * @return A {@link Mono} where, upon completion, emits the Message the reaction was removed from. If an error is received, it is emitted through the Mono.
      */
     public Mono<Message> getMessage() {
         return getClient().getMessageById(getChannelId(), getMessageId());
     }
 
     /**
-     * Gets the Snowflake ID of the Guild the message involved is in. This may not be available if the message was sent in a private channel.
-     * @return The ID of the guild involved.
+     * Gets the Snowflake ID of the Guild the message involved is in, if present. This may not be available if the message was sent in a private channel.
+     *
+     * @return The ID of the guild involved, if present.
      */
     public Optional<Snowflake> getGuildId() {
         return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
-     * Gets the Guild the message involved is in. This may not be available if the message was sent in a private channel.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild the message involved is in, if present. This may not be available if the message was sent in a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the Message involved, if present. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
@@ -123,6 +131,7 @@ public class ReactionRemoveEvent extends MessageEvent {
 
     /**
      * The ReactionEmoji that was removed from a message.
+     *
      * @return The emoji that has been removed.
      */
     public ReactionEmoji getEmoji() {

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleCreateEvent.java
@@ -42,6 +42,7 @@ public class RoleCreateEvent extends RoleEvent {
 
     /**
      * Gets the Snowflake ID of the Guild the role was created in.
+     *
      * @return The ID of the Guild the role was created in.
      */
     public Snowflake getGuildId() {
@@ -49,8 +50,9 @@ public class RoleCreateEvent extends RoleEvent {
     }
 
     /**
-     * Gets the Guild the role was created in.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild the role was created in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild the role was created in. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -58,6 +60,7 @@ public class RoleCreateEvent extends RoleEvent {
 
     /**
      * Gets the role that was created in this event.
+     *
      * @return The Role that was created.
      */
     public Role getRole() {

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleCreateEvent.java
@@ -24,6 +24,8 @@ import reactor.core.publisher.Mono;
 
 /**
  * Dispatched when a role is created in a guild.
+ * <p>
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-role-create">Guild Role Create</a>
  */
@@ -38,14 +40,26 @@ public class RoleCreateEvent extends RoleEvent {
         this.role = role;
     }
 
+    /**
+     * Gets the Snowflake ID of the Guild the role was created in.
+     * @return The ID of the Guild the role was created in.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild the role was created in.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the role that was created in this event.
+     * @return The Role that was created.
+     */
     public Role getRole() {
         return role;
     }

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleCreateEvent.java
@@ -41,27 +41,29 @@ public class RoleCreateEvent extends RoleEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the Guild the role was created in.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Role} was created in.
      *
-     * @return The ID of the Guild the role was created in.
+     * @return The ID of the {@link Guild} the {@link Role} was created in.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild the role was created in.
+     * Requests to retrieve the {@link Guild} the {@link Role} was created in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild the role was created in. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} the {@link Guild}
+     * was created in.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the role that was created in this event.
+     * Gets the {@link Role} that was created in this event.
      *
-     * @return The Role that was created.
+     * @return The {@link Role} that was created.
      */
     public Role getRole() {
         return role;

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleDeleteEvent.java
@@ -29,6 +29,8 @@ import java.util.Optional;
  * Dispatched when a role is deleted in a guild.
  * <p>
  * The deleted role may not be present if roles are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-role-delete">Guild Role Delete</a>
  */
@@ -46,18 +48,34 @@ public class RoleDeleteEvent extends RoleEvent {
         this.role = role;
     }
 
+    /**
+     * Gets the Snowflake ID of the guild the role was deleted in.
+     * @return The ID of the guild involved.
+     */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
+    /**
+     * Gets the Guild the Role was deleted in.
+     * @return The Guild involved.
+     */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
+    /**
+     * Gets the Snowflake ID of the Role that was deleted in this event.
+     * @return The ID of the deleted Role.
+     */
     public Snowflake getRoleId() {
         return Snowflake.of(roleId);
     }
 
+    /**
+     * Gets the Role that was deleted in this event. This may not be available if Roles are not stored.
+     * @return The Role that was deleted in this event.
+     */
     public Optional<Role> getRole() {
         return Optional.ofNullable(role);
     }

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleDeleteEvent.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * <p>
  * The deleted role may not be present if roles are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-role-delete">Guild Role Delete</a>
  */
@@ -49,27 +49,29 @@ public class RoleDeleteEvent extends RoleEvent {
     }
 
     /**
-     * Gets the Snowflake ID of the guild the role was deleted in.
+     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Role} was deleted in.
      *
-     * @return The ID of the guild involved.
+     * @return The ID of the {@link Guild} involved.
      */
     public Snowflake getGuildId() {
         return Snowflake.of(guildId);
     }
 
     /**
-     * Requests to retrieve the Guild the Role was deleted in.
+     * Requests to retrieve the {@link Guild} the {@link Role} was deleted in.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the deleted role. If an error is received, it is emitted through the Mono.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the deleted
+     * {@link Role}.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
     }
 
     /**
-     * Gets the Snowflake ID of the Role that was deleted in this event.
+     * Gets the {@link Snowflake} ID of the {@link Role} that was deleted in this event.
      *
-     * @return The ID of the deleted Role.
+     * @return The ID of the deleted {@link Role}.
      *
      */
     public Snowflake getRoleId() {
@@ -77,9 +79,10 @@ public class RoleDeleteEvent extends RoleEvent {
     }
 
     /**
-     * Gets the Role that was deleted in this event, if present. This may not be available if Roles are not stored.
+     * Gets the {@link Role} that was deleted in this event, if present. This may not be available if {@code Roles} are
+     * not stored.
      *
-     * @return The Role that was deleted in this event, if present.
+     * @return The {@link Role} that was deleted in this event, if present.
      */
     public Optional<Role> getRole() {
         return Optional.ofNullable(role);

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleDeleteEvent.java
@@ -50,6 +50,7 @@ public class RoleDeleteEvent extends RoleEvent {
 
     /**
      * Gets the Snowflake ID of the guild the role was deleted in.
+     *
      * @return The ID of the guild involved.
      */
     public Snowflake getGuildId() {
@@ -57,8 +58,9 @@ public class RoleDeleteEvent extends RoleEvent {
     }
 
     /**
-     * Gets the Guild the Role was deleted in.
-     * @return The Guild involved.
+     * Requests to retrieve the Guild the Role was deleted in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Guild containing the deleted role. If an error is received, it is emitted through the Mono.
      */
     public Mono<Guild> getGuild() {
         return getClient().getGuildById(getGuildId());
@@ -66,15 +68,18 @@ public class RoleDeleteEvent extends RoleEvent {
 
     /**
      * Gets the Snowflake ID of the Role that was deleted in this event.
+     *
      * @return The ID of the deleted Role.
+     *
      */
     public Snowflake getRoleId() {
         return Snowflake.of(roleId);
     }
 
     /**
-     * Gets the Role that was deleted in this event. This may not be available if Roles are not stored.
-     * @return The Role that was deleted in this event.
+     * Gets the Role that was deleted in this event, if present. This may not be available if Roles are not stored.
+     *
+     * @return The Role that was deleted in this event, if present.
      */
     public Optional<Role> getRole() {
         return Optional.ofNullable(role);

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleUpdateEvent.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * <p>
  * The old role may not be present if roles are not stored.
  * <p>
- * This event is dispatched by Discord
+ * This event is dispatched by Discord.
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-role-update">Guild Role Update</a>
  */
@@ -43,18 +43,19 @@ public class RoleUpdateEvent extends RoleEvent {
     }
 
     /**
-     * Gets the current, new version of the Role that was updated in the event.
+     * Gets the current, new version of the {@link Role} that was updated in the event.
      *
-     * @return The current version of the updated Role.
+     * @return The current version of the updated {@link Role}.
      */
     public Role getCurrent() {
         return current;
     }
 
     /**
-     * Gets the old version of the Role that was updated in this event. if present. This may not be available if Roles are not stored.
+     * Gets the old version of the {@link Role} that was updated in this event. if present.
+     * This may not be available if {@code Role} are not stored.
      *
-     * @return The old version of the updated Role, if present.
+     * @return The old version of the updated {@link Role}, if present.
      */
     public Optional<Role> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleUpdateEvent.java
@@ -44,6 +44,7 @@ public class RoleUpdateEvent extends RoleEvent {
 
     /**
      * Gets the current, new version of the Role that was updated in the event.
+     *
      * @return The current version of the updated Role.
      */
     public Role getCurrent() {
@@ -51,8 +52,9 @@ public class RoleUpdateEvent extends RoleEvent {
     }
 
     /**
-     * Gets the old version of the Role that was updated in this event. This may not be available if Roles are not stored.
-     * @return The old version of the updated Role.
+     * Gets the old version of the Role that was updated in this event. if present. This may not be available if Roles are not stored.
+     *
+     * @return The old version of the updated Role, if present.
      */
     public Optional<Role> getOld() {
         return Optional.ofNullable(old);

--- a/core/src/main/java/discord4j/core/event/domain/role/RoleUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/role/RoleUpdateEvent.java
@@ -25,7 +25,9 @@ import java.util.Optional;
 /**
  * Dispatched when a role is updated in a guild.
  * <p>
- * The old role may not be present if messages are not stored.
+ * The old role may not be present if roles are not stored.
+ * <p>
+ * This event is dispatched by Discord
  *
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-role-update">Guild Role Update</a>
  */
@@ -40,10 +42,18 @@ public class RoleUpdateEvent extends RoleEvent {
         this.old = old;
     }
 
+    /**
+     * Gets the current, new version of the Role that was updated in the event.
+     * @return The current version of the updated Role.
+     */
     public Role getCurrent() {
         return current;
     }
 
+    /**
+     * Gets the old version of the Role that was updated in this event. This may not be available if Roles are not stored.
+     * @return The old version of the updated Role.
+     */
     public Optional<Role> getOld() {
         return Optional.ofNullable(old);
     }


### PR DESCRIPTION
**Description:** 
Added missing documentation to events about if they are dispatched by Discord or Discord4J. As well as add documentation to methods that were undocumented.

**Justification:**
Adding info about which events are dispatched by Discord and which are dispatched by D4J helps clear up some life cycle pitfalls and confusion (as evidenced 03/26/19 in the v3 help channel). 

Adding documentation for the event methods brings the event documentation back up to par with the rest of the library as they were previously lacking any documentation.