### PR TITLE
Improve support for configuring shard-aware stores

### DIFF
--- a/core/src/main/java/discord4j/core/shard/ShardAwareStore.java
+++ b/core/src/main/java/discord4j/core/shard/ShardAwareStore.java
@@ -115,4 +115,11 @@ public class ShardAwareStore<K extends Comparable<K>, V extends Serializable> im
         return delete(Flux.fromIterable(keySet))
                 .then(Mono.fromRunnable(keySet::clear));
     }
+
+    @Override
+    public String toString() {
+        return "ShardAwareStore{"
+                + "valueStore=" + valueStore
+                + '}';
+    }
 }

--- a/core/src/main/java/discord4j/core/shard/ShardAwareStoreService.java
+++ b/core/src/main/java/discord4j/core/shard/ShardAwareStoreService.java
@@ -59,7 +59,7 @@ public class ShardAwareStoreService implements StoreService {
 
     @Override
     public boolean hasLongObjStores() {
-        return backingStoreService.hasLongObjStores();
+        return true;
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/shard/ShardAwareStoreService.java
+++ b/core/src/main/java/discord4j/core/shard/ShardAwareStoreService.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.shard;
+
+import java.io.Serializable;
+
+import discord4j.store.api.Store;
+import discord4j.store.api.primitive.ForwardingStore;
+import discord4j.store.api.primitive.LongObjStore;
+import discord4j.store.api.service.StoreService;
+import discord4j.store.api.util.StoreContext;
+import reactor.core.publisher.Mono;
+
+public class ShardAwareStoreService implements StoreService {
+
+    private final ShardingStoreRegistry registry;
+    private final StoreService backingStoreService;
+
+    volatile Class<?> messageClass;
+    volatile int shardId;
+
+    public ShardAwareStoreService(ShardingStoreRegistry registry, StoreService backingStoreService) {
+        this.registry = registry;
+        this.backingStoreService = backingStoreService;
+    }
+
+    @Override
+    public boolean hasGenericStores() {
+        return backingStoreService.hasGenericStores();
+    }
+
+    @Override
+    public <K extends Comparable<K>, V extends Serializable> Store<K, V> provideGenericStore(Class<K> keyClass,
+            Class<V> valueClass) {
+        if (!registry.containsStore(valueClass)) {
+            registry.putStore(valueClass, backingStoreService.provideGenericStore(keyClass, valueClass));
+        }
+        return new ShardAwareStore<>(registry.getValueStore(keyClass, valueClass), registry.getKeyStore(valueClass, shardId));
+    }
+
+    @Override
+    public boolean hasLongObjStores() {
+        return backingStoreService.hasLongObjStores();
+    }
+
+    @Override
+    public <V extends Serializable> LongObjStore<V> provideLongObjStore(Class<V> valueClass) {
+        return new ForwardingStore<>(provideGenericStore(Long.class, valueClass));
+    }
+
+    @Override
+    public void init(StoreContext context) {
+        backingStoreService.init(context);
+        messageClass = context.getMessageClass();
+        shardId = context.getShard();
+    }
+
+    @Override
+    public Mono<Void> dispose() {
+        return backingStoreService.dispose();
+    }
+}

--- a/core/src/main/java/discord4j/core/shard/ShardAwareStoreService.java
+++ b/core/src/main/java/discord4j/core/shard/ShardAwareStoreService.java
@@ -26,6 +26,10 @@ import discord4j.store.api.service.StoreService;
 import discord4j.store.api.util.StoreContext;
 import reactor.core.publisher.Mono;
 
+/**
+ * Factory that delegates the creation of the store to a backing factory and then wraps it into a
+ * {@link ShardAwareStore}.
+ */
 public class ShardAwareStoreService implements StoreService {
 
     private final ShardingStoreRegistry registry;

--- a/core/src/test/java/discord4j/core/StoreBotTest.java
+++ b/core/src/test/java/discord4j/core/StoreBotTest.java
@@ -71,7 +71,7 @@ public class StoreBotTest {
         new ShardingClientBuilder(token)
                 .setShardingStoreRegistry(registry)
                 // showcase disabling the cache for messages
-                .setStoreServiceForShard(index -> MappingStoreService.create()
+                .setStoreService(MappingStoreService.create()
                         //.setMapping(new NoOpStoreService(), MessageBean.class)
                         .setFallback(new JdkStoreService()))
                 .build()

--- a/core/src/test/java/discord4j/core/StoreBotTest.java
+++ b/core/src/test/java/discord4j/core/StoreBotTest.java
@@ -24,9 +24,10 @@ import discord4j.core.event.domain.Event;
 import discord4j.core.object.presence.Presence;
 import discord4j.core.shard.ShardingClientBuilder;
 import discord4j.core.shard.ShardingJdkStoreRegistry;
-import discord4j.core.shard.ShardingJdkStoreService;
 import discord4j.core.shard.ShardingStoreRegistry;
 import discord4j.store.api.mapping.MappingStoreService;
+import discord4j.store.jdk.JdkStoreService;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -69,12 +70,12 @@ public class StoreBotTest {
         ShardingStoreRegistry registry = new ShardingJdkStoreRegistry();
         new ShardingClientBuilder(token)
                 .setShardingStoreRegistry(registry)
+                // showcase disabling the cache for messages
+                .setStoreServiceForShard(index -> MappingStoreService.create()
+                        //.setMapping(new NoOpStoreService(), MessageBean.class)
+                        .setFallback(new JdkStoreService()))
                 .build()
                 .map(builder -> builder.setJacksonResourceProvider(jackson)
-                        // showcase disabling the cache for messages
-                        .setStoreService(MappingStoreService.create()
-                                //.setMapping(new NoOpStoreService(), MessageBean.class)
-                                .setFallback(new ShardingJdkStoreService(registry)))
                         .setInitialPresence(Presence.invisible()))
                 .map(DiscordClientBuilder::build)
                 .doOnNext(client -> clients.put(client.getConfig().getShardIndex(), client))

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -4,7 +4,6 @@
     <logger name="reactor" level="INFO"/>
     <logger name="reactor.retry" level="INFO"/>
     <logger name="discord4j.core" level="INFO"/>
-    <logger name="discord4j.core.StateHolder" level="DEBUG"/>
     <logger name="discord4j.gateway.client" level="INFO"/>
     <logger name="discord4j.gateway.inbound" level="INFO"/>
     <logger name="discord4j.gateway.outbound" level="INFO"/>

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -4,6 +4,7 @@
     <logger name="reactor" level="INFO"/>
     <logger name="reactor.retry" level="INFO"/>
     <logger name="discord4j.core" level="INFO"/>
+    <logger name="discord4j.core.StateHolder" level="DEBUG"/>
     <logger name="discord4j.gateway.client" level="INFO"/>
     <logger name="discord4j.gateway.inbound" level="INFO"/>
     <logger name="discord4j.gateway.outbound" level="INFO"/>


### PR DESCRIPTION
**Description**:

- Adds a new class `ShardAwareStoreService`, a wrapper `StoreService` that allows to make any implementation of `Store` shard-aware
- Adds a new method `ShardingClientBuilder#setStoreService` that provides a higher level of abstraction to configure shard-aware stores when building a sharding client
- Adds toString method to `ShardAwareStore`
- Added docs and tests for the aforementioned changes

**Justification:**

Currently the support for configuring shard-aware stores is very limited. Discord4J provides only one class to achieve this, `ShardingJdkStoreService`, which is the default implementation used when building multi-sharded DiscordClients, and is only applicable for the `JdkStore` implementation.

When I switched to Caffeine for messages store, the only way I found to make it shard-aware was by creating my own class `ShardingCaffeineStoreService` which is basically a copy-paste of the source code of `ShardingJdkStoreService`, but extending `CaffeineStoreSevice` instead of `JdkStoreService` : https://gist.github.com/Alex1304/0c076bcbcdee21f3a1d2035f12d7d9c7. Here is how I use it:

```java
ShardingStoreRegistry registry = new ShardingJdkStoreRegistry();
Flux<DiscordClient> discordClients = new ShardingClientBuilder(token)
        .build()
        .map(dcb -> dcb.setStoreService(MappingStoreService.create()
                .setMapping(new ShardingCaffeineStoreService(storeRegistry, builder -> builder
                        .maximumSize(messageCacheMaxSize)
                        .expireAfterWrite(messageCacheTtl)), MessageBean.class)
                .setFallback(new ShardingJdkStoreService(storeRegistry))))
        .map(DiscordClientBuilder::build)
        .cache();
```

It works, but in my opinion is not convenient at all, because we would need to create a such class for each Store impl. So my idea was simply to have a generic class accepting any kind of StoreService, that delegates the creation of the Store impl and then wraps a `ShardAwareStore` around it. Here is the said class in action (called `ShardAwareStoreService`):

```java
ShardingStoreRegistry registry = new ShardingJdkStoreRegistry();
Flux<DiscordClient> discordClients = new ShardingClientBuilder(token)
        .build()
        .map(dcb -> dcb.setStoreService(MappingStoreService.create()
                .setMapping(new ShardAwareStoreService(storeRegistry, new CaffeineStoreService(builder -> builder
                        .maximumSize(messageCacheMaxSize)
                        .expireAfterWrite(messageCacheTtl))), MessageBean.class)
                .setFallback(new ShardingJdkStoreService(storeRegistry))
                // or equivalent:
                .setFallback(new ShardAwareStoreService(storeRegistry, new JdkStoreService()))))
        .map(DiscordClientBuilder::build)
        .cache();
```

I think it will even be possible to deprecate `ShardingJdkStoreService` since `new ShardAwareStoreService(storeRegistry, new JdkStoreService())` is equivalent. I didn't do it cuz I'm not sure about the deprecation policy for classes in D4J.

This is better, but there's something else that bothers me: the fact that it's still up to you to instantiate and manage the `ShardingStoreRegistry`, even if you want to use the default one. I felt like a method was missing in `ShardingClientBuilder` to make abstraction of it, and also that `ShardingClientBuilder#setStoreServiceRegistry` almost had no use. That's how I got the idea for the `ShardingClientBuilder#setStoreService` method, which is similar to `DiscordClientBuilder#setStoreService` but at the sharding level. That way you just need to tell which `StoreService` to use for each shard, and at build time it will wrap all of them in a `ShardAwareStoreService` using the provided (or default) `ShardingStoreRegistry` for you. It greatly simplifies the code as you won't need to deal with `ShardingStoreRegistry` nor even `ShardAwareStoreService` anymore, the builder does everything for you:

```java
Flux<DiscordClient> discordClients = new ShardingClientBuilder(token)
        .setStoreService(MappingStoreService.create()
                .setMapping(new CaffeineStoreService(builder -> builder
                        .maximumSize(messageCacheMaxSize)
                        .expireAfterWrite(messageCacheTtl)), MessageBean.class)
                .setFallback(new JdkStoreService()))
        .build()
        .map(DiscordClientBuilder::build)
        .cache();
```

On another note, I used `StoreBotTest` to test the new method, and I added a toString to `ShardAwareStore` to know the Store type it wraps (I realized it was missing when I wanted to debug).