### PR TITLE
EmbedCreateSpec update for the addition of already instantiated EmbedFieldEntities

### DIFF
--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
@@ -149,6 +149,18 @@ public class EmbedCreateSpec implements Spec<EmbedRequest> {
         this.fields.add(new EmbedFieldEntity(name, value, inline));
         return this;
     }
+    
+    /**
+     * Adds a field to the embed. 
+     * 
+     * @param entity An already instantiated {@link EmbedFieldEntity}
+     * @return This spec.
+     * @see {@link #addField(String, String, boolean)}
+     */
+    public EmbedCreateSpec addField(EmbedFieldEntity entity) {
+    	this.fields.add(entity);
+    	return this;
+    }
 
     @Override
     public EmbedRequest asRequest() {


### PR DESCRIPTION
**Description:**
I wrote a short method with the corresponding documentation to add an already instantiated EmbedFieldEntity to an EmbedCreateSpec's list of fields.

**Justification:**
Allowing the developer to create an EmbedFieldEntity before passing it into the addField(String, String, boolean) method allows for some more flexibility in their code