### PR TITLE
Support missing user fields

### DIFF
--- a/common/src/main/java/discord4j/common/json/UserResponse.java
+++ b/common/src/main/java/discord4j/common/json/UserResponse.java
@@ -16,6 +16,7 @@
  */
 package discord4j.common.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
 import reactor.util.annotation.Nullable;
 
@@ -29,6 +30,16 @@ public class UserResponse {
     private String avatar;
     @Nullable
     private Boolean bot;
+    @JsonProperty("mfa_enabled")
+    @Nullable
+    private Boolean mfaEnabled;
+    @Nullable
+    private String locale;
+    @Nullable
+    private Integer flags;
+    @JsonProperty("premium_type")
+    @Nullable
+    private Integer premiumType;
 
     public long getId() {
         return id;
@@ -52,6 +63,26 @@ public class UserResponse {
         return bot;
     }
 
+    @Nullable
+    public Boolean isMfaEnabled() {
+        return mfaEnabled;
+    }
+
+    @Nullable
+    public String getLocale() {
+        return locale;
+    }
+
+    @Nullable
+    public Integer getFlags() {
+        return flags;
+    }
+
+    @Nullable
+    public Integer getPremiumType() {
+        return premiumType;
+    }
+
     @Override
     public String toString() {
         return "UserResponse{" +
@@ -60,6 +91,10 @@ public class UserResponse {
                 ", discriminator='" + discriminator + '\'' +
                 ", avatar='" + avatar + '\'' +
                 ", bot=" + bot +
+                ", mfaEnabled=" + mfaEnabled +
+                ", locale=" + locale +
+                ", flags=" + flags +
+                ", premiumType=" + premiumType +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/stored/UserBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/UserBean.java
@@ -33,6 +33,14 @@ public final class UserBean implements Serializable {
     @Nullable
     private String avatar;
     private boolean isBot;
+    private boolean isMfaEnabled;
+    @Nullable
+    private String locale;
+    @Nullable
+    private Integer flags;
+    @Nullable
+    private Integer premiumType;
+
 
     public UserBean(final UserResponse response) {
         id = response.getId();
@@ -40,6 +48,10 @@ public final class UserBean implements Serializable {
         discriminator = response.getDiscriminator();
         avatar = response.getAvatar();
         isBot = response.isBot() != null && response.isBot();
+        isMfaEnabled = response.isMfaEnabled() != null && response.isMfaEnabled();
+        locale = response.getLocale();
+        flags = response.getFlags();
+        premiumType = response.getPremiumType();
     }
 
     public UserBean(final UserBean toCopy) {
@@ -48,6 +60,10 @@ public final class UserBean implements Serializable {
         discriminator = toCopy.discriminator;
         avatar = toCopy.avatar;
         isBot = toCopy.isBot;
+        isMfaEnabled = toCopy.isMfaEnabled;
+        locale = toCopy.locale;
+        flags = toCopy.flags;
+        premiumType = toCopy.premiumType;
     }
 
     public UserBean() {}
@@ -89,8 +105,43 @@ public final class UserBean implements Serializable {
         return isBot;
     }
 
-    public void setBot(boolean bot) {
+    public void setBot(final boolean bot) {
         isBot = bot;
+    }
+
+    public boolean isMfaEnabled() {
+        return isMfaEnabled;
+    }
+
+    public void setMfaEnabled(final boolean mfaEnabled) {
+        this.isMfaEnabled = isMfaEnabled;
+    }
+
+    @Nullable
+    public String getLocale() {
+        return locale;
+    }
+
+    public void setLocale(@Nullable final String locale) {
+        this.locale = locale;
+    }
+
+    @Nullable
+    public Integer getFlags() {
+        return flags;
+    }
+
+    public void setFlags(@Nullable final Integer flags) {
+        this.flags = flags;
+    }
+
+    @Nullable
+    public Integer getPremiumType() {
+        return premiumType;
+    }
+
+    public void setPremiumType(@Nullable final Integer premiumType) {
+        this.premiumType = premiumType;
     }
 
     @Override
@@ -101,6 +152,10 @@ public final class UserBean implements Serializable {
                 ", discriminator='" + discriminator + '\'' +
                 ", avatar='" + avatar + '\'' +
                 ", isBot=" + isBot +
+                ", isMfaEnabled=" + isMfaEnabled +
+                ", locale=" + locale +
+                ", flags=" + flags +
+                ", premiumType=" + premiumType +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/entity/User.java
+++ b/core/src/main/java/discord4j/core/object/entity/User.java
@@ -164,6 +164,24 @@ public class User implements Entity {
     }
 
     /**
+     * Gets whether the user has two factor enabled on their account.
+     *
+     * @return {@code true} if the user has two factor enabled on their account, {@code false} otherwise.
+     */
+    public boolean isMfaEnabled() {
+        return data.isMfaEnabled();
+    }
+
+    /**
+     * Gets the user's chosen language option, if present.
+     *
+     * @return the user's chosen language option, if present.
+     */
+    public Optional<String> getLocale() {
+        return Optional.ofNullable(data.getLocale());
+    }
+
+    /**
      * Gets the <i>raw</i> mention. This is the format utilized to directly mention another user (assuming the user
      * exists in context of the mention).
      *


### PR DESCRIPTION
**Description:**

- Adds support for `mfa_enabled` to get whether the user has two factor enabled on their account.
- Adds support for `locale` to get the user's chosen language option, if present.

**TODO:**
- Adds support for `flags` to get the flags on a user's account, if present. 
- Adds support for `premium_type` to get the type of Nitro subscription on a user's account, if present.
- Checks the returned value of locale and convert it to a Locale object if possible.

**Justification:** 
Support all user missing fields: https://discordapp.com/developers/docs/resources/user