### PR TITLE
Improve handling of sorting for guild channels and roles

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -33,6 +33,7 @@ import discord4j.core.object.util.Snowflake;
 import discord4j.core.spec.*;
 import discord4j.core.util.EntityUtil;
 import discord4j.core.util.ImageUtil;
+import discord4j.core.util.OrderUtil;
 import discord4j.core.util.PaginationUtil;
 import discord4j.rest.json.request.NicknameModifyRequest;
 import discord4j.rest.json.response.AuditLogEntryResponse;
@@ -332,16 +333,14 @@ public final class Guild implements Entity {
     /**
      * Requests to retrieve the guild's roles.
      * <p>
-     * The returned {@code Flux} will emit items in order based off their <i>natural</i> position, which is indicated
-     * visually in the Discord client. For roles, the "lowest" role will be emitted first.
+     * The order of items emitted by the returned {@code Flux} is unspecified.
      *
      * @return A {@link Flux} that continually emits the guild's {@link Role roles}. If an error is received, it is
      * emitted through the {@code Flux}.
      */
     public Flux<Role> getRoles() {
         return Flux.fromIterable(getRoleIds())
-                .flatMap(id -> getClient().getRoleById(getId(), id))
-                .sort(Comparator.comparing(Role::getRawPosition).thenComparing(Role::getId));
+                .flatMap(id -> getClient().getRoleById(getId(), id));
     }
 
     /**
@@ -576,13 +575,12 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Requests to retrieve the channels of the guild.
+     * Requests to retrieve the guild's channels.
      * <p>
-     * The returned {@code Flux} will emit items in order based off their <i>natural</i> position, which is indicated
-     * visually in the Discord client. For channels, the "highest" channel will be emitted first.
+     * The order of items emitted by the returned {@code Flux} is unspecified.
      *
-     * @return A {@link Flux} that continually emits the {@link GuildChannel channels} of the guild. If an error is
-     * received, it is emitted through the {@code Flux}.
+     * @return A {@link Flux} that continually emits the guild's {@link GuildChannel channels}. If an error is received, it is
+     * emitted through the {@code Flux}.
      */
     public Flux<GuildChannel> getChannels() {
         return Mono.justOrEmpty(getGatewayData())
@@ -598,8 +596,7 @@ public final class Guild implements Entity {
                         .map(ChannelBean::new)
                         .map(bean -> EntityUtil.getChannel(serviceMediator, bean))
                         .cast(GuildChannel.class)
-                        .subscriberContext(ctx -> ctx.put("shard", serviceMediator.getClientConfig().getShardIndex())))
-                .sort(Comparator.comparing(GuildChannel::getRawPosition).thenComparing(GuildChannel::getId));
+                        .subscriberContext(ctx -> ctx.put("shard", serviceMediator.getClientConfig().getShardIndex())));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -333,7 +333,8 @@ public final class Guild implements Entity {
     /**
      * Requests to retrieve the guild's roles.
      * <p>
-     * The order of items emitted by the returned {@code Flux} is unspecified.
+     * The order of items emitted by the returned {@code Flux} is unspecified. Use {@link OrderUtil#orderRoles(Flux)}
+     * to consistently order roles.
      *
      * @return A {@link Flux} that continually emits the guild's {@link Role roles}. If an error is received, it is
      * emitted through the {@code Flux}.
@@ -577,7 +578,8 @@ public final class Guild implements Entity {
     /**
      * Requests to retrieve the guild's channels.
      * <p>
-     * The order of items emitted by the returned {@code Flux} is unspecified.
+     * The order of items emitted by the returned {@code Flux} is unspecified. Use {@link OrderUtil#orderGuildChannels(Flux)}
+     * to consistently order channels.
      *
      * @return A {@link Flux} that continually emits the guild's {@link GuildChannel channels}. If an error is received, it is
      * emitted through the {@code Flux}.

--- a/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
@@ -26,6 +26,7 @@ import discord4j.core.object.util.Snowflake;
 import discord4j.core.spec.GuildEmojiEditSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.core.util.ImageUtil;
+import discord4j.core.util.OrderUtil;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
@@ -105,7 +106,8 @@ public final class GuildEmoji implements Entity {
     /**
      * Requests to retrieve the roles this emoji is whitelisted to.
      * <p>
-     * The order of items emitted by the returned {@code Flux} is unspecified.
+     * The order of items emitted by the returned {@code Flux} is unspecified. Use {@link OrderUtil#orderRoles(Flux)}
+     * to consistently order roles.
      *
      * @return A {@link Flux} that continually emits the {@link Role roles} this emoji is whitelisted for. if an error
      * is received, it is emitted through the {@code Flux}.

--- a/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
@@ -105,15 +105,13 @@ public final class GuildEmoji implements Entity {
     /**
      * Requests to retrieve the roles this emoji is whitelisted to.
      * <p>
-     * The returned {@code Flux} will emit items in order based off their <i>natural</i> position, which is indicated
-     * visually in the Discord client. For roles, the "lowest" role will be emitted first.
+     * The order of items emitted by the returned {@code Flux} is unspecified.
      *
      * @return A {@link Flux} that continually emits the {@link Role roles} this emoji is whitelisted for. if an error
      * is received, it is emitted through the {@code Flux}.
      */
     public Flux<Role> getRoles() {
-        return Flux.fromIterable(getRoleIds()).flatMap(id -> getClient().getRoleById(getGuildId(), id))
-                .sort(Comparator.comparing(Role::getRawPosition).thenComparing(Role::getId));
+        return Flux.fromIterable(getRoleIds()).flatMap(id -> getClient().getRoleById(getGuildId(), id));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -90,7 +90,8 @@ public final class Member extends User {
     /**
      * Requests to retrieve the user's guild roles.
      * <p>
-     * The order of items emitted by the returned {@code Flux} is unspecified.
+     * The order of items emitted by the returned {@code Flux} is unspecified. Use {@link OrderUtil#orderRoles(Flux)}
+     * to consistently order roles.
      *
      * @return A {@link Flux} that continually emits the user's guild {@link Role roles}. If an error is received, it is
      * emitted through the {@code Flux}.

--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseChannel.java
@@ -89,7 +89,14 @@ class BaseChannel implements Channel {
 
     @Override
     public final boolean equals(@Nullable final Object obj) {
-        return EntityUtil.equals(this, obj);
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || !BaseChannel.class.isAssignableFrom(obj.getClass())) {
+            return false;
+        }
+        BaseChannel that = (BaseChannel) obj;
+        return getId().equals(that.getId());
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildChannel.java
@@ -25,6 +25,7 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.Member;
 import discord4j.core.object.util.PermissionSet;
 import discord4j.core.object.util.Snowflake;
+import discord4j.core.util.OrderUtil;
 import discord4j.core.util.PermissionUtil;
 import discord4j.rest.json.request.PermissionsEditRequest;
 import reactor.core.publisher.Mono;
@@ -115,7 +116,11 @@ class BaseGuildChannel extends BaseChannel implements GuildChannel {
 
     @Override
     public final Mono<Integer> getPosition() {
-        return getGuild().flatMapMany(Guild::getChannels).collectList().map(list -> list.indexOf(this));
+        return getGuild()
+                .flatMapMany(Guild::getChannels)
+                .transform(OrderUtil::orderGuildChannels)
+                .collectList()
+                .map(channels -> channels.indexOf(this));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/GuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/GuildChannel.java
@@ -21,6 +21,8 @@ import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.object.util.PermissionSet;
 import discord4j.core.object.util.Snowflake;
+import discord4j.core.util.OrderUtil;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
@@ -92,6 +94,25 @@ public interface GuildChannel extends Channel {
 
     /**
      * Requests to retrieve the position of the channel relative to other channels in the guild.
+     * <p>
+     * This is determined by the index of this channel in the {@link OrderUtil#orderGuildChannels(Flux) sorted} list of channels of the guild.
+     * <p>
+     * Warning: Because this method must sort the guild channels, it is inefficient to make repeated invocations for the
+     * same set of channels (meaning that channels haven't been added or removed). For example, instead of writing:
+     * <pre>
+     * {@code
+     * guild.getChannels()
+     *   .flatMap(c -> c.getPosition().map(pos -> c.getName() + " : " + pos))
+     * }
+     * </pre>
+     * It would be much more efficient to write:
+     * <pre>
+     * {@code
+     * guild.getChannels()
+     *   .transform(OrderUtil::orderGuildChannels)
+     *   .index((pos, c) -> c.getName() + " : " + pos)
+     * }
+     * </pre>
      *
      * @return A {@link Mono} where, upon successful completion, emits the position of the channel. If an error is
      * received, it is emitted through the {@code Mono}.

--- a/core/src/main/java/discord4j/core/util/OrderUtil.java
+++ b/core/src/main/java/discord4j/core/util/OrderUtil.java
@@ -25,7 +25,9 @@ import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Flux;
 
 import java.util.*;
+import java.util.function.Function;
 
+/** A utility class for the sorting of {@link Role roles} and {@link GuildChannel guild channels}. */
 public final class OrderUtil {
 
     /**
@@ -70,6 +72,14 @@ public final class OrderUtil {
      * Sorts {@link GuildChannel guild channels} according to visual ordering in Discord. Channels at the top of the
      * list are first. This sorts channels within the same category according to {@link #BUCKETED_CHANNEL_ORDER} and
      * then sorts those categories according to {@link #CHANNEL_ORDER}.
+     * <p>
+     * This function can be used with {@link Flux#transform(Function)} for better chaining:
+     * <pre>
+     * {@code
+     * guild.getChannels()
+     *   .transform(OrderUtil::orderGuildChannels)
+     * }
+     * </pre>
      *
      * @param channels The guild channels to sort.
      * @return The sorted guild channels.
@@ -83,6 +93,14 @@ public final class OrderUtil {
     /**
      * Sorts {@link Role roles} according to visual ordering in Discord. Roles at the bottom of the list are first. This
      * sorts roles according to {@link #ROLE_ORDER}.
+     * <p>
+     * This function can be used with {@link Flux#transform(Function)} for better chaining:
+     * <pre>
+     * {@code
+     * guild.getRoles()
+     *   .transform(OrderUtil::orderRoles)
+     * }
+     * </pre>
      *
      * @param roles The roles to sort.
      * @return The sorted roles.

--- a/core/src/main/java/discord4j/core/util/OrderUtil.java
+++ b/core/src/main/java/discord4j/core/util/OrderUtil.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.util;
+
+import discord4j.core.object.entity.Role;
+import discord4j.core.object.entity.channel.CategorizableChannel;
+import discord4j.core.object.entity.channel.Category;
+import discord4j.core.object.entity.channel.GuildChannel;
+import discord4j.core.object.entity.channel.VoiceChannel;
+import discord4j.core.object.util.Snowflake;
+import reactor.core.publisher.Flux;
+
+import java.util.*;
+
+public final class OrderUtil {
+
+    /**
+     * The ordering of Discord {@link Role roles}.
+     * <p>
+     * In Discord, two orderable entities may have the same "raw position," the position as reported by the "position" field.
+     * This conflict is resolved by comparing the creation time of the entities, reflected in their {@link Snowflake IDs}.
+     */
+    public static Comparator<Role> ROLE_ORDER =
+            Comparator.comparing(Role::getRawPosition).thenComparing(Role::getId);
+
+    /**
+     * The base ordering of Discord {@link GuildChannel guild channels}.
+     * <p>
+     * In Discord, two orderable entities may have the same "raw position," the position as reported by the "position" field.
+     * This conflict is resolved by comparing the creation time of the entities, reflected in their {@link Snowflake IDs}.
+     * <p>
+     * Note that this order is only applicable to channels if they are of the same type and in the same category. See
+     * {@link #BUCKETED_CHANNEL_ORDER} for ordering between different channel types.
+     */
+    public static Comparator<GuildChannel> CHANNEL_ORDER =
+            Comparator.comparing(GuildChannel::getRawPosition).thenComparing(GuildChannel::getId);
+
+    /**
+     * The ordering of {@link GuildChannel guild channels} which considers channel type.
+     * <p>
+     * Guild channels are first ordered by "bucket" which is determined by the type of the channels. Then,
+     * {@link #CHANNEL_ORDER} is used to determine order within a buvket. Effectively, this only means that voice
+     * channels always appear below other types of channels.
+     * <p>
+     * Note that this order is only applicable to channels if they are in the same category.
+     */
+    public static Comparator<CategorizableChannel> BUCKETED_CHANNEL_ORDER =
+            Comparator.<CategorizableChannel>comparingInt(c -> {
+                if (c instanceof VoiceChannel) {
+                    return 1;
+                }
+                return 0;
+            }).thenComparing(CHANNEL_ORDER);
+
+    /**
+     * Sorts {@link GuildChannel guild channels} according to visual ordering in Discord. Channels at the top of the
+     * list are first. This sorts channels within the same category according to {@link #BUCKETED_CHANNEL_ORDER} and
+     * then sorts those categories according to {@link #CHANNEL_ORDER}.
+     *
+     * @param channels The guild channels to sort.
+     * @return The sorted guild channels.
+     */
+    public static Flux<GuildChannel> orderGuildChannels(Flux<GuildChannel> channels) {
+        return channels
+                .collectMap(GuildChannel::getId) // associate channels to ids
+                .flatMapIterable(OrderUtil::orderGuildChannels);
+    }
+
+    /**
+     * Sorts {@link Role roles} according to visual ordering in Discord. Roles at the bottom of the list are first. This
+     * sorts roles according to {@link #ROLE_ORDER}.
+     *
+     * @param roles The roles to sort.
+     * @return The sorted roles.
+     */
+    public static Flux<Role> orderRoles(Flux<Role> roles) {
+        return roles.sort(OrderUtil.ROLE_ORDER);
+    }
+
+    private static List<GuildChannel> orderGuildChannels(Map<Snowflake, GuildChannel> channels) {
+        // associate channels to their parent category
+        // sorted by raw position then ID
+        // channels not in a category always appear before all other channels, so nulls are first
+        Map<Category, SortedSet<CategorizableChannel>> byCategory = new TreeMap<>(Comparator.nullsFirst(CHANNEL_ORDER));
+        channels.forEach((id, channel) -> {
+            if (channel instanceof CategorizableChannel) {
+                CategorizableChannel categorizable = (CategorizableChannel) channel;
+                Category parent = (Category) channels.get(categorizable.getCategoryId().orElse(null));
+
+                // add the channel to the set of channels in the category (creating the set if necessary)
+                // sorted by sort bucket, then raw position, then ID
+                // sort bucket is determined by channel type. Voice channels always appear below other types
+                byCategory.computeIfAbsent(parent, __ -> new TreeSet<>(BUCKETED_CHANNEL_ORDER)).add(categorizable);
+            } else {
+                // to account for empty categories
+                byCategory.putIfAbsent(((Category) channel), new TreeSet<>(BUCKETED_CHANNEL_ORDER));
+            }
+        });
+
+        // flatten the map into a list which must be sorted
+        List<GuildChannel> sorted = new ArrayList<>();
+        byCategory.forEach((category, children) -> {
+            if (category != null) { // don't add the "parent" of channels which don't have one
+                sorted.add(category);
+            }
+            sorted.addAll(children);
+        });
+
+        return sorted;
+    }
+}


### PR DESCRIPTION
**Description:** <!-- A description of the changes made in this pull request. -->
* The order of emitted items from the following methods is now unspecified:
  - `Guild#getRoles()`
  - `Guild#getChannels()`
  - `GuildEmoji#getRoles()`
  - `Member#getRoles()`
* Centralize sorting behavior in `OrderUtil`.
* Change `Member#hasHigherRoles()`
  - Now accepts `Set<Snowflake>`
  - No longer defensively checks that roles belong to the same guild

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
* Defaulting to sorted is inefficient when most people don't care about the ordering. If they do care, they can still very easily access the sorted roles/channels.
* Centralized code in `OrderUtil` deduplicates sorting logic and will allow for testing.
* `Member#hasHigherRoles()` is more efficient by only sorting all of the guild roles once (instead of three times) and by making a maximum of 1 HTTP request. 
* Fix #529 . `OrderUtil#orderGuildChannels()` sorts correctly. 

**Migration:**
Any calls to the above methods which relied on the order of emitted items should use the appropriate method from `OrderUtil`. For example, `guild.getRoles()` becomes `guild.getRoles().transform(OrderUtil::orderRoles)`.