### PR TITLE
Support missing invite fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/ExtendedInvite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedInvite.java
@@ -102,6 +102,15 @@ public final class ExtendedInvite extends Invite {
         return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(getData().getCreatedAt(), Instant::from);
     }
 
+    /**
+     * Gets whether this invite is revoked.
+     *
+     * @return {@code true} if this invite is revoked, {@code false} otherwise.
+     */
+    public boolean isRevoked() {
+        return getData().isRevoked();
+    }
+
     @Override
     ExtendedInviteBean getData() {
         return (ExtendedInviteBean) super.getData();

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -21,6 +21,7 @@ import discord4j.core.ServiceMediator;
 import discord4j.core.object.data.InviteBean;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.TextChannel;
+import discord4j.core.object.entity.User;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
@@ -96,6 +97,36 @@ public class Invite implements DiscordObject {
     }
 
     /**
+     * Requests to retrieve the channel this invite is associated to.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} this invite is
+     * associated to. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public final Mono<TextChannel> getChannel() {
+        return getClient().getChannelById(getChannelId()).cast(TextChannel.class);
+    }
+
+    /**
+     * Gets the ID of the target user this invite is associated to, if present.
+     *
+     * @return The ID of the target user this invite is associated to, if present.
+     */
+    public final Optional<Snowflake> getTargetUserId() {
+        return Optional.ofNullable(data.getTargetUserId())
+            .map(Snowflake::of);
+    }
+
+    /**
+     * Requests to retrieve the target user this invite is associated to.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User target user} this invite is
+     * associated to. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public final Mono<User> getTargetUser() {
+        return getTargetUserId().map(getClient()::getUserById).orElse(Mono.empty());
+    }
+
+    /**
      * Gets an approximate count of online members (only present when the target user is set) of the guild this invite
      * is associated to, if present.
      *
@@ -117,16 +148,6 @@ public class Invite implements DiscordObject {
         return Optional.ofNullable(data.getApproximateMemberCount())
             .map(OptionalInt::of)
             .orElse(OptionalInt.empty());
-    }
-
-    /**
-     * Requests to retrieve the channel this invite is associated to.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} this invite is
-     * associated to. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public final Mono<TextChannel> getChannel() {
-        return getClient().getChannelById(getChannelId()).cast(TextChannel.class);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -26,6 +26,8 @@ import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * A Discord invite.
@@ -91,6 +93,19 @@ public class Invite implements DiscordObject {
      */
     public final Snowflake getChannelId() {
         return Snowflake.of(data.getChannelId());
+    }
+
+    /**
+     * Gets an approximate count of online members (only present when the target user is set) of the guild this invite
+     * is associated to, if present.
+     *
+     * @return An approximate count of online members (only present when the target user is set) of the guild this
+     * invite is associated to, if present.
+     */
+    public final OptionalInt getApproximatePresenceCount() {
+        return Optional.ofNullable(data.getApproximatePresenceCount())
+            .map(OptionalInt::of)
+            .orElse(OptionalInt.empty());
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -109,6 +109,17 @@ public class Invite implements DiscordObject {
     }
 
     /**
+     * Gets approximate count of total members of the guild this invite is associated to., if present.
+     *
+     * @return An approximate count of total members of the guild this invite is associated to, if present.
+     */
+    public final OptionalInt getApproximateMemberCount() {
+        return Optional.ofNullable(data.getApproximateMemberCount())
+            .map(OptionalInt::of)
+            .orElse(OptionalInt.empty());
+    }
+
+    /**
      * Requests to retrieve the channel this invite is associated to.
      *
      * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} this invite is

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -109,7 +109,7 @@ public class Invite implements DiscordObject {
     }
 
     /**
-     * Gets approximate count of total members of the guild this invite is associated to., if present.
+     * Gets approximate count of total members of the guild this invite is associated to, if present.
      *
      * @return An approximate count of total members of the guild this invite is associated to, if present.
      */

--- a/core/src/main/java/discord4j/core/object/data/ExtendedInviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/ExtendedInviteBean.java
@@ -30,6 +30,7 @@ public final class ExtendedInviteBean extends InviteBean {
     private int maxAge;
     private boolean temporary;
     private String createdAt;
+    private boolean revoked;
 
     public ExtendedInviteBean(final InviteResponse response) {
         super(response);
@@ -39,6 +40,7 @@ public final class ExtendedInviteBean extends InviteBean {
         maxAge = Objects.requireNonNull(response.getMaxAge());
         temporary = Objects.requireNonNull(response.getTemporary());
         createdAt = Objects.requireNonNull(response.getCreatedAt());
+        revoked = Objects.requireNonNull(response.getRevoked());
     }
 
     public ExtendedInviteBean() {}
@@ -91,6 +93,14 @@ public final class ExtendedInviteBean extends InviteBean {
         this.createdAt = createdAt;
     }
 
+    public boolean isRevoked() {
+        return revoked;
+    }
+
+    public void setRevoked(final boolean revoked) {
+        this.revoked = revoked;
+    }
+
     @Override
     public String toString() {
         return "ExtendedInviteBean{" +
@@ -100,6 +110,7 @@ public final class ExtendedInviteBean extends InviteBean {
                 ", maxAge=" + maxAge +
                 ", temporary=" + temporary +
                 ", createdAt='" + createdAt + '\'' +
+                ", revoked=" + revoked +
                 "} " + super.toString();
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/InviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/InviteBean.java
@@ -17,6 +17,7 @@
 package discord4j.core.object.data;
 
 import discord4j.rest.json.response.InviteResponse;
+import reactor.util.annotation.Nullable;
 
 import java.io.Serializable;
 
@@ -27,11 +28,14 @@ public class InviteBean implements Serializable {
     private String code;
     private long guildId;
     private long channelId;
+    @Nullable
+    private Integer approximatePresenceCount;
 
     public InviteBean(final InviteResponse response) {
         code = response.getCode();
         guildId = response.getGuild().getId();
         channelId = response.getChannel().getId();
+        approximatePresenceCount = response.getApproximatePresenceCount();
     }
 
     public InviteBean() {}
@@ -60,12 +64,22 @@ public class InviteBean implements Serializable {
         this.channelId = channelId;
     }
 
+    @Nullable
+    public final Integer getApproximatePresenceCount() {
+        return approximatePresenceCount;
+    }
+
+    public final void setApproximatePresenceCount(@Nullable final Integer approximatePresenceCount) {
+        this.approximatePresenceCount = approximatePresenceCount;
+    }
+
     @Override
     public String toString() {
         return "InviteBean{" +
                 "code='" + code + '\'' +
                 ", guildId=" + guildId +
                 ", channelId=" + channelId +
+                ", approximatePresenceCount=" + approximatePresenceCount +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/InviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/InviteBean.java
@@ -30,12 +30,15 @@ public class InviteBean implements Serializable {
     private long channelId;
     @Nullable
     private Integer approximatePresenceCount;
+    @Nullable
+    private Integer approximateMemberCount;
 
     public InviteBean(final InviteResponse response) {
         code = response.getCode();
         guildId = response.getGuild().getId();
         channelId = response.getChannel().getId();
         approximatePresenceCount = response.getApproximatePresenceCount();
+        approximateMemberCount = response.getApproximateMemberCount();
     }
 
     public InviteBean() {}
@@ -73,6 +76,15 @@ public class InviteBean implements Serializable {
         this.approximatePresenceCount = approximatePresenceCount;
     }
 
+    @Nullable
+    public final Integer getApproximateMemberCount() {
+        return approximateMemberCount;
+    }
+
+    public final void setApproximateMemberCount(@Nullable final Integer approximateMemberCount) {
+        this.approximateMemberCount = approximateMemberCount;
+    }
+
     @Override
     public String toString() {
         return "InviteBean{" +
@@ -80,6 +92,7 @@ public class InviteBean implements Serializable {
                 ", guildId=" + guildId +
                 ", channelId=" + channelId +
                 ", approximatePresenceCount=" + approximatePresenceCount +
+                ", approximateMemberCount=" + approximateMemberCount +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/InviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/InviteBean.java
@@ -29,6 +29,8 @@ public class InviteBean implements Serializable {
     private long guildId;
     private long channelId;
     @Nullable
+    private Long targetUserId;
+    @Nullable
     private Integer approximatePresenceCount;
     @Nullable
     private Integer approximateMemberCount;
@@ -37,6 +39,7 @@ public class InviteBean implements Serializable {
         code = response.getCode();
         guildId = response.getGuild().getId();
         channelId = response.getChannel().getId();
+        targetUserId = response.getTargetUser() == null ? null : response.getTargetUser().getId();
         approximatePresenceCount = response.getApproximatePresenceCount();
         approximateMemberCount = response.getApproximateMemberCount();
     }
@@ -68,6 +71,15 @@ public class InviteBean implements Serializable {
     }
 
     @Nullable
+    public final Long getTargetUserId() {
+        return targetUserId;
+    }
+
+    public final void setTargetUserId(@Nullable final Long targetUserId) {
+        this.targetUserId = targetUserId;
+    }
+
+    @Nullable
     public final Integer getApproximatePresenceCount() {
         return approximatePresenceCount;
     }
@@ -91,6 +103,7 @@ public class InviteBean implements Serializable {
                 "code='" + code + '\'' +
                 ", guildId=" + guildId +
                 ", channelId=" + channelId +
+                ", targetUserId=" + targetUserId +
                 ", approximatePresenceCount=" + approximatePresenceCount +
                 ", approximateMemberCount=" + approximateMemberCount +
                 '}';

--- a/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
@@ -25,6 +25,9 @@ public class InviteResponse {
     private String code;
     private GuildResponse guild;
     private ChannelResponse channel;
+    @JsonProperty("approximate_presence_count")
+    @Nullable
+    private Integer approximatePresenceCount;
     @Nullable
     private UserResponse inviter;
     @Nullable
@@ -54,6 +57,11 @@ public class InviteResponse {
 
     public ChannelResponse getChannel() {
         return channel;
+    }
+
+    @Nullable
+    public Integer getApproximatePresenceCount() {
+        return approximatePresenceCount;
     }
 
     @Nullable
@@ -97,6 +105,7 @@ public class InviteResponse {
                 "code='" + code + '\'' +
                 ", guild=" + guild +
                 ", channel=" + channel +
+                ", approximatePresenceCount=" + approximatePresenceCount +
                 ", inviter=" + inviter +
                 ", uses=" + uses +
                 ", maxUses=" + maxUses +

--- a/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
@@ -25,6 +25,9 @@ public class InviteResponse {
     private String code;
     private GuildResponse guild;
     private ChannelResponse channel;
+    @JsonProperty("target_user")
+    @Nullable
+    private UserResponse targetUser;
     @JsonProperty("approximate_presence_count")
     @Nullable
     private Integer approximatePresenceCount;
@@ -60,6 +63,11 @@ public class InviteResponse {
 
     public ChannelResponse getChannel() {
         return channel;
+    }
+
+    @Nullable
+    public UserResponse getTargetUser() {
+        return targetUser;
     }
 
     @Nullable
@@ -113,6 +121,7 @@ public class InviteResponse {
                 "code='" + code + '\'' +
                 ", guild=" + guild +
                 ", channel=" + channel +
+                ", targetUser=" + targetUser +
                 ", approximatePresenceCount=" + approximatePresenceCount +
                 ", approximateMemberCount=" + approximateMemberCount +
                 ", inviter=" + inviter +

--- a/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
@@ -28,6 +28,9 @@ public class InviteResponse {
     @JsonProperty("approximate_presence_count")
     @Nullable
     private Integer approximatePresenceCount;
+    @JsonProperty("approximate_member_count")
+    @Nullable
+    private Integer approximateMemberCount;
     @Nullable
     private UserResponse inviter;
     @Nullable
@@ -62,6 +65,11 @@ public class InviteResponse {
     @Nullable
     public Integer getApproximatePresenceCount() {
         return approximatePresenceCount;
+    }
+
+    @Nullable
+    public Integer getApproximateMemberCount() {
+        return approximateMemberCount;
     }
 
     @Nullable
@@ -106,6 +114,7 @@ public class InviteResponse {
                 ", guild=" + guild +
                 ", channel=" + channel +
                 ", approximatePresenceCount=" + approximatePresenceCount +
+                ", approximateMemberCount=" + approximateMemberCount +
                 ", inviter=" + inviter +
                 ", uses=" + uses +
                 ", maxUses=" + maxUses +

--- a/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
@@ -40,6 +40,9 @@ public class InviteResponse {
     @JsonProperty("created_at")
     @Nullable
     private String createdAt;
+    @JsonProperty("revoked")
+    @Nullable
+    private Boolean revoked;
 
     public String getCode() {
         return code;
@@ -83,6 +86,11 @@ public class InviteResponse {
         return createdAt;
     }
 
+    @Nullable
+    public Boolean getRevoked() {
+        return revoked;
+    }
+
     @Override
     public String toString() {
         return "InviteResponse{" +
@@ -95,6 +103,7 @@ public class InviteResponse {
                 ", maxAge=" + maxAge +
                 ", temporary=" + temporary +
                 ", createdAt='" + createdAt + '\'' +
+                ", revoked=" + revoked +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:**

- Adds support for `revoked` to get whether an invite is revoked.
- Adds support for `target_user` to get the target user this invite is associated to, if present.
- Adds support for `approximate_presence_count` to get an approximate count of online members (only present when target_user is set), if present. 
- Adds support for `approximate_member_count` to get an approximate count of total members, if present.

**Justification:** 
Support all invite missing fields: https://discordapp.com/developers/docs/resources/invite