### PR TITLE
Image refactor

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/ApplicationInfo.java
+++ b/core/src/main/java/discord4j/core/object/entity/ApplicationInfo.java
@@ -74,16 +74,25 @@ public final class ApplicationInfo implements Entity {
     }
 
     /**
-     * Gets the icon URL of the application, if present and in a supported format.
+     * Gets the icon URL of the application, if present.
      *
-     * @param format The format for the URL. Supported format types are {@link Image.Format#PNG PNG},
-     * {@link Image.Format#JPEG JPEG}, and {@link Image.Format#WEB_P WebP}.
-     * @return The icon URL of the application, if present and in a supported format.
+     * @param format The format for the URL.
+     * @return The icon URL of the application, if present.
      */
-    public Optional<String> getIcon(final Image.Format format) {
+    public Optional<String> getIconUrl(final Image.Format format) {
         return Optional.ofNullable(data.getIcon())
-                .filter(ignored -> (format == PNG) || (format == JPEG) || (format == WEB_P))
                 .map(icon -> ImageUtil.getUrl(String.format(ICON_IMAGE_PATH, getId().asString(), icon), format));
+    }
+
+    /**
+     * Gets the icon of the application.
+     *
+     * @param format The format in which to get the icon.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Image icon} of the application. If an
+     * error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Image> getIcon(final Image.Format format) {
+        return Mono.justOrEmpty(getIconUrl(format)).flatMap(Image::ofUrl);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -113,15 +113,13 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets the icon URL of the guild, if present and in a supported format.
+     * Gets the icon URL of the guild, if present.
      *
-     * @param format The format for the URL. Supported format types are {@link Image.Format#PNG PNG},
-     * {@link Image.Format#JPEG JPEG}, and {@link Image.Format#WEB_P WebP}.
-     * @return The icon URL of the guild, if present and in a supported format.
+     * @param format The format for the URL.
+     * @return The icon URL of the guild, if present.
      */
     public Optional<String> getIconUrl(final Image.Format format) {
         return Optional.ofNullable(data.getIcon())
-                .filter(ignored -> (format == PNG) || (format == JPEG) || (format == WEB_P) || (format == GIF))
                 .map(icon -> ImageUtil.getUrl(String.format(ICON_IMAGE_PATH, getId().asString(), icon), format));
     }
 
@@ -137,15 +135,13 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets the splash URL of the guild, if present and in a supported format.
+     * Gets the splash URL of the guild, if present.
      *
-     * @param format The format for the URL. Supported format types are {@link Image.Format#PNG PNG},
-     * {@link Image.Format#JPEG JPEG}, and {@link Image.Format#WEB_P WebP}.
-     * @return The splash URL of the guild, if present and in a supported format.
+     * @param format The format for the URL.
+     * @return The splash URL of the guild, if present.
      */
     public Optional<String> getSplashUrl(final Image.Format format) {
         return Optional.ofNullable(data.getSplash())
-                .filter(ignored -> (format == PNG) || (format == JPEG) || (format == WEB_P))
                 .map(splash -> ImageUtil.getUrl(String.format(SPLASH_IMAGE_PATH, getId().asString(), splash), format));
     }
 
@@ -161,15 +157,13 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets the banner URL of the guild, if present and in a supported format.
+     * Gets the banner URL of the guild, if present.
      *
-     * @param format The format for the URL. Supported format types are {@link Image.Format#PNG PNG},
-     * {@link Image.Format#JPEG JPEG}, and {@link Image.Format#WEB_P WebP}.
-     * @return The banner URL of the guild, if present and in a supported format.
+     * @param format The format for the URL.
+     * @return The banner URL of the guild, if present.
      */
     public Optional<String> getBannerUrl(final Image.Format format) {
         return Optional.ofNullable(data.getBanner())
-            .filter(ignored -> (format == PNG) || (format == JPEG) || (format == WEB_P))
             .map(splash -> ImageUtil.getUrl(String.format(BANNER_IMAGE_PATH, getId().asString(), splash), format));
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/User.java
+++ b/core/src/main/java/discord4j/core/object/entity/User.java
@@ -98,17 +98,13 @@ public class User implements Entity {
     }
 
     /**
-     * Gets the user's avatar URL, if present and in a supported format.
+     * Gets the user's avatar URL, if present.
      *
-     * @param format The format for the URL. Supported format types are {@link Image.Format#GIF GIF} if
-     * {@link #hasAnimatedAvatar() animated}, otherwise {@link Image.Format#PNG PNG} or {@link Image.Format#JPEG JPEG}.
-     * @return The user's avatar URL, if present and in a supported format.
+     * @param format The format for the URL.
+     * @return The user's avatar URL, if present.
      */
     public final Optional<String> getAvatarUrl(final Image.Format format) {
-        final boolean animated = hasAnimatedAvatar();
         return Optional.ofNullable(data.getAvatar())
-                .filter(ignored -> !animated || (format == GIF))
-                .filter(ignored -> (!animated && ((format == PNG) || (format == JPEG))) || animated)
                 .map(avatar -> ImageUtil.getUrl(String.format(AVATAR_IMAGE_PATH, getId().asString(), avatar), format));
     }
 

--- a/core/src/main/java/discord4j/core/object/util/Image.java
+++ b/core/src/main/java/discord4j/core/object/util/Image.java
@@ -18,8 +18,8 @@ package discord4j.core.object.util;
 
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
-import reactor.util.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
 
@@ -33,12 +33,12 @@ public final class Image {
     /**
      * Constructs an {@code Image} utilizing raw image data.
      *
-     * @param image The raw image data.
+     * @param data The raw image data.
      * @param format The {@link Format} of the data.
      * @return An {@code Image} with raw image data.
      */
-    public static Image ofRaw(final byte[] image, final Format format) {
-        return new Image(Base64.getEncoder().encodeToString(image), format);
+    public static Image ofRaw(final byte[] data, final Format format) {
+        return new Image(data, format);
     }
 
     /**
@@ -58,24 +58,24 @@ public final class Image {
                 }));
     }
 
-    /** The hash of the image. */
-    private final String hash;
+    /** The raw image data. */
+    private final byte[] data;
 
     /** The format of the image. */
     private final Format format;
 
-    private Image(final String hash, final Format format) {
-        this.hash = Objects.requireNonNull(hash);
-        this.format = Objects.requireNonNull(format);
+    private Image(byte[] data, Format format) {
+        this.data = data;
+        this.format = format;
     }
 
     /**
-     * Gets the hash of the image.
+     * Gets the raw data of the image.
      *
-     * @return The hash of the image.
+     * @return The raw data of the image.
      */
-    public String getHash() {
-        return hash;
+    public byte[] getData() {
+        return data;
     }
 
     /**
@@ -88,55 +88,49 @@ public final class Image {
     }
 
     /**
+     * Gets the Base64-encoded data of the image.
+     *
+     * @return The Base64-encoded data of the image.
+     */
+    public String getHash() {
+        return Base64.getEncoder().encodeToString(data);
+    }
+
+    /**
      * Gets a data URI for this image.
      *
      * @return The data URI for this image.
      */
-    public String getData() {
-        return String.format("data:image/%s;base64,%s", format.extension, hash);
+    public String getDataUri() {
+        return String.format("data:image/%s;base64,%s", format.extension, getHash());
     }
 
-    /**
-     * Indicates whether some other object is "equal to" this {@code Image}.
-     * The other object is considered equal if:
-     * <ul>
-     * <li>It is also a {@code Image} and;</li>
-     * <li>Both instances have equal {@link #getData()} data}.</li>
-     * </ul>
-     *
-     * @param obj An object to be tested for equality.
-     * @return {@code true} if the other object is "equal to" this one, false otherwise.
-     */
-    @Override
-    public boolean equals(@Nullable final Object obj) {
-        return (obj instanceof Image) && ((Image) obj).getData().equals(getData());
-    }
-
-    /**
-     * Gets the hash code value of the {@link #getData()} data}.
-     *
-     * @return The hash code value of the {@link #getData()} data}.
-     */
-    @Override
-    public int hashCode() {
-        return getData().hashCode();
-    }
-
-    /**
-     * Gets the String represents of this {@code Image}.
-     * <p>
-     * The format returned by this method is unspecified and may vary between implementations; however, it is guaranteed
-     * to always be non-empty. This method is not suitable for obtaining the data; use {@link #getData()} instead.
-     *
-     * @return The String representation of this {@code Image}.
-     * @see #getData()
-     */
     @Override
     public String toString() {
         return "Image{" +
-                "hash='" + hash + '\'' +
+                "data=" + Arrays.toString(data) +
                 ", format=" + format +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Image image = (Image) o;
+        return Arrays.equals(data, image.data) &&
+                format == image.format;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(format);
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
     }
 
     /**

--- a/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
@@ -79,7 +79,7 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec setIcon(@Nullable Image icon) {
-        this.icon = (icon == null) ? null : icon.getData();
+        this.icon = (icon == null) ? null : icon.getDataUri();
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
@@ -107,7 +107,7 @@ public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
      * @return This spec.
      */
     public GuildEditSpec setIcon(@Nullable Image icon) {
-        requestBuilder.icon((icon == null) ? null : icon.getData());
+        requestBuilder.icon((icon == null) ? null : icon.getDataUri());
         return this;
     }
 
@@ -129,7 +129,7 @@ public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
      * @return This spec.
      */
     public GuildEditSpec setSplash(@Nullable Image splash) {
-        requestBuilder.splash((splash == null) ? null : splash.getData());
+        requestBuilder.splash((splash == null) ? null : splash.getDataUri());
         return this;
     }
 
@@ -140,7 +140,7 @@ public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
      * @return This spec.
      */
     public GuildEditSpec setBanner(@Nullable Image banner) {
-        requestBuilder.banner((banner == null) ? null : banner.getData());
+        requestBuilder.banner((banner == null) ? null : banner.getDataUri());
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/GuildEmojiCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEmojiCreateSpec.java
@@ -55,7 +55,7 @@ public class GuildEmojiCreateSpec implements AuditSpec<GuildEmojiCreateRequest> 
      * @return This spec.
      */
     public GuildEmojiCreateSpec setImage(Image image) {
-        this.image = image.getData();
+        this.image = image.getDataUri();
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/UserEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/UserEditSpec.java
@@ -49,7 +49,7 @@ public class UserEditSpec implements Spec<UserModifyRequest> {
      * @return This spec.
      */
     public UserEditSpec setAvatar(@Nullable Image avatar) {
-        this.avatar = avatar == null ? Possible.absent() : Possible.of(avatar.getData());
+        this.avatar = avatar == null ? Possible.absent() : Possible.of(avatar.getDataUri());
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/WebhookCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookCreateSpec.java
@@ -50,7 +50,7 @@ public class WebhookCreateSpec implements AuditSpec<WebhookCreateRequest> {
      * @return This spec.
      */
     public WebhookCreateSpec setAvatar(@Nullable Image avatar) {
-        this.avatar = avatar == null ? null : avatar.getData();
+        this.avatar = avatar == null ? null : avatar.getDataUri();
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/WebhookEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookEditSpec.java
@@ -51,7 +51,7 @@ public class WebhookEditSpec implements AuditSpec<WebhookModifyRequest> {
      * @return This spec.
      */
     public WebhookEditSpec setAvatar(@Nullable Image avatar) {
-        this.avatar = avatar == null ? Possible.absent() : Possible.of(avatar.getData());
+        this.avatar = avatar == null ? Possible.absent() : Possible.of(avatar.getDataUri());
         return this;
     }
 


### PR DESCRIPTION
* Remove filtering based on image format
  This is a form of local validation which breaks with our philosophy of letting Discord take care of validation. In this case, an image url with an unsupported format will 404. As with other forms of local validation, it is a burden to maintain and doesn't gain us very much.
* Refactor `Image` to keep raw image data and to be value-based.
* Add `ApplicationInfo#getIconUrl()` and change `getIcon()` to be consistent with the rest of the image-getting methods.