### PR TITLE
Fix typo with premium_subscription_count guild field

### DIFF
--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -280,6 +280,10 @@ public class BaseGuildBean implements Serializable {
         return premiumTier;
     }
 
+    public void setPremiumTier(final int premiumTier) {
+        this.premiumTier = premiumTier;
+    }
+
     public int getDefaultMessageNotifications() {
         return defaultMessageNotifications;
     }

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -46,7 +46,6 @@ public class BaseGuildBean implements Serializable {
     @Nullable
     private Long embedChannelId;
     private int premiumTier;
-    private int premiumSubscriptionsCount;
     private int verificationLevel;
     private int defaultMessageNotifications;
     private int explicitContentFilter;

--- a/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
@@ -32,7 +32,7 @@ public final class GuildBean extends BaseGuildBean {
 
     private String joinedAt;
     private boolean large;
-    private int premiumSubscriptionsCount;
+    private int premiumSubscriptionCount;
     private int memberCount;
     private long[] members;
     private long[] channels;
@@ -43,12 +43,12 @@ public final class GuildBean extends BaseGuildBean {
         this.joinedAt = guildCreate.getJoinedAt();
         this.large = guildCreate.isLarge();
         this.memberCount = guildCreate.getMemberCount();
-        this.premiumSubscriptionsCount = guildCreate.getPremiumSubcriptionsCount();
+        this.premiumSubscriptionCount = guildCreate.getPremiumSubscriptionCount();
 
         members = Arrays.stream(guildCreate.getMembers())
                 .map(GuildMemberResponse::getUser)
                 .mapToLong(UserResponse::getId)
-                .distinct() 
+                .distinct()
                 .toArray();
 
         channels = Arrays.stream(guildCreate.getChannels())
@@ -94,12 +94,12 @@ public final class GuildBean extends BaseGuildBean {
         this.large = large;
     }
 
-    public int getPremiumSubscriptionsCount() {
-        return premiumSubscriptionsCount;
+    public int getPremiumSubscriptionCount() {
+        return premiumSubscriptionCount;
     }
 
-    public void setPremiumSubscriptionsCount(final Integer premiumSubscriptionsCount) {
-        this.premiumSubscriptionsCount = premiumSubscriptionsCount;
+    public void setPremiumSubscriptionCount(final Integer premiumSubscriptionCount) {
+        this.premiumSubscriptionCount = premiumSubscriptionCount;
     }
 
     public int getMemberCount() {
@@ -132,7 +132,7 @@ public final class GuildBean extends BaseGuildBean {
                 "joinedAt='" + joinedAt + '\'' +
                 ", large=" + large +
                 ", memberCount=" + memberCount +
-                ", premiumSubscriptionsCount=" + premiumSubscriptionsCount +
+                ", premiumSubscriptionCount=" + premiumSubscriptionCount +
                 ", members=" + Arrays.toString(members) +
                 ", channels=" + Arrays.toString(channels) +
                 "} " + super.toString();

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -54,8 +54,6 @@ import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static discord4j.core.object.util.Image.Format.*;
-
 /**
  * A Discord guild.
  *

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -506,9 +506,9 @@ public final class Guild implements Entity {
      * {@link GuildBean} instances <b>OR</b> the bot is currently not logged in then the returned {@code Optional} will
      * always be empty.
      */
-    public OptionalInt getPremiumSubcriptionsCount() {
+    public OptionalInt getPremiumSubscriptionCount() {
         return getGatewayData()
-            .map(guildBean -> OptionalInt.of(guildBean.getPremiumSubscriptionsCount()))
+            .map(guildBean -> OptionalInt.of(guildBean.getPremiumSubscriptionCount()))
             .orElseGet(OptionalInt::empty);
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -52,7 +52,7 @@ public class GuildCreate implements Dispatch {
     @JsonProperty("premium_tier")
     private int premiumTier;
     @JsonProperty("premium_subscription_count")
-    private int premiumSubcriptionsCount;
+    private int premiumSubscriptionCount;
     private GuildMemberResponse[] members;
     @JsonProperty("member_count")
     private int memberCount;
@@ -97,8 +97,8 @@ public class GuildCreate implements Dispatch {
         return premiumTier;
     }
 
-    public int getPremiumSubcriptionsCount() {
-        return premiumSubcriptionsCount;
+    public int getPremiumSubscriptionCount() {
+        return premiumSubscriptionCount;
     }
 
     public int getVerificationLevel() {
@@ -224,7 +224,7 @@ public class GuildCreate implements Dispatch {
                 "voiceStates=" + Arrays.toString(voiceStates) +
                 ", verificationLevel=" + verificationLevel +
                 ", premiumTier=" + premiumTier +
-                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", premiumSubscriptionCount=" + premiumSubscriptionCount +
                 ", unavailable=" + unavailable +
                 ", systemChannelId=" + systemChannelId +
                 ", splash='" + splash + '\'' +

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -37,7 +37,7 @@ public class GuildUpdate implements Dispatch {
     @JsonProperty("premium_tier")
     private int premiumTier;
     @JsonProperty("premium_subscription_count")
-    private int premiumSubcriptionsCount;
+    private int premiumSubscriptionCount;
     @JsonProperty("system_channel_id")
     @Nullable
     @UnsignedJson
@@ -94,8 +94,8 @@ public class GuildUpdate implements Dispatch {
         return premiumTier;
     }
 
-    public int getPremiumSubcriptionsCount() {
-        return premiumSubcriptionsCount;
+    public int getPremiumSubscriptionCount() {
+        return premiumSubscriptionCount;
     }
 
     public int getVerificationLevel() {
@@ -193,7 +193,7 @@ public class GuildUpdate implements Dispatch {
                 ", widgetChannelId=" + widgetChannelId +
                 ", verificationLevel=" + verificationLevel +
                 ", premiumTier=" + premiumTier +
-                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", premiumSubscriptionCount=" + premiumSubscriptionCount +
                 ", systemChannelId=" + systemChannelId +
                 ", splash='" + splash + '\'' +
                 ", splash='" + banner + '\'' +

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -68,7 +68,7 @@ public class GuildResponse {
     @JsonProperty("premium_tier")
     private int premiumTier;
     @JsonProperty("premium_subscription_count")
-    private int premiumSubcriptionsCount;
+    private int premiumSubscriptionCount;
     @JsonProperty("owner_id")
     @UnsignedJson
     private long ownerId;
@@ -155,8 +155,8 @@ public class GuildResponse {
         return premiumTier;
     }
 
-    public int getPremiumSubcriptionsCount() {
-        return premiumSubcriptionsCount;
+    public int getPremiumSubscriptionCount() {
+        return premiumSubscriptionCount;
     }
 
     public int getVerificationLevel() {
@@ -184,7 +184,7 @@ public class GuildResponse {
         return "GuildResponse{" +
                 "mfaLevel=" + mfaLevel +
                 ", premiumTier=" + premiumTier +
-                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", premiumSubscriptionCount=" + premiumSubscriptionCount +
                 ", emojis=" + Arrays.toString(emojis) +
                 ", applicationId=" + applicationId +
                 ", name='" + name + '\'' +


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** The main purpose of this pull request is to fix the name of the `premium_subscription_count` guild field because it contains a typo.
`premiumSubcriptionsCount` and `premiumSubscriptionsCount` have been renamed to `premiumSubscriptionCount`
**This is a breaking change because the getter inside the Guild class has been renamed too.**

I have removed the `premiumSubscriptionsCount` member in BaseGuildBean because it was not used and possible field are not included in this class. (This field is marked as `premium_subscription_count?` in the [DAPI documentation](https://discordapp.com/developers/docs/resources/guild)).

The setter of `premiumTier` was missing in the BaseGuildBean class.

**Justification:** Fix a typo and add consistency.