### PR TITLE
Global Rate Limiter performance improvements

### DIFF
--- a/core/src/test/java/discord4j/core/ExampleBot.java
+++ b/core/src/test/java/discord4j/core/ExampleBot.java
@@ -24,7 +24,9 @@ import discord4j.core.event.domain.lifecycle.ResumeEvent;
 import discord4j.core.event.domain.message.MessageCreateEvent;
 import discord4j.core.object.entity.ApplicationInfo;
 import discord4j.core.object.entity.Attachment;
+import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.TextChannel;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.reaction.ReactionEmoji;
 import discord4j.core.object.util.Image;
@@ -43,6 +45,7 @@ import reactor.BlockHound;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.function.TupleUtils;
 import reactor.netty.http.client.HttpClient;
 import reactor.retry.Retry;
 import reactor.util.Logger;
@@ -108,6 +111,7 @@ public class ExampleBot {
         eventHandlers.add(new LogLevelChange());
         eventHandlers.add(new Reactor());
         eventHandlers.add(new ChangeAvatar());
+        eventHandlers.add(new BurstMessages());
 
         // Build a safe event-processing pipeline
         client.getEventDispatcher().on(MessageCreateEvent.class)
@@ -307,6 +311,32 @@ public class ExampleBot {
                 }
             }
             return Mono.empty();
+        }
+    }
+
+    public static class BurstMessages extends EventHandler {
+
+        @Override
+        public Mono<Void> onMessageCreate(MessageCreateEvent event) {
+            if (!event.getMessage().getContent().orElse("").startsWith("!burstmessages")) {
+                return Mono.empty();
+            }
+            return event.getGuild()
+                    .flatMapMany(Guild::getChannels)
+                    .ofType(TextChannel.class)
+                    .filter(channel -> channel.getName().startsWith("test"))
+                    .collectList()
+                    .doOnNext(channelList -> Flux.fromIterable(channelList)
+                            .flatMap(channel -> Flux.range(1, 5)
+                                    .map(String::valueOf)
+                                    .flatMap(channel::createMessage))
+                            .collectList()
+                            .elapsed()
+                            .doOnNext(TupleUtils.consumer(
+                                    (time, messageList) -> log.info("Sent {} messages in {} milliseconds ({} messages/s)",
+                                            messageList.size(), time, (messageList.size() / (double) time) * 1000)))
+                            .subscribe()) // Separate subscribe in order to improve accuracy of elapsed time
+                    .then();
         }
     }
 

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
@@ -46,7 +46,7 @@ public class DefaultRouter implements Router {
 
     private final DiscordWebClient httpClient;
     private final RouterOptions routerOptions;
-    private final GlobalRateLimiter globalRateLimiter = new GlobalRateLimiter();
+    private final GlobalRateLimiter globalRateLimiter = new GlobalRateLimiter(14 /* To be parametrized */);
     private final Map<BucketKey, RequestStream<?>> streamMap = new ConcurrentHashMap<>();
 
     /**

--- a/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
+++ b/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
@@ -73,7 +73,7 @@ public class GlobalRateLimiter {
         return Mono.empty();
     }
 
-    private long delayNanos() {
+    long delayNanos() {
         return limitedUntil.get() - System.nanoTime();
     }
 

--- a/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
+++ b/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
@@ -17,8 +17,7 @@
 package discord4j.rest.request;
 
 import reactor.core.publisher.Mono;
-import reactor.util.Logger;
-import reactor.util.Loggers;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.util.concurrent.Semaphore;
@@ -41,11 +40,18 @@ import java.util.function.Supplier;
  */
 public class GlobalRateLimiter {
 
-    private static final Logger log = Loggers.getLogger(GlobalRateLimiter.class);
-
-    private final Semaphore outer = new Semaphore(14, true);
+    private final Semaphore outer;
     private final Semaphore inner = new Semaphore(1, true);
     private final AtomicLong limitedUntil = new AtomicLong(0L);
+
+    /**
+     * Creates a new global rate limiter with the specified parallelism level.
+     *
+     * @param parallelism the maximum number of requests that this limiter will allow in parallel
+     */
+    public GlobalRateLimiter(int parallelism) {
+        this.outer = new Semaphore(parallelism, true);
+    }
 
     /**
      * Sets a new rate limit that will be applied to every new resource acquired.
@@ -68,7 +74,7 @@ public class GlobalRateLimiter {
     private Mono<Void> notifier() {
         long delayNanos = delayNanos();
         if (delayNanos > 0) {
-            return Mono.delay(Duration.ofNanos(delayNanos)).then();
+            return Mono.delay(Duration.ofNanos(delayNanos), Schedulers.elastic()).then();
         }
         return Mono.empty();
     }
@@ -103,6 +109,7 @@ public class GlobalRateLimiter {
                     }
                     return new Resource(outer, null);
                 })
+                .subscribeOn(Schedulers.elastic())
                 .delayUntil(resource -> onComplete());
     }
 

--- a/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
+++ b/rest/src/main/java/discord4j/rest/request/GlobalRateLimiter.java
@@ -43,7 +43,7 @@ public class GlobalRateLimiter {
 
     private static final Logger log = Loggers.getLogger(GlobalRateLimiter.class);
 
-    private final Semaphore outer = new Semaphore(8, true);
+    private final Semaphore outer = new Semaphore(14, true);
     private final Semaphore inner = new Semaphore(1, true);
     private final AtomicLong limitedUntil = new AtomicLong(0L);
 

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -84,6 +84,10 @@ class RequestStream<T> {
                 long retryAfter = Long.valueOf(clientException.getHeaders().get("Retry-After"));
                 Duration fixedBackoff = Duration.ofMillis(retryAfter);
                 if (global) {
+                    long existingRateLimit = globalRateLimiter.delayNanos();
+                    if (existingRateLimit > 0) {
+                        return new BackoffDelay(Duration.ofNanos(existingRateLimit));
+                    }
                     log.debug("Globally rate limited for {}", fixedBackoff);
                     globalRateLimiter.rateLimitFor(fixedBackoff);
                 }

--- a/rest/src/test/java/discord4j/rest/request/GlobalRateLimiterTest.java
+++ b/rest/src/test/java/discord4j/rest/request/GlobalRateLimiterTest.java
@@ -27,7 +27,7 @@ public class GlobalRateLimiterTest {
 
     @Test
     public void testGlobalRateLimiter() {
-        GlobalRateLimiter rateLimiter = new GlobalRateLimiter();
+        GlobalRateLimiter rateLimiter = new GlobalRateLimiter(14);
 
         rateLimiter.rateLimitFor(Duration.ofSeconds(1));
 
@@ -42,7 +42,7 @@ public class GlobalRateLimiterTest {
 
     @Test
     public void testBurstingRequestsGlobalRateLimiter() {
-        GlobalRateLimiter rateLimiter = new GlobalRateLimiter();
+        GlobalRateLimiter rateLimiter = new GlobalRateLimiter(14);
         Random random = new Random();
         Flux.range(0, 100)
                 .flatMap(index -> rateLimiter.withLimiter(() -> {


### PR DESCRIPTION
**Justification:** *(it makes more sense for me to start with this section)*

A few weeks ago I reported a bug affecting the global rate limiter (#513) that has been fixed as of Discord4J v3.0.3. In that issue I provided an example code which consisted of calling `client.getChannelById()` hundreds of times with fake snowflakes, so that it would result in cache misses and hit REST on each call. The bugfix works well for this specific test case, however when I deployed the Discord4J update to my production bot, I was kinda disappointed because basically I am experiencing a regression where the request throughput for some REST calls such as `channel.createMessage()` would be too slow to reach global rate limit. In this pull request I brought some optimizations to the global rate limiter in order to address this regression.

To give a bit of context regarding my case, the main purpose of my bot is to periodically send news messages to all guilds that the bot is in, in a channel chosen by the server owners. I expect this process to be as fast as possible, without making the bot unstable either. In order to achieve this I need Discord4J to have a solid and efficient global rate limit handling, as sending one message in 1000+ channels over Discord is a process that is subject to hit the global rate limit frequently during a limited time.

**Description:**

The issue that I am having right now is that I can't even get close to the global rate limit when I proceed to send a message across hundreds of channels. In order to illustrate that, I have added a new command to the ExampleBot (discord4j.core.ExampleBot) which simulates perfectly the behavior of my bot. Here is how to use it:

1. Create a new Discord server and add the example bot in it
2. Create a large number of text channels (let's say 50) by prefixing their name with `test`. For example, create channels named `#test01`, `#test02`, `#test03`, ..., up to `#test50`.
3. Edit the file `core/bin/test/logback.xml` and enable DEBUG level for `discord4j.rest.traces`, this will just print in logs when the bot is being globally rate limited.
4. Launch the ExampleBot 
5. Run the command `!burstmessages`

In this pull request there are 3 commits. In the first commit, I just added the burstmessages command to the ExampleBot, but I didn't touch anything in the global rate limiter yet. If you checkout the first commit and try the command, you should have the following output in logs:

```
19:22:30.397 [elastic-33] INFO  discord4j.core.ExampleBot - Sent 250 messages in 8069 milliseconds (30.982773577890693 messages/s)
```
As you can see, absolutely nothing is printed saying that it reached the global rate limit. Indeed, 30 messages/s is way below the global rate limit which is theoretically at 50 requests/s and this is reflecting what I am experiencing in production right now. This is weird because as I said I am able to reach the global rate limit just fine with other REST calls such as `client.getChannelById()` or `channel.type()`. I think the explanation for this is that the Mono returned by createMessage takes in average more time to complete than the Mono returned by getChannelById, and as a result takes more time to release the resources acquired on the global rate limiter and causes the throughput to be lower. But well, I didn't really verify it, this is just my theory.

Anyway, I thought the correct way to fix that would be to simply increase the number of resources available in the global rate limiter, in order to allow for a higher throughput. This is the change I made in the second commit of this pull request. By increasing the resource semaphore from 8 to 14, I now get this output when running !burstmessages:

```
19:19:03.496 [reactor-http-epoll-16] DEBUG discord4j.rest.traces.614b0389 - Globally rate limited for PT0.149S
19:19:03.550 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.16c6b952 - Globally rate limited for PT0.093S
19:19:03.555 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.277a21f3 - Globally rate limited for PT0.085S
19:19:03.585 [reactor-http-epoll-15] DEBUG discord4j.rest.traces.abb77648 - Globally rate limited for PT0.06S
19:19:03.601 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.6d7b3a42 - Globally rate limited for PT0.041S
19:19:03.603 [reactor-http-epoll-6] DEBUG discord4j.rest.traces.c11b2021 - Globally rate limited for PT0.045S
19:19:03.604 [reactor-http-epoll-16] DEBUG discord4j.rest.traces.fd945250 - Globally rate limited for PT0.041S
19:19:03.618 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.c073cd9a - Globally rate limited for PT0.03S
19:19:03.620 [reactor-http-epoll-2] DEBUG discord4j.rest.traces.c3ce2271 - Globally rate limited for PT0.139S
19:19:03.633 [reactor-http-epoll-10] DEBUG discord4j.rest.traces.b4636129 - Globally rate limited for PT0.121S
19:19:04.553 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.14d35934 - Globally rate limited for PT0.203S
19:19:04.576 [reactor-http-epoll-16] DEBUG discord4j.rest.traces.ec2a6691 - Globally rate limited for PT0.186S
19:19:04.588 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.ccb637f5 - Globally rate limited for PT0.202S
19:19:04.604 [reactor-http-epoll-8] DEBUG discord4j.rest.traces.ce5a9390 - Globally rate limited for PT0.153S
19:19:04.638 [reactor-http-epoll-15] DEBUG discord4j.rest.traces.5db665cf - Globally rate limited for PT0.196S
19:19:04.652 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.c7888716 - Globally rate limited for PT0.106S
19:19:06.860 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.ae310211 - Globally rate limited for PT0.142S
19:19:06.873 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.ed087c59 - Globally rate limited for PT0.141S
19:19:06.883 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.b02d9454 - Globally rate limited for PT0.131S
19:19:06.887 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.985df09e - Globally rate limited for PT0.116S
19:19:06.907 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.e90f17dd - Globally rate limited for PT0.098S
19:19:06.944 [reactor-http-epoll-10] DEBUG discord4j.rest.traces.6f46f39f - Globally rate limited for PT0.13S
19:19:06.960 [reactor-http-epoll-16] DEBUG discord4j.rest.traces.e91b1882 - Globally rate limited for PT0.044S
19:19:06.976 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.4522d433 - Globally rate limited for PT0.036S
19:19:07.986 [reactor-http-epoll-2] DEBUG discord4j.rest.traces.95969458 - Globally rate limited for PT0.129S
19:19:07.993 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.c1d6209 - Globally rate limited for PT0.125S
19:19:07.996 [reactor-http-epoll-8] DEBUG discord4j.rest.traces.3df96edb - Globally rate limited for PT0.13S
19:19:08.018 [reactor-http-epoll-14] DEBUG discord4j.rest.traces.efd56a7b - Globally rate limited for PT0.103S
19:19:08.091 [reactor-http-epoll-15] DEBUG discord4j.rest.traces.fcf475d5 - Globally rate limited for PT0.045S
19:19:09.249 [elastic-15] INFO  discord4j.core.ExampleBot - Sent 250 messages in 6726 milliseconds (37.16919417187035 messages/s)

```
This time it's clear that the global rate limit is being reached. However, I was still bothered by the fact that it reports a speed of 37 messages/s, which is *still* below the theoretical maximum speed according to global rate limit. On another note, I found it weird that logs are being spammed that way, since it's supposed to stop bursting as soon as the global rate limit is reached. So I tried to think and find a way to optimize that, and I investigated on what could cause that log spam. I concluded that it was a race condition caused by requests that were *__sent before__* but *__received after__* the first call of `rateLimitFor`.
The one thing I tried, and it turned out to work pretty well, was to make it so that all of those requests that are sent before but received after the first call of rateLimitFor don't call rateLimitFor once again, and instead use a backoff delay based on the remaining time since the first call of rateLimitFor. With this small change, I was able to considerably reduce log spam and improve the throughput to 45 messages/s! This change is the third and last commit of this PR.

```
19:32:31.319 [reactor-http-epoll-16] DEBUG discord4j.rest.traces.ce5a9390 - Globally rate limited for PT0.246S
19:32:32.465 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.14d35934 - Globally rate limited for PT0.211S
19:32:33.784 [reactor-http-epoll-4] DEBUG discord4j.rest.traces.76b8bf7c - Globally rate limited for PT0.012S
19:32:34.652 [reactor-http-epoll-15] DEBUG discord4j.rest.traces.fcf475d5 - Globally rate limited for PT0.162S
19:32:34.820 [reactor-http-epoll-16] DEBUG discord4j.rest.traces.9290aa59 - Globally rate limited for PT0.069S
19:32:35.994 [elastic-23] INFO  discord4j.core.ExampleBot - Sent 250 messages in 5546 milliseconds (45.07753335737468 messages/s)
```

In conclusion, I believe I was successfully able to improve the global rate limiter, so that bots like mine that do operations on Discord susceptible to send requests in a burst don't get bottle-necked by the resource acquiring system introduced by quantic as a fix for #513.

Note that this is my very first pull request ever on GitHub, I never contributed to any project before. I hope I'm doing good and I'm open to feedback and remarks about it :)