### PR TITLE
Add docs for voice kick to setNewVoiceChannel

### DIFF
--- a/core/src/main/java/discord4j/core/spec/GuildMemberEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildMemberEditSpec.java
@@ -39,7 +39,7 @@ public class GuildMemberEditSpec implements AuditSpec<GuildMemberModifyRequest> 
      * Sets the new voice channel to move the targeted {@link Member}, if they are connected to voice. Requires the
      * {@link Permission#MOVE_MEMBERS} permission.
      *
-     * @param channel The voice channel identifier.
+     * @param channel The voice channel identifier or null to disconnect from voice channel.
      * @return This spec.
      */
     public GuildMemberEditSpec setNewVoiceChannel(@Nullable Snowflake channel) {


### PR DESCRIPTION
**Description:** A little changes for understand you can "kick" members from channel voice

**Justification:** The actual docs not specific you can pass a null Snowflake channelid for kick a member.

**Note:** i dont know is is necesary a method like (Member::kick) for kickVoice because its strange use newchannel for kick cases.