### PR TITLE
Fix #513 parallel requests vs rate limiting 

### DIFF
--- a/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
+++ b/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
@@ -16,17 +16,23 @@
  */
 package discord4j.rest.request;
 
-import reactor.core.publisher.EmitterProcessor;
-import reactor.core.publisher.Flux;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 
 import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 /**
  * Used to prevent requests from being sent while the bot is
- * <a href="https://discordapp.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit">globally ratelimited</a>.
+ * <a href="https://discordapp.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit">globally rate limited</a>.
+ * <p>
+ * Provides a single resource that can be acquired through the use of {@link #withLimiter(Supplier)}, blocking all other
+ * attempts until the {@link Mono} supplier completes or terminates with an error.
+ * <p>
+ * This rate limiter can have their delay directly indicated through {@link #rateLimitFor(Duration)}, determining the
+ * duration a resource holder must wait before processing starts.
  * <p>
  * When subscribing to the rate limiter, the only guarantee is that the subscription will be completed at some point in
  * the future. If a global ratelimit is in effect, it will be completed when the cooldown ends. Otherwise, it is
@@ -34,41 +40,69 @@ import java.time.Duration;
  */
 public class GlobalRateLimiter {
 
-    private static final Logger log = Loggers.getLogger(GlobalRateLimiter.class);
-
-    private static final Object PERMIT = new Object();
-
-    private final EmitterProcessor<Object> resetNotifier = EmitterProcessor.create(false);
-    private volatile boolean isRateLimited;
-    private final Flux<Void> flux = Flux.create(sink -> sink.onRequest(l -> {
-        if (isRateLimited) {
-            resetNotifier.next().subscribe(o -> sink.complete(),
-                    t -> log.error("Could not reset global notifier", t));
-        } else {
-            sink.complete();
-        }
-    }));
+    private final Semaphore semaphore = new Semaphore(1, true);
+    private final AtomicLong limitedUntil = new AtomicLong(0L);
 
     /**
-     * Prevents the rate limiter from completing subscriptions for the given duration.
+     * Sets a new rate limit that will be applied to every new resource acquired.
      *
-     * @param duration The duration to prevent completions for.
+     * @param duration the {@link Duration} every new acquired resource should wait before being used
      */
-    void rateLimitFor(Duration duration) {
-        if (log.isTraceEnabled()) {
-            log.trace("Setting a global rate limit for {}", duration);
-        }
-        isRateLimited = true;
-        Mono.delay(duration).subscribe(l -> {
-            if (log.isTraceEnabled()) {
-                log.trace("Global rate limit has completed after {}", duration);
-            }
-            isRateLimited = false;
-            resetNotifier.onNext(PERMIT);
-        }, t -> log.error("Error while resolving global rate limiter", t));
+    public void rateLimitFor(Duration duration) {
+        limitedUntil.set(System.nanoTime() + duration.toNanos());
     }
 
-    public Mono<Void> onComplete() {
-        return flux.then();
+    /**
+     * Returns a {@link Mono} indicating that the rate limit has ended.
+     *
+     * @return a {@link Mono} that completes when the currently set limit has completed
+     */
+    Mono<Void> onComplete() {
+        return Mono.defer(this::notifier);
+    }
+
+    private Mono<Void> notifier() {
+        long delayNanos = delayNanos();
+        if (delayNanos > 0) {
+            return Mono.delay(Duration.ofNanos(delayNanos)).then();
+        }
+        return Mono.empty();
+    }
+
+    private long delayNanos() {
+        return limitedUntil.get() - System.nanoTime();
+    }
+
+    /**
+     * Provides a scope to perform reactive operations under this limiter resources. Resources are acquired on
+     * subscription and released when the given stage has completed or terminated with an error.
+     *
+     * @param stage a supplier containing a {@link Mono} that will manage this limiter resources
+     * @param <T> the type of the stage supplier
+     * @return a {@link Mono} where each subscription represents acquiring a rate limiter resource
+     */
+    public <T> Mono<T> withLimiter(Supplier<Mono<T>> stage) {
+        return Mono.usingWhen(
+                acquire(),
+                resource -> stage.get(),
+                this::release,
+                this::release);
+    }
+
+    private Mono<Semaphore> acquire() {
+        return Mono
+                .fromRunnable(() -> {
+                    try {
+                        semaphore.acquire();
+                    } catch (InterruptedException e) {
+                        throw Exceptions.propagate(e);
+                    }
+                })
+                .then(onComplete())
+                .thenReturn(semaphore);
+    }
+
+    private Mono<Void> release(Semaphore resource) {
+        return Mono.fromRunnable(resource::release);
     }
 }

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -22,10 +22,8 @@ import discord4j.rest.http.client.DiscordWebClient;
 import discord4j.rest.util.RouteUtils;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
-import reactor.core.publisher.EmitterProcessor;
-import reactor.core.publisher.Mono;
-import reactor.core.publisher.MonoProcessor;
-import reactor.core.publisher.SignalType;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.*;
 import reactor.core.scheduler.Scheduler;
 import reactor.netty.http.client.HttpClientResponse;
 import reactor.retry.BackoffDelay;
@@ -44,8 +42,8 @@ import java.util.logging.Level;
 
 /**
  * A stream of {@link DiscordRequest DiscordRequests}. Any number of items may be {@link #push(RequestCorrelation)}
- * written to the stream. However, the {@link Reader reader} ensures that only one is read at a time. This
- * linearization ensures proper ratelimit handling.
+ * written to the stream. However, the {@link RequestSubscriber} ensures that only one is read at a time. This
+ * serialization ensures proper rate limit handling.
  * <p>
  * The flow of a request through the stream is as follows:
  *
@@ -74,8 +72,8 @@ class RequestStream<T> {
     }
 
     /**
-     * The retry function used for reading and completing HTTP requests. The backoff is determined by the ratelimit
-     * headers returned by Discord in the event of a 429. If the bot is being globally ratelimited, the backoff is
+     * The retry function used for reading and completing HTTP requests. The backoff is determined by the rate limit
+     * headers returned by Discord in the event of a 429. If the bot is being globally rate limited, the backoff is
      * applied to the global rate limiter. Otherwise, it is applied only to this stream.
      */
     private Retry<?> rateLimitRetryFactory() {
@@ -87,6 +85,7 @@ class RequestStream<T> {
                 long retryAfter = Long.valueOf(clientException.getHeaders().get("Retry-After"));
                 Duration fixedBackoff = Duration.ofMillis(retryAfter);
                 if (global) {
+                    log.debug("Globally rate limited for {}", fixedBackoff);
                     globalRateLimiter.rateLimitFor(fixedBackoff);
                 }
                 return new BackoffDelay(fixedBackoff);
@@ -94,7 +93,8 @@ class RequestStream<T> {
             return new BackoffDelay(Duration.ZERO);
         }).doOnRetry(ctx -> {
             if (log.isTraceEnabled()) {
-                log.trace("Retry {} due to {} for {}", ctx.iteration(), ctx.exception().toString(), ctx.backoff());
+                log.trace("Retry {} due to {} for {}", ctx.iteration(), ctx.exception().toString(), ctx.backoff
+                        ());
             }
         });
     }
@@ -140,27 +140,23 @@ class RequestStream<T> {
     }
 
     void start() {
-        read().subscribe(new Reader(rateLimitStrategy), t -> log.error("Error while consuming first request", t));
-    }
-
-    private Mono<RequestCorrelation<T>> read() {
-        return backing.next();
+        backing.subscribe(new RequestSubscriber(rateLimitStrategy));
     }
 
     /**
      * Reads and completes one request from the stream at a time. If a request fails, it is retried according a retry
-     * strategy. The reader may wait in between each request if preemptive ratelimiting is necessary according to the
+     * strategy. The reader may wait in between each request if preemptive rate limiting is necessary according to the
      * response headers.
      *
      * @see #sleepTime
      * @see #rateLimitHandler
      */
-    private class Reader implements Consumer<RequestCorrelation<T>> {
+    private class RequestSubscriber extends BaseSubscriber<RequestCorrelation<T>> {
 
         private volatile Duration sleepTime = Duration.ZERO;
         private final Consumer<HttpClientResponse> rateLimitHandler;
 
-        private Reader(RateLimitStrategy strategy) {
+        public RequestSubscriber(RateLimitStrategy strategy) {
             this.rateLimitHandler = response -> {
                 if (log.isTraceEnabled()) {
                     log.trace("Read {} with headers: {}", response.status(), response.responseHeaders());
@@ -173,6 +169,45 @@ class RequestStream<T> {
                     sleepTime = nextReset;
                 }
             };
+        }
+
+        @Override
+        protected void hookOnSubscribe(Subscription subscription) {
+            request(1);
+        }
+
+        @Override
+        protected void hookOnNext(RequestCorrelation<T> correlation) {
+            DiscordRequest<T> request = correlation.getRequest();
+            MonoProcessor<T> callback = correlation.getResponse();
+            String shard = correlation.getShardId();
+            Logger traceLog = getLogger("traces", shard);
+            if (traceLog.isTraceEnabled()) {
+                traceLog.trace("Accepting request: {}", request);
+            }
+            Logger requestLog = getLogger("request", shard);
+            Logger responseLog = getLogger("response", shard);
+            Class<T> responseType = request.getRoute().getResponseType();
+
+            globalRateLimiter.withLimiter(() -> adaptRequest(request)
+                    .log(requestLog, Level.FINEST, false)
+                    .flatMap(r -> httpClient.exchange(r, request.getBody(), responseType, rateLimitHandler))
+                    .retryWhen(rateLimitRetryFactory())
+                    .retryWhen(serverErrorRetryFactory())
+                    .log(responseLog, Level.FINEST, false)
+                    .doFinally(signal -> next(signal, traceLog)))
+                    .materialize()
+                    .subscribe(signal -> {
+                        if (signal.isOnSubscribe()) {
+                            callback.onSubscribe(signal.getSubscription());
+                        } else if (signal.isOnNext()) {
+                            callback.onNext(signal.get());
+                        } else if (signal.isOnError()) {
+                            callback.onError(signal.getThrowable());
+                        } else if (signal.isOnComplete()) {
+                            callback.onComplete();
+                        }
+                    });
         }
 
         private Mono<ClientRequest> adaptRequest(DiscordRequest<?> req) {
@@ -188,49 +223,13 @@ class RequestStream<T> {
                             .orElse(new DefaultHttpHeaders())));
         }
 
-        @Override
-        public void accept(RequestCorrelation<T> correlation) {
-            DiscordRequest<T> req = correlation.getRequest();
-            MonoProcessor<T> callback = correlation.getResponse();
-            String shard = correlation.getShardId();
-            Logger traceLog = getLogger("traces", shard);
-            if (traceLog.isTraceEnabled()) {
-                traceLog.trace("Accepting request: {}", req);
-            }
-            Logger requestLog = getLogger("request", shard);
-            Logger responseLog = getLogger("response", shard);
-            Mono<ClientRequest> request = adaptRequest(req);
-            Class<T> responseType = req.getRoute().getResponseType();
-
-            globalRateLimiter.onComplete()
-                    .then(request)
-                    .log(requestLog, Level.FINEST, false)
-                    .flatMap(r -> httpClient.exchange(r, req.getBody(), responseType, rateLimitHandler))
-                    .retryWhen(rateLimitRetryFactory())
-                    .retryWhen(serverErrorRetryFactory())
-                    .log(responseLog, Level.FINEST, false)
-                    .doFinally(signal -> next(signal, traceLog))
-                    .materialize()
-                    .subscribe(signal -> {
-                        if (signal.isOnSubscribe()) {
-                            callback.onSubscribe(signal.getSubscription());
-                        } else if (signal.isOnNext()) {
-                            callback.onNext(signal.get());
-                        } else if (signal.isOnError()) {
-                            callback.onError(signal.getThrowable());
-                        } else if (signal.isOnComplete()) {
-                            callback.onComplete();
-                        }
-                    });
-        }
-
         private void next(SignalType signal, Logger logger) {
             Mono.delay(sleepTime, rateLimitScheduler).subscribe(l -> {
                 if (logger.isTraceEnabled()) {
                     logger.trace("Ready to consume next request after {}", signal);
                 }
                 sleepTime = Duration.ZERO;
-                read().subscribe(this, t -> logger.error("Error while consuming request", t));
+                request(1);
             }, t -> logger.error("Error while scheduling next request", t));
         }
 

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -22,7 +22,6 @@ import discord4j.rest.http.client.DiscordWebClient;
 import discord4j.rest.util.RouteUtils;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
-import org.reactivestreams.Subscription;
 import reactor.core.publisher.*;
 import reactor.core.scheduler.Scheduler;
 import reactor.netty.http.client.HttpClientResponse;
@@ -171,11 +170,6 @@ class RequestStream<T> {
         }
 
         @Override
-        protected void hookOnSubscribe(Subscription subscription) {
-            request(1);
-        }
-
-        @Override
         protected void hookOnNext(RequestCorrelation<T> correlation) {
             DiscordRequest<T> request = correlation.getRequest();
             MonoProcessor<T> callback = correlation.getResponse();
@@ -228,7 +222,6 @@ class RequestStream<T> {
                     logger.trace("Ready to consume next request after {}", signal);
                 }
                 sleepTime = Duration.ZERO;
-                request(1);
             }, t -> logger.error("Error while scheduling next request", t));
         }
 

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -93,8 +93,7 @@ class RequestStream<T> {
             return new BackoffDelay(Duration.ZERO);
         }).doOnRetry(ctx -> {
             if (log.isTraceEnabled()) {
-                log.trace("Retry {} due to {} for {}", ctx.iteration(), ctx.exception().toString(), ctx.backoff
-                        ());
+                log.trace("Retry {} due to {} for {}", ctx.iteration(), ctx.exception().toString(), ctx.backoff());
             }
         });
     }


### PR DESCRIPTION
**Description:** Include a fix for #513 by making each request acquire a common resource before being executed, allowing proper limiting even under parallel scenarios. Moving from a purely scheduled GRL -that could cause starvation of the parallel pool- into a transactional one.

**Justification:** Global rate limiter must be respected at the cost of throughput under very bursty scenarios. Since we currently share our event loop group across REST and gateway we must also protect that resource and avoid starvation scenarios. 

In the future we might want to explore the [reactor-pool](https://github.com/reactor/reactor-pool) project to avoid relying on blocking structures.