### PR TITLE
Support missing guild fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -58,6 +58,8 @@ public class BaseGuildBean implements Serializable {
     @Nullable
     private Long applicationId;
     @Nullable
+    private Boolean widgetEnabled;
+    @Nullable
     private Long widgetChannelId;
     @Nullable
     private Long systemChannelId;
@@ -99,6 +101,7 @@ public class BaseGuildBean implements Serializable {
         features = guildCreate.getFeatures();
         mfaLevel = guildCreate.getMfaLevel();
         applicationId = guildCreate.getApplicationId();
+        widgetEnabled = guildCreate.isWidgetEnabled();
         widgetChannelId = guildCreate.getWidgetChannelId();
         systemChannelId = guildCreate.getSystemChannelId();
         vanityUrlCode = guildCreate.getVanityUrlCode();
@@ -135,6 +138,7 @@ public class BaseGuildBean implements Serializable {
         features = guildUpdate.getFeatures();
         mfaLevel = guildUpdate.getMfaLevel();
         applicationId = guildUpdate.getApplicationId();
+        widgetEnabled = guildUpdate.isWidgetEnabled();
         widgetChannelId = guildUpdate.getWidgetChannelId();
         systemChannelId = guildUpdate.getSystemChannelId();
         vanityUrlCode = guildUpdate.getVanityUrlCode();
@@ -171,6 +175,7 @@ public class BaseGuildBean implements Serializable {
         features = response.getFeatures();
         mfaLevel = response.getMfaLevel();
         applicationId = response.getApplicationId();
+        widgetEnabled = response.isWidgetEnabled();
         widgetChannelId = response.getWidgetChannelId();
         systemChannelId = response.getSystemChannelId();
         vanityUrlCode = response.getVanityUrlCode();
@@ -202,6 +207,7 @@ public class BaseGuildBean implements Serializable {
         features = toCopy.getFeatures();
         mfaLevel = toCopy.getMfaLevel();
         applicationId = toCopy.getApplicationId();
+        widgetEnabled = toCopy.isWidgetEnabled();
         widgetChannelId = toCopy.getWidgetChannelId();
         systemChannelId = toCopy.getSystemChannelId();
         vanityUrlCode = toCopy.getVanityUrlCode();
@@ -375,6 +381,15 @@ public class BaseGuildBean implements Serializable {
     }
 
     @Nullable
+    public Boolean isWidgetEnabled() {
+        return widgetEnabled;
+    }
+
+    public void setWidgetEnabled(@Nullable final Boolean widgetEnabled) {
+        this.widgetEnabled = widgetEnabled;
+    }
+
+    @Nullable
     public Long getWidgetChannelId() {
         return widgetChannelId;
     }
@@ -451,6 +466,7 @@ public class BaseGuildBean implements Serializable {
                 ", features=" + Arrays.toString(features) +
                 ", mfaLevel=" + mfaLevel +
                 ", applicationId=" + applicationId +
+                ", widgetEnabled=" + widgetEnabled +
                 ", widgetChannelId=" + widgetChannelId +
                 ", systemChannelId=" + systemChannelId +
                 ", vanityUrlCode=" + vanityUrlCode +

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -67,6 +67,8 @@ public class BaseGuildBean implements Serializable {
     private String description;
     @Nullable
     private Integer maxPresences;
+    @Nullable
+    private Integer maxMembers;
 
     public BaseGuildBean(final GuildCreate guildCreate) {
         id = guildCreate.getId();
@@ -102,6 +104,7 @@ public class BaseGuildBean implements Serializable {
         vanityUrlCode = guildCreate.getVanityUrlCode();
         description = guildCreate.getDescription();
         maxPresences = guildCreate.getMaxPresences();
+        maxMembers = guildCreate.getMaxMembers();
     }
 
     public BaseGuildBean(final GuildUpdate guildUpdate) {
@@ -137,6 +140,7 @@ public class BaseGuildBean implements Serializable {
         vanityUrlCode = guildUpdate.getVanityUrlCode();
         description = guildUpdate.getDescription();
         maxPresences = guildUpdate.getMaxPresences();
+        maxMembers = guildUpdate.getMaxMembers();
     }
 
     public BaseGuildBean(final GuildResponse response) {
@@ -172,6 +176,7 @@ public class BaseGuildBean implements Serializable {
         vanityUrlCode = response.getVanityUrlCode();
         description = response.getDescription();
         maxPresences = response.getMaxPresences();
+        maxMembers = response.getMaxMembers();
     }
 
     public BaseGuildBean(final BaseGuildBean toCopy) {
@@ -202,6 +207,7 @@ public class BaseGuildBean implements Serializable {
         vanityUrlCode = toCopy.getVanityUrlCode();
         description = toCopy.getDescription();
         maxPresences = toCopy.getMaxPresences();
+        maxMembers = toCopy.getMaxMembers();
     }
 
     public BaseGuildBean() {}
@@ -413,6 +419,15 @@ public class BaseGuildBean implements Serializable {
         this.maxPresences = maxPresences;
     }
 
+    @Nullable
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
+
+    public void setMaxMembers(@Nullable final Integer maxMembers) {
+        this.maxMembers = maxMembers;
+    }
+
     @Override
     public String toString() {
         return "BaseGuildBean{" +
@@ -441,6 +456,7 @@ public class BaseGuildBean implements Serializable {
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
                 ", maxPresences=" + maxPresences +
+                ", maxMembers=" + maxMembers +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -47,6 +47,7 @@ public class BaseGuildBean implements Serializable {
     private Long embedChannelId;
     private int premiumTier;
     private int premiumSubscriptionsCount;
+    private String preferredLocale;
     private int verificationLevel;
     private int defaultMessageNotifications;
     private int explicitContentFilter;
@@ -74,6 +75,7 @@ public class BaseGuildBean implements Serializable {
         embedChannelId = guildCreate.getEmbedChannelId();
         verificationLevel = guildCreate.getVerificationLevel();
         premiumTier = guildCreate.getPremiumTier();
+        preferredLocale = guildCreate.getPreferredLocale();
 
         defaultMessageNotifications = guildCreate.getDefaultMessageNotifications();
         explicitContentFilter = guildCreate.getExplicitContentFilter();
@@ -106,6 +108,7 @@ public class BaseGuildBean implements Serializable {
         embedChannelId = guildUpdate.getEmbedChannelId();
         verificationLevel = guildUpdate.getVerificationLevel();
         premiumTier = guildUpdate.getPremiumTier();
+        preferredLocale = guildUpdate.getPreferredLocale();
         defaultMessageNotifications = guildUpdate.getDefaultMessageNotifications();
         explicitContentFilter = guildUpdate.getExplicitContentFilter();
 
@@ -137,6 +140,7 @@ public class BaseGuildBean implements Serializable {
         embedChannelId = response.getEmbedChannelId();
         verificationLevel = response.getVerificationLevel();
         premiumTier = response.getPremiumTier();
+        preferredLocale = response.getPreferredLocale();
         defaultMessageNotifications = response.getDefaultMessageNotifications();
         explicitContentFilter = response.getExplicitContentFilter();
 
@@ -168,6 +172,7 @@ public class BaseGuildBean implements Serializable {
         embedChannelId = toCopy.getEmbedChannelId();
         verificationLevel = toCopy.getVerificationLevel();
         premiumTier = toCopy.getPremiumTier();
+        preferredLocale = toCopy.getPreferredLocale();
         defaultMessageNotifications = toCopy.getDefaultMessageNotifications();
         explicitContentFilter = toCopy.getExplicitContentFilter();
 
@@ -280,6 +285,14 @@ public class BaseGuildBean implements Serializable {
         return premiumTier;
     }
 
+    public String getPreferredLocale() {
+        return preferredLocale;
+    }
+
+    public void setPreferredLocale(final String preferredLocale) {
+        this.preferredLocale = preferredLocale;
+    }
+    
     public int getDefaultMessageNotifications() {
         return defaultMessageNotifications;
     }
@@ -369,6 +382,7 @@ public class BaseGuildBean implements Serializable {
                 ", afkTimeout=" + afkTimeout +
                 ", embedChannelId=" + embedChannelId +
                 ", premiumTier=" + premiumTier +
+                ", preferredLocale=" + preferredLocale +
                 ", verificationLevel=" + verificationLevel +
                 ", defaultMessageNotifications=" + defaultMessageNotifications +
                 ", explicitContentFilter=" + explicitContentFilter +

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -65,6 +65,8 @@ public class BaseGuildBean implements Serializable {
     private String vanityUrlCode;
     @Nullable
     private String description;
+    @Nullable
+    private Integer maxPresences;
 
     public BaseGuildBean(final GuildCreate guildCreate) {
         id = guildCreate.getId();
@@ -99,6 +101,7 @@ public class BaseGuildBean implements Serializable {
         systemChannelId = guildCreate.getSystemChannelId();
         vanityUrlCode = guildCreate.getVanityUrlCode();
         description = guildCreate.getDescription();
+        maxPresences = guildCreate.getMaxPresences();
     }
 
     public BaseGuildBean(final GuildUpdate guildUpdate) {
@@ -133,6 +136,7 @@ public class BaseGuildBean implements Serializable {
         systemChannelId = guildUpdate.getSystemChannelId();
         vanityUrlCode = guildUpdate.getVanityUrlCode();
         description = guildUpdate.getDescription();
+        maxPresences = guildUpdate.getMaxPresences();
     }
 
     public BaseGuildBean(final GuildResponse response) {
@@ -167,6 +171,7 @@ public class BaseGuildBean implements Serializable {
         systemChannelId = response.getSystemChannelId();
         vanityUrlCode = response.getVanityUrlCode();
         description = response.getDescription();
+        maxPresences = response.getMaxPresences();
     }
 
     public BaseGuildBean(final BaseGuildBean toCopy) {
@@ -196,6 +201,7 @@ public class BaseGuildBean implements Serializable {
         systemChannelId = toCopy.getSystemChannelId();
         vanityUrlCode = toCopy.getVanityUrlCode();
         description = toCopy.getDescription();
+        maxPresences = toCopy.getMaxPresences();
     }
 
     public BaseGuildBean() {}
@@ -398,6 +404,15 @@ public class BaseGuildBean implements Serializable {
         this.description = description;
     }
 
+    @Nullable
+    public Integer getMaxPresences() {
+        return maxPresences;
+    }
+
+    public void setMaxPresences(@Nullable final Integer maxPresences) {
+        this.maxPresences = maxPresences;
+    }
+
     @Override
     public String toString() {
         return "BaseGuildBean{" +
@@ -425,6 +440,7 @@ public class BaseGuildBean implements Serializable {
                 ", systemChannelId=" + systemChannelId +
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
+                ", maxPresences=" + maxPresences +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -63,6 +63,8 @@ public class BaseGuildBean implements Serializable {
     private Long systemChannelId;
     @Nullable
     private String vanityUrlCode;
+    @Nullable
+    private String description;
 
     public BaseGuildBean(final GuildCreate guildCreate) {
         id = guildCreate.getId();
@@ -96,6 +98,7 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = guildCreate.getWidgetChannelId();
         systemChannelId = guildCreate.getSystemChannelId();
         vanityUrlCode = guildCreate.getVanityUrlCode();
+        description = guildCreate.getDescription();
     }
 
     public BaseGuildBean(final GuildUpdate guildUpdate) {
@@ -129,6 +132,7 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = guildUpdate.getWidgetChannelId();
         systemChannelId = guildUpdate.getSystemChannelId();
         vanityUrlCode = guildUpdate.getVanityUrlCode();
+        description = guildUpdate.getDescription();
     }
 
     public BaseGuildBean(final GuildResponse response) {
@@ -162,6 +166,7 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = response.getWidgetChannelId();
         systemChannelId = response.getSystemChannelId();
         vanityUrlCode = response.getVanityUrlCode();
+        description = response.getDescription();
     }
 
     public BaseGuildBean(final BaseGuildBean toCopy) {
@@ -190,6 +195,7 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = toCopy.getWidgetChannelId();
         systemChannelId = toCopy.getSystemChannelId();
         vanityUrlCode = toCopy.getVanityUrlCode();
+        description = toCopy.getDescription();
     }
 
     public BaseGuildBean() {}
@@ -298,7 +304,7 @@ public class BaseGuildBean implements Serializable {
     public void setPreferredLocale(final String preferredLocale) {
         this.preferredLocale = preferredLocale;
     }
-    
+
     public int getDefaultMessageNotifications() {
         return defaultMessageNotifications;
     }
@@ -383,6 +389,15 @@ public class BaseGuildBean implements Serializable {
         this.vanityUrlCode = vanityUrlCode;
     }
 
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(@Nullable final String description) {
+        this.description = description;
+    }
+
     @Override
     public String toString() {
         return "BaseGuildBean{" +
@@ -409,6 +424,7 @@ public class BaseGuildBean implements Serializable {
                 ", widgetChannelId=" + widgetChannelId +
                 ", systemChannelId=" + systemChannelId +
                 ", vanityUrlCode=" + vanityUrlCode +
+                ", description=" + description +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -61,6 +61,8 @@ public class BaseGuildBean implements Serializable {
     private Long widgetChannelId;
     @Nullable
     private Long systemChannelId;
+    @Nullable
+    private String vanityUrlCode;
 
     public BaseGuildBean(final GuildCreate guildCreate) {
         id = guildCreate.getId();
@@ -93,6 +95,7 @@ public class BaseGuildBean implements Serializable {
         applicationId = guildCreate.getApplicationId();
         widgetChannelId = guildCreate.getWidgetChannelId();
         systemChannelId = guildCreate.getSystemChannelId();
+        vanityUrlCode = guildCreate.getVanityUrlCode();
     }
 
     public BaseGuildBean(final GuildUpdate guildUpdate) {
@@ -125,6 +128,7 @@ public class BaseGuildBean implements Serializable {
         applicationId = guildUpdate.getApplicationId();
         widgetChannelId = guildUpdate.getWidgetChannelId();
         systemChannelId = guildUpdate.getSystemChannelId();
+        vanityUrlCode = guildUpdate.getVanityUrlCode();
     }
 
     public BaseGuildBean(final GuildResponse response) {
@@ -157,6 +161,7 @@ public class BaseGuildBean implements Serializable {
         applicationId = response.getApplicationId();
         widgetChannelId = response.getWidgetChannelId();
         systemChannelId = response.getSystemChannelId();
+        vanityUrlCode = response.getVanityUrlCode();
     }
 
     public BaseGuildBean(final BaseGuildBean toCopy) {
@@ -184,6 +189,7 @@ public class BaseGuildBean implements Serializable {
         applicationId = toCopy.getApplicationId();
         widgetChannelId = toCopy.getWidgetChannelId();
         systemChannelId = toCopy.getSystemChannelId();
+        vanityUrlCode = toCopy.getVanityUrlCode();
     }
 
     public BaseGuildBean() {}
@@ -368,6 +374,15 @@ public class BaseGuildBean implements Serializable {
         this.systemChannelId = systemChannelId;
     }
 
+    @Nullable
+    public String getVanityUrlCode() {
+        return vanityUrlCode;
+    }
+
+    public void setVanityUrlCode(@Nullable final String vanityUrlCode) {
+        this.vanityUrlCode = vanityUrlCode;
+    }
+
     @Override
     public String toString() {
         return "BaseGuildBean{" +
@@ -393,6 +408,7 @@ public class BaseGuildBean implements Serializable {
                 ", applicationId=" + applicationId +
                 ", widgetChannelId=" + widgetChannelId +
                 ", systemChannelId=" + systemChannelId +
+                ", vanityUrlCode=" + vanityUrlCode +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
@@ -94,7 +94,7 @@ public final class GuildBean extends BaseGuildBean {
         return large;
     }
 
-    public void setLarge(final Boolean large) {
+    public void setLarge(final boolean large) {
         this.large = large;
     }
 
@@ -110,7 +110,7 @@ public final class GuildBean extends BaseGuildBean {
         return unavailable;
     }
 
-    public void setUnavailable(final Boolean unavailable) {
+    public void setUnavailable(final boolean unavailable) {
         this.unavailable = unavailable;
     }
 
@@ -118,7 +118,7 @@ public final class GuildBean extends BaseGuildBean {
         return memberCount;
     }
 
-    public void setMemberCount(final Integer memberCount) {
+    public void setMemberCount(final int memberCount) {
         this.memberCount = memberCount;
     }
 

--- a/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
@@ -33,6 +33,7 @@ public final class GuildBean extends BaseGuildBean {
     private String joinedAt;
     private boolean large;
     private int premiumSubscriptionsCount;
+    private boolean unavailable;
     private int memberCount;
     private long[] members;
     private long[] channels;
@@ -42,6 +43,7 @@ public final class GuildBean extends BaseGuildBean {
 
         this.joinedAt = guildCreate.getJoinedAt();
         this.large = guildCreate.isLarge();
+        this.unavailable = guildCreate.isUnavailable();
         this.memberCount = guildCreate.getMemberCount();
         this.premiumSubscriptionsCount = guildCreate.getPremiumSubcriptionsCount();
 
@@ -61,6 +63,7 @@ public final class GuildBean extends BaseGuildBean {
 
         this.joinedAt = toCopy.joinedAt;
         this.large = toCopy.large;
+        this.unavailable = toCopy.unavailable;
         this.memberCount = toCopy.memberCount;
         this.members = Arrays.copyOf(toCopy.members, toCopy.members.length);
         this.channels = Arrays.copyOf(toCopy.channels, toCopy.channels.length);
@@ -71,6 +74,7 @@ public final class GuildBean extends BaseGuildBean {
 
         this.joinedAt = toCopy.getJoinedAt();
         this.large = toCopy.getLarge();
+        this.unavailable = toCopy.getUnavailable();
         this.memberCount = toCopy.getMemberCount();
         this.members = Arrays.copyOf(toCopy.members, toCopy.members.length);
         this.channels = Arrays.copyOf(toCopy.channels, toCopy.channels.length);
@@ -102,6 +106,14 @@ public final class GuildBean extends BaseGuildBean {
         this.premiumSubscriptionsCount = premiumSubscriptionsCount;
     }
 
+    public boolean getUnavailable() {
+        return unavailable;
+    }
+
+    public void setUnavailable(final Boolean unavailable) {
+        this.unavailable = unavailable;
+    }
+
     public int getMemberCount() {
         return memberCount;
     }
@@ -131,6 +143,7 @@ public final class GuildBean extends BaseGuildBean {
         return "GuildBean{" +
                 "joinedAt='" + joinedAt + '\'' +
                 ", large=" + large +
+                ", unavailable=" + unavailable +
                 ", memberCount=" + memberCount +
                 ", premiumSubscriptionsCount=" + premiumSubscriptionsCount +
                 ", members=" + Arrays.toString(members) +

--- a/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/GuildBean.java
@@ -48,7 +48,7 @@ public final class GuildBean extends BaseGuildBean {
         members = Arrays.stream(guildCreate.getMembers())
                 .map(GuildMemberResponse::getUser)
                 .mapToLong(UserResponse::getId)
-                .distinct() 
+                .distinct()
                 .toArray();
 
         channels = Arrays.stream(guildCreate.getChannels())

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -641,6 +641,15 @@ public final class Guild implements Entity {
     }
 
     /**
+     *	Gets the vanity url code of the guild, if present.
+     *
+     * @return The vanity url code of the guild, if present.
+     */
+    public Optional<String> getVanityUrlCode() {
+        return Optional.ofNullable(data.getVanityUrlCode());
+    }
+
+    /**
      * Requests to edit this guild.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link GuildEditSpec} to be operated on.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -61,6 +61,9 @@ import static discord4j.core.object.util.Image.Format.*;
  */
 public final class Guild implements Entity {
 
+    /** The default value for the maximum number of presences. **/
+    private static final int DEFAULT_MAX_PRESENCES = 5000;
+
     /** The path for guild icon image URLs. */
     private static final String ICON_IMAGE_PATH = "icons/%s/%s";
 
@@ -687,7 +690,7 @@ public final class Guild implements Entity {
      * @return The maximum amount of presences for the guild.
      */
     public int getMaxPresences() {
-        return data.getMaxPresences() == null ? 5000 : data.getMaxPresences();
+        return Optional.ofNullable(data.getMaxPresences()).orElse(DEFAULT_MAX_PRESENCES);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -499,6 +499,19 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Gets whether this guild is unavailable, if present.
+     *
+     * @return If present, {@code true} if the guild is unavailable, {@code false} otherwise.
+     *
+     * @implNote If the underlying {@link discord4j.core.DiscordClientBuilder#getStoreService() store} does not save
+     * {@link GuildBean} instances <b>OR</b> the bot is currently not logged in then the returned {@code Optional} will
+     * always be empty.
+     */
+    public Optional<Boolean> isUnavailable() {
+        return getGatewayData().map(GuildBean::getUnavailable);
+    }
+
+    /**
      * Gets the total number of members in the guild, if present.
      *
      * @return The total number of members in the guild, if present.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -433,13 +433,13 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets whether this guild widget is enabled, if present.
+     * Gets whether this guild widget is enabled.
      *
-     * @return If present, {@code true} if the guild widget is enabled, {@code false} otherwise.
+     * @return {@code true} if the guild widget is enabled, {@code false} otherwise.
      *
      */
-    public Optional<Boolean> isWidgetEnabled() {
-        return Optional.ofNullable(data.isWidgetEnabled());
+    public boolean isWidgetEnabled() {
+        return Optional.ofNullable(data.isWidgetEnabled()).orElse(false);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -659,6 +659,15 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Gets the maximum amount of presences of the guild.
+     *
+     * @return The maximum amount of presences for the guild.
+     */
+    public int getMaxPresences() {
+        return data.getMaxPresences() == null ? 5000 : data.getMaxPresences();
+    }
+
+    /**
      * Requests to edit this guild.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link GuildEditSpec} to be operated on.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -433,6 +433,16 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Gets whether this guild widget is enabled, if present.
+     *
+     * @return If present, {@code true} if the guild widget is enabled, {@code false} otherwise.
+     *
+     */
+    public Optional<Boolean> isWidgetEnabled() {
+        return Optional.ofNullable(data.isWidgetEnabled());
+    }
+
+    /**
      * Gets the channel ID for the server widget, if present.
      *
      * @return The channel ID for the server widget, if present.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -668,6 +668,15 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Gets the maximum amount of members of the guild, if present.
+     *
+     * @return The maximum amount of members for the guild, if present.
+     */
+    public OptionalInt getMaxMembers() {
+        return data.getMaxMembers() == null ? OptionalInt.empty() : OptionalInt.of(data.getMaxMembers());
+    }
+
+    /**
      * Requests to edit this guild.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link GuildEditSpec} to be operated on.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -291,9 +291,9 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets the preferred locale of this guild, only set if guild has the "DISCOVERABLE" feature, defaults to en-US.
+     * Gets the preferred locale of the guild, only set if guild has the "DISCOVERABLE" feature, defaults to en-US.
      *
-     * @return The preferred locale of this guild, only set if guild has the "DISCOVERABLE" feature, defaults to en-US.
+     * @return The preferred locale of the guild, only set if guild has the "DISCOVERABLE" feature, defaults to en-US.
      */
     public Locale getPreferredLocale() {
         return new Locale.Builder().setLanguageTag(data.getPreferredLocale()).build();
@@ -647,6 +647,15 @@ public final class Guild implements Entity {
      */
     public Optional<String> getVanityUrlCode() {
         return Optional.ofNullable(data.getVanityUrlCode());
+    }
+
+    /**
+     * Gets the description of the guild, if present.
+     *
+     * @return The description of the guild, if present.
+     */
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(data.getDescription());
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -291,6 +291,15 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Gets the preferred locale of this guild, only set if guild has the "DISCOVERABLE" feature, defaults to en-US.
+     *
+     * @return The preferred locale of this guild, only set if guild has the "DISCOVERABLE" feature, defaults to en-US.
+     */
+    public Locale getPreferredLocale() {
+        return new Locale.Builder().setLanguageTag(data.getPreferredLocale()).build();
+    }
+
+    /**
      * Gets the level of verification required for the guild.
      *
      * @return The level of verification required for the guild.

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -90,6 +90,9 @@ public class GuildCreate implements Dispatch {
     @Nullable
     @UnsignedJson
     private Long widgetChannelId;
+    @JsonProperty("widget_enabled")
+    @Nullable
+    private Boolean widgetEnabled;
     @JsonProperty("vanity_url_code")
     @Nullable
     private String vanityUrlCode;
@@ -231,6 +234,11 @@ public class GuildCreate implements Dispatch {
     }
 
     @Nullable
+    public Boolean isWidgetEnabled() {
+        return widgetEnabled;
+    }
+
+    @Nullable
     public Long getWidgetChannelId() {
         return widgetChannelId;
     }
@@ -289,6 +297,7 @@ public class GuildCreate implements Dispatch {
                 ", afkTimeout=" + afkTimeout +
                 ", afkChannelId=" + afkChannelId +
                 ", embedChannelId=" + embedChannelId +
+                ", widgetEnabled=" + widgetEnabled +
                 ", widgetChannelId=" + widgetChannelId +
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -95,6 +95,9 @@ public class GuildCreate implements Dispatch {
     private String vanityUrlCode;
     @Nullable
     private String description;
+    @JsonProperty("max_presences")
+    @Nullable
+    private Integer maxPresences;
 
     public VoiceState[] getVoiceStates() {
         return voiceStates;
@@ -239,6 +242,11 @@ public class GuildCreate implements Dispatch {
         return description;
     }
 
+    @Nullable
+    public Integer getMaxPresences() {
+        return maxPresences;
+    }
+
     @Override
     public String toString() {
         return "GuildCreate{" +
@@ -276,6 +284,7 @@ public class GuildCreate implements Dispatch {
                 ", widgetChannelId=" + widgetChannelId +
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
+                ", maxPresences=" + maxPresences +
                 '}';
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -98,6 +98,9 @@ public class GuildCreate implements Dispatch {
     @JsonProperty("max_presences")
     @Nullable
     private Integer maxPresences;
+    @JsonProperty("max_members")
+    @Nullable
+    private Integer maxMembers;
 
     public VoiceState[] getVoiceStates() {
         return voiceStates;
@@ -247,6 +250,11 @@ public class GuildCreate implements Dispatch {
         return maxPresences;
     }
 
+    @Nullable
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
+
     @Override
     public String toString() {
         return "GuildCreate{" +
@@ -285,6 +293,7 @@ public class GuildCreate implements Dispatch {
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
                 ", maxPresences=" + maxPresences +
+                ", maxMembers=" + maxMembers +
                 '}';
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -93,6 +93,8 @@ public class GuildCreate implements Dispatch {
     @JsonProperty("vanity_url_code")
     @Nullable
     private String vanityUrlCode;
+    @Nullable
+    private String description;
 
     public VoiceState[] getVoiceStates() {
         return voiceStates;
@@ -232,6 +234,11 @@ public class GuildCreate implements Dispatch {
         return vanityUrlCode;
     }
 
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
     @Override
     public String toString() {
         return "GuildCreate{" +
@@ -268,6 +275,7 @@ public class GuildCreate implements Dispatch {
                 ", embedChannelId=" + embedChannelId +
                 ", widgetChannelId=" + widgetChannelId +
                 ", vanityUrlCode=" + vanityUrlCode +
+                ", description=" + description +
                 '}';
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -53,6 +53,8 @@ public class GuildCreate implements Dispatch {
     private int premiumTier;
     @JsonProperty("premium_subscription_count")
     private int premiumSubcriptionsCount;
+    @JsonProperty("preferred_locale")
+    private String preferredLocale;
     private GuildMemberResponse[] members;
     @JsonProperty("member_count")
     private int memberCount;
@@ -99,6 +101,10 @@ public class GuildCreate implements Dispatch {
 
     public int getPremiumSubcriptionsCount() {
         return premiumSubcriptionsCount;
+    }
+
+    public String getPreferredLocale() {
+        return preferredLocale;
     }
 
     public int getVerificationLevel() {
@@ -225,6 +231,7 @@ public class GuildCreate implements Dispatch {
                 ", verificationLevel=" + verificationLevel +
                 ", premiumTier=" + premiumTier +
                 ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", preferredLocale=" + preferredLocale +
                 ", unavailable=" + unavailable +
                 ", systemChannelId=" + systemChannelId +
                 ", splash='" + splash + '\'' +

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -90,6 +90,9 @@ public class GuildCreate implements Dispatch {
     @Nullable
     @UnsignedJson
     private Long widgetChannelId;
+    @JsonProperty("vanity_url_code")
+    @Nullable
+    private String vanityUrlCode;
 
     public VoiceState[] getVoiceStates() {
         return voiceStates;
@@ -224,6 +227,11 @@ public class GuildCreate implements Dispatch {
         return widgetChannelId;
     }
 
+    @Nullable
+    public String getVanityUrlCode() {
+        return vanityUrlCode;
+    }
+
     @Override
     public String toString() {
         return "GuildCreate{" +
@@ -259,6 +267,7 @@ public class GuildCreate implements Dispatch {
                 ", afkChannelId=" + afkChannelId +
                 ", embedChannelId=" + embedChannelId +
                 ", widgetChannelId=" + widgetChannelId +
+                ", vanityUrlCode=" + vanityUrlCode +
                 '}';
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -90,6 +90,9 @@ public class GuildUpdate implements Dispatch {
     @JsonProperty("max_presences")
     @Nullable
     private Integer maxPresences;
+    @JsonProperty("max_members")
+    @Nullable
+    private Integer maxMembers;
 
     public boolean isWidgetEnabled() {
         return widgetEnabled;
@@ -215,6 +218,11 @@ public class GuildUpdate implements Dispatch {
         return maxPresences;
     }
 
+    @Nullable
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
+
     @Override
     public String toString() {
         return "GuildUpdate{" +
@@ -247,6 +255,7 @@ public class GuildUpdate implements Dispatch {
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
                 ", maxPresences=" + maxPresences +
+                ", maxMembers=" + maxMembers +
                 '}';
     }
 }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -82,6 +82,9 @@ public class GuildUpdate implements Dispatch {
     @JsonProperty("guild_id")
     @UnsignedJson
     private long guildId;
+    @JsonProperty("vanity_url_code")
+    @Nullable
+    private String vanityUrlCode;
 
     public boolean isWidgetEnabled() {
         return widgetEnabled;
@@ -192,6 +195,11 @@ public class GuildUpdate implements Dispatch {
         return guildId;
     }
 
+    @Nullable
+    public String getVanityUrlCode() {
+        return vanityUrlCode;
+    }
+
     @Override
     public String toString() {
         return "GuildUpdate{" +
@@ -221,6 +229,7 @@ public class GuildUpdate implements Dispatch {
                 ", afkTimeout=" + afkTimeout +
                 ", afkChannelId=" + afkChannelId +
                 ", guildId=" + guildId +
+                ", vanityUrlCode=" + vanityUrlCode +
                 '}';
     }
 }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -27,7 +27,8 @@ import java.util.Arrays;
 public class GuildUpdate implements Dispatch {
 
     @JsonProperty("widget_enabled")
-    private boolean widgetEnabled;
+    @Nullable
+    private Boolean widgetEnabled;
     @JsonProperty("widget_channel_id")
     @Nullable
     @UnsignedJson
@@ -94,7 +95,8 @@ public class GuildUpdate implements Dispatch {
     @Nullable
     private Integer maxMembers;
 
-    public boolean isWidgetEnabled() {
+    @Nullable
+    public Boolean isWidgetEnabled() {
         return widgetEnabled;
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -38,6 +38,8 @@ public class GuildUpdate implements Dispatch {
     private int premiumTier;
     @JsonProperty("premium_subscription_count")
     private int premiumSubcriptionsCount;
+    @JsonProperty("preferred_locale")
+    private String preferredLocale;
     @JsonProperty("system_channel_id")
     @Nullable
     @UnsignedJson
@@ -96,6 +98,10 @@ public class GuildUpdate implements Dispatch {
 
     public int getPremiumSubcriptionsCount() {
         return premiumSubcriptionsCount;
+    }
+
+    public String getPreferredLocale() {
+        return preferredLocale;
     }
 
     public int getVerificationLevel() {
@@ -194,6 +200,7 @@ public class GuildUpdate implements Dispatch {
                 ", verificationLevel=" + verificationLevel +
                 ", premiumTier=" + premiumTier +
                 ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", preferredLocale=" + preferredLocale +
                 ", systemChannelId=" + systemChannelId +
                 ", splash='" + splash + '\'' +
                 ", splash='" + banner + '\'' +

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -87,6 +87,9 @@ public class GuildUpdate implements Dispatch {
     private String vanityUrlCode;
     @Nullable
     private String description;
+    @JsonProperty("max_presences")
+    @Nullable
+    private Integer maxPresences;
 
     public boolean isWidgetEnabled() {
         return widgetEnabled;
@@ -207,6 +210,11 @@ public class GuildUpdate implements Dispatch {
         return description;
     }
 
+    @Nullable
+    public Integer getMaxPresences() {
+        return maxPresences;
+    }
+
     @Override
     public String toString() {
         return "GuildUpdate{" +
@@ -238,6 +246,7 @@ public class GuildUpdate implements Dispatch {
                 ", guildId=" + guildId +
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
+                ", maxPresences=" + maxPresences +
                 '}';
     }
 }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -85,6 +85,8 @@ public class GuildUpdate implements Dispatch {
     @JsonProperty("vanity_url_code")
     @Nullable
     private String vanityUrlCode;
+    @Nullable
+    private String description;
 
     public boolean isWidgetEnabled() {
         return widgetEnabled;
@@ -200,6 +202,11 @@ public class GuildUpdate implements Dispatch {
         return vanityUrlCode;
     }
 
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
     @Override
     public String toString() {
         return "GuildUpdate{" +
@@ -230,6 +237,7 @@ public class GuildUpdate implements Dispatch {
                 ", afkChannelId=" + afkChannelId +
                 ", guildId=" + guildId +
                 ", vanityUrlCode=" + vanityUrlCode +
+                ", description=" + description +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -84,6 +84,9 @@ public class GuildResponse {
     private String vanityUrlCode;
     @Nullable
     private String description;
+    @JsonProperty("max_presences")
+    @Nullable
+    private Integer maxPresences;
 
     public int getMfaLevel() {
         return mfaLevel;
@@ -200,6 +203,11 @@ public class GuildResponse {
         return description;
     }
 
+    @Nullable
+    public Integer getMaxPresences() {
+        return maxPresences;
+    }
+
     @Override
     public String toString() {
         return "GuildResponse{" +
@@ -230,6 +238,7 @@ public class GuildResponse {
                 ", icon='" + icon + '\'' +
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
+                ", maxPresences=" + maxPresences +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -87,6 +87,9 @@ public class GuildResponse {
     @JsonProperty("max_presences")
     @Nullable
     private Integer maxPresences;
+    @JsonProperty("max_members")
+    @Nullable
+    private Integer maxMembers;
 
     public int getMfaLevel() {
         return mfaLevel;
@@ -208,6 +211,11 @@ public class GuildResponse {
         return maxPresences;
     }
 
+    @Nullable
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
+
     @Override
     public String toString() {
         return "GuildResponse{" +
@@ -239,6 +247,7 @@ public class GuildResponse {
                 ", vanityUrlCode=" + vanityUrlCode +
                 ", description=" + description +
                 ", maxPresences=" + maxPresences +
+                ", maxMembers=" + maxMembers +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -82,6 +82,8 @@ public class GuildResponse {
     @JsonProperty("vanity_url_code")
     @Nullable
     private String vanityUrlCode;
+    @Nullable
+    private String description;
 
     public int getMfaLevel() {
         return mfaLevel;
@@ -193,6 +195,11 @@ public class GuildResponse {
         return vanityUrlCode;
     }
 
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
     @Override
     public String toString() {
         return "GuildResponse{" +
@@ -222,6 +229,7 @@ public class GuildResponse {
                 ", id=" + id +
                 ", icon='" + icon + '\'' +
                 ", vanityUrlCode=" + vanityUrlCode +
+                ", description=" + description +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -62,7 +62,8 @@ public class GuildResponse {
     @UnsignedJson
     private Long afkChannelId;
     @JsonProperty("widget_enabled")
-    private boolean widgetEnabled;
+    @Nullable
+    private Boolean widgetEnabled;
     @JsonProperty("verification_level")
     private int verificationLevel;
     @JsonProperty("premium_tier")
@@ -160,7 +161,8 @@ public class GuildResponse {
         return afkChannelId;
     }
 
-    public boolean isWidgetEnabled() {
+    @Nullable
+    public Boolean isWidgetEnabled() {
         return widgetEnabled;
     }
 

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -69,6 +69,8 @@ public class GuildResponse {
     private int premiumTier;
     @JsonProperty("premium_subscription_count")
     private int premiumSubcriptionsCount;
+    @JsonProperty("preferred_locale")
+    private String preferredLocale;
     @JsonProperty("owner_id")
     @UnsignedJson
     private long ownerId;
@@ -159,6 +161,10 @@ public class GuildResponse {
         return premiumSubcriptionsCount;
     }
 
+    public String getPreferredLocale() {
+        return preferredLocale;
+    }
+
     public int getVerificationLevel() {
         return verificationLevel;
     }
@@ -185,6 +191,7 @@ public class GuildResponse {
                 "mfaLevel=" + mfaLevel +
                 ", premiumTier=" + premiumTier +
                 ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", preferredLocale=" + preferredLocale +
                 ", emojis=" + Arrays.toString(emojis) +
                 ", applicationId=" + applicationId +
                 ", name='" + name + '\'' +

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -79,6 +79,9 @@ public class GuildResponse {
     @UnsignedJson
     private long id;
     private String icon;
+    @JsonProperty("vanity_url_code")
+    @Nullable
+    private String vanityUrlCode;
 
     public int getMfaLevel() {
         return mfaLevel;
@@ -185,6 +188,11 @@ public class GuildResponse {
         return icon;
     }
 
+    @Nullable
+    public String getVanityUrlCode() {
+        return vanityUrlCode;
+    }
+
     @Override
     public String toString() {
         return "GuildResponse{" +
@@ -213,6 +221,7 @@ public class GuildResponse {
                 ", embedEnabled=" + embedEnabled +
                 ", id=" + id +
                 ", icon='" + icon + '\'' +
+                ", vanityUrlCode=" + vanityUrlCode +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:**

- Adds support for `preferred_locale` to get the preferred locale of a guild. 
- Adds support for `vanity_url_code` to get the vanity url code of a guild, if present. 
- Adds support for `description` to get the description of a guild, if present. 
- Adds support for `max_presences` to get the maximum amount of presences for the guild (the default value, currently 5000, is in effect when null is returned).
- Adds support for `max_members` to get the maximum amount of members for the guild, if present.
- Adds support for `unavailable` to get whether this guild is unavailable, if present. 
- Adds support for `widget_enabled` to get whether or not the server widget is enabled, if present. 

**Justification:** 
Support all guild missing fields: https://discordapp.com/developers/docs/resources/guild