### PR TITLE
Change return type of  ClientException#getErrorResponse

### DIFF
--- a/rest/src/main/java/discord4j/rest/http/client/ClientException.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientException.java
@@ -23,12 +23,14 @@ import discord4j.rest.route.Route;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.util.Optional;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClientResponse;
 import reactor.retry.Backoff;
 import reactor.retry.Retry;
 import reactor.retry.RetryContext;
+import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
@@ -127,9 +129,9 @@ public class ClientException extends RuntimeException {
      *
      * @return the Discord error response, if present.
      */
-    @Nullable
-    public ErrorResponse getErrorResponse() {
-        return errorResponse;
+    @NonNull
+    public Optional<ErrorResponse> getErrorResponse() {
+        return Optional.ofNullable(errorResponse);
     }
 
     @Override

--- a/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
@@ -63,7 +63,7 @@ public class UserServiceTest {
         try {
             getUserService().getUser(1111222).block(); // should throw ClientException
         } catch (ClientException e) {
-            ErrorResponse response = e.getErrorResponse();
+            ErrorResponse response = e.getErrorResponse().orElse(null);
             System.out.println("Error code: " + response.getFields().get("code"));
             System.out.println("Error message: " + response.getFields().get("message"));
         }


### PR DESCRIPTION
**Description:** 
Change the return type of ClientException#getErrorResponse() from a Nullable ErrorResponse to an Optional\<ErrorResponse\>.

**Justification:**
This change was requested in Issue #517