### PR TITLE
Fix 552: ReactionEmoji.Custom#equals() is inconsistent

### DIFF
--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -133,14 +133,12 @@ public abstract class ReactionEmoji {
                 return false;
             }
             Custom custom = (Custom) o;
-            return id == custom.id &&
-                    isAnimated == custom.isAnimated &&
-                    Objects.equals(name, custom.name);
+            return id == custom.id;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, name, isAnimated);
+            return Objects.hash(id);
         }
     }
 

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -138,7 +138,7 @@ public abstract class ReactionEmoji {
 
         @Override
         public int hashCode() {
-            return Objects.hash(id);
+            return Objects.hash(id, name, isAnimated);
         }
     }
 

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -138,7 +138,7 @@ public abstract class ReactionEmoji {
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, name, isAnimated);
+            return Objects.hash(id);
         }
     }
 


### PR DESCRIPTION
**Description:** As described here: https://github.com/discordapp/discord-api-docs/issues/812, reaction emoji name and isAnimated fields are inconsistent and Discord4J should not rely on these values to check for equality between two emojis. The id is unique across Discord and should be suffisent. 

**Reference:** cc @HunterCop224 https://github.com/Discord4J/Discord4J/issues/552

**Justification:** Fix `ReactionEmoji.Custom#equals`