### PR TITLE
Update voice state fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/VoiceState.java
+++ b/core/src/main/java/discord4j/core/object/VoiceState.java
@@ -160,6 +160,15 @@ public final class VoiceState implements DiscordObject {
     }
 
     /**
+     * Gets whether this user is streaming using "Go Live".
+     *
+     * @return {@code true} if this user is streaming using "Go Live", {@code false} otherwise.
+     */
+    public boolean isSelfStreaming() {
+        return Optional.ofNullable(data.isSelfStream()).orElse(false);
+    }
+
+    /**
      * Gets whether this user is muted by the current user.
      *
      * @return {@code true} if this user is muted by the current user, {@code false} otherwise.

--- a/core/src/main/java/discord4j/core/object/data/stored/VoiceStateBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/VoiceStateBean.java
@@ -37,6 +37,8 @@ public final class VoiceStateBean implements Serializable {
     private boolean mute;
     private boolean selfDeaf;
     private boolean selfMute;
+    @Nullable
+    private Boolean selfStream;
     private boolean suppress;
 
     public VoiceStateBean(final GuildCreate.VoiceState voiceState, final long guildId) {
@@ -48,6 +50,7 @@ public final class VoiceStateBean implements Serializable {
         mute = voiceState.isMute();
         selfDeaf = voiceState.isSelfDeaf();
         selfMute = voiceState.isSelfMute();
+        selfStream = voiceState.isSelfStream();
         suppress = voiceState.isSuppress();
     }
 
@@ -60,6 +63,7 @@ public final class VoiceStateBean implements Serializable {
         mute = response.isMute();
         selfDeaf = response.isSelfDeaf();
         selfMute = response.isSelfMute();
+        selfStream = response.isSelfStream();
         suppress = response.isSuppress();
     }
 
@@ -130,6 +134,15 @@ public final class VoiceStateBean implements Serializable {
         this.selfMute = selfMute;
     }
 
+    @Nullable
+    public Boolean isSelfStream() {
+        return selfStream;
+    }
+
+    public void setSelfStream(@Nullable final Boolean selfStream) {
+        this.selfStream = selfStream;
+    }
+
     public boolean isSuppress() {
         return suppress;
     }
@@ -149,6 +162,7 @@ public final class VoiceStateBean implements Serializable {
                 ", mute=" + mute +
                 ", selfDeaf=" + selfDeaf +
                 ", selfMute=" + selfMute +
+                ", selfStream=" + selfStream +
                 ", suppress=" + suppress +
                 '}';
     }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -308,74 +308,74 @@ public class GuildCreate implements Dispatch {
 
     public static class VoiceState {
 
-        @JsonProperty("user_id")
-        @UnsignedJson
-        private long userId;
-        private boolean suppress;
-        @JsonProperty("session_id")
-        private String sessionId;
-        @JsonProperty("self_mute")
-        private boolean selfMute;
-        @JsonProperty("self_deaf")
-        private boolean selfDeaf;
-        private boolean mute;
-        private boolean deaf;
         @JsonProperty("channel_id")
         @UnsignedJson
         private long channelId;
+        @JsonProperty("user_id")
+        @UnsignedJson
+        private long userId;
+        @JsonProperty("session_id")
+        private String sessionId;
+        private boolean deaf;
+        private boolean mute;
+        @JsonProperty("self_deaf")
+        private boolean selfDeaf;
+        @JsonProperty("self_mute")
+        private boolean selfMute;
         @JsonProperty("self_stream")
         @Nullable
         private Boolean selfStream;
+        private boolean suppress;
+
+        public long getChannelId() {
+            return channelId;
+        }
 
         public long getUserId() {
             return userId;
-        }
-
-        public boolean isSuppress() {
-            return suppress;
         }
 
         public String getSessionId() {
             return sessionId;
         }
 
-        }
-
-        public boolean isSelfMute() {
-            return selfMute;
-        }
-
-        public boolean isSelfDeaf() {
-            return selfDeaf;
+        public boolean isDeaf() {
+            return deaf;
         }
 
         public boolean isMute() {
             return mute;
         }
 
-        public boolean isDeaf() {
-            return deaf;
+        public boolean isSelfDeaf() {
+            return selfDeaf;
+        }
+
+        public boolean isSelfMute() {
+            return selfMute;
+        }
+
         @Nullable
         public Boolean isSelfStream() {
             return selfStream;
         }
 
-        public long getChannelId() {
-            return channelId;
+        public boolean isSuppress() {
+            return suppress;
         }
 
         @Override
         public String toString() {
             return "VoiceState{" +
-                    "userId=" + userId +
-                    ", suppress=" + suppress +
+                    "channelId=" + channelId +
+                    ", userId=" + userId +
                     ", sessionId='" + sessionId + '\'' +
-                    ", selfMute=" + selfMute +
-                    ", selfDeaf=" + selfDeaf +
-                    ", mute=" + mute +
                     ", deaf=" + deaf +
-                    ", channelId=" + channelId +
+                    ", mute=" + mute +
+                    ", selfDeaf=" + selfDeaf +
+                    ", selfMute=" + selfMute +
                     ", selfStream=" + selfStream +
+                    ", suppress=" + suppress +
                     '}';
         }
     }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -314,8 +314,6 @@ public class GuildCreate implements Dispatch {
         private boolean suppress;
         @JsonProperty("session_id")
         private String sessionId;
-        @JsonProperty("self_video")
-        private boolean selfVideo;
         @JsonProperty("self_mute")
         private boolean selfMute;
         @JsonProperty("self_deaf")
@@ -338,8 +336,6 @@ public class GuildCreate implements Dispatch {
             return sessionId;
         }
 
-        public boolean isSelfVideo() {
-            return selfVideo;
         }
 
         public boolean isSelfMute() {
@@ -368,7 +364,6 @@ public class GuildCreate implements Dispatch {
                     "userId=" + userId +
                     ", suppress=" + suppress +
                     ", sessionId='" + sessionId + '\'' +
-                    ", selfVideo=" + selfVideo +
                     ", selfMute=" + selfMute +
                     ", selfDeaf=" + selfDeaf +
                     ", mute=" + mute +

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -323,6 +323,9 @@ public class GuildCreate implements Dispatch {
         @JsonProperty("channel_id")
         @UnsignedJson
         private long channelId;
+        @JsonProperty("self_stream")
+        @Nullable
+        private Boolean selfStream;
 
         public long getUserId() {
             return userId;
@@ -352,6 +355,9 @@ public class GuildCreate implements Dispatch {
 
         public boolean isDeaf() {
             return deaf;
+        @Nullable
+        public Boolean isSelfStream() {
+            return selfStream;
         }
 
         public long getChannelId() {
@@ -369,6 +375,7 @@ public class GuildCreate implements Dispatch {
                     ", mute=" + mute +
                     ", deaf=" + deaf +
                     ", channelId=" + channelId +
+                    ", selfStream=" + selfStream +
                     '}';
         }
     }

--- a/gateway/src/main/java/discord4j/gateway/json/response/VoiceStateResponse.java
+++ b/gateway/src/main/java/discord4j/gateway/json/response/VoiceStateResponse.java
@@ -38,8 +38,6 @@ public class VoiceStateResponse {
     private boolean mute;
     @JsonProperty("self_deaf")
     private boolean selfDeaf;
-    @JsonProperty("self_video")
-    private boolean selfVideo;
     @JsonProperty("self_mute")
     private boolean selfMute;
     private boolean suppress;
@@ -73,10 +71,6 @@ public class VoiceStateResponse {
         return selfDeaf;
     }
 
-    public boolean isSelfVideo() {
-        return selfVideo;
-    }
-
     public boolean isSelfMute() {
         return selfMute;
     }
@@ -95,7 +89,6 @@ public class VoiceStateResponse {
                 ", deaf=" + deaf +
                 ", mute=" + mute +
                 ", selfDeaf=" + selfDeaf +
-                ", selfVideo=" + selfVideo +
                 ", selfMute=" + selfMute +
                 ", suppress=" + suppress +
                 '}';

--- a/gateway/src/main/java/discord4j/gateway/json/response/VoiceStateResponse.java
+++ b/gateway/src/main/java/discord4j/gateway/json/response/VoiceStateResponse.java
@@ -40,6 +40,9 @@ public class VoiceStateResponse {
     private boolean selfDeaf;
     @JsonProperty("self_mute")
     private boolean selfMute;
+    @JsonProperty("self_stream")
+    @Nullable
+    private Boolean selfStream;
     private boolean suppress;
 
     public long getGuildId() {
@@ -75,6 +78,11 @@ public class VoiceStateResponse {
         return selfMute;
     }
 
+    @Nullable
+    public Boolean isSelfStream() {
+        return selfStream;
+    }
+
     public boolean isSuppress() {
         return suppress;
     }
@@ -90,6 +98,7 @@ public class VoiceStateResponse {
                 ", mute=" + mute +
                 ", selfDeaf=" + selfDeaf +
                 ", selfMute=" + selfMute +
+                ", selfStream=" + selfStream +
                 ", suppress=" + suppress +
                 '}';
     }


### PR DESCRIPTION
**Description:**
- Removes `self_video` field from `VoiceStateResponse` and `GuildCreate.VoiceState` because it was not used, is experimental and will be removed.

- Adds support for `self_stream` to get whether a user is streaming using "Go Live".

- Re-order `GuildCreate.VoiceState` fields to be consistent with the documentation and the `VoiceStateResponse` fields order.

**Note:** I didn't update `VoiceStateUpdate` because I don't know if the `self_stream` field should be there.

**Reference:** https://github.com/discordapp/discord-api-docs/issues/1104 and https://github.com/discordapp/discord-api-docs/pull/1108

**Justification:** Update Voice State fields: https://discordapp.com/developers/docs/resources/voice#voice-state-object