### PR TITLE
Add UNKNOWN activity type

### DIFF
--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -211,6 +211,9 @@ public class Activity {
     /** The type of "action" for an activity. */
     public enum Type {
 
+        /** Unknown type **/
+        UNKNOWN(-1),
+
         /** "Playing {name}" */
         PLAYING(0),
 
@@ -257,7 +260,7 @@ public class Activity {
                 case 1: return STREAMING;
                 case 2: return LISTENING;
                 case 3: return WATCHING;
-                default: return EntityUtil.throwUnsupportedDiscordValue(value);
+                default: return UNKNOWN;
             }
         }
     }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** This pull request closes issue https://github.com/Discord4J/Discord4J/issues/571 by returning an unknown activity type with ID -1 instead of throwing an exception.

**Justification:** As described in the issue linked above, `D4J enums representing discord values should be made with forwards compatibility in mind, and accept IDs that could be future additions to the Discord API.`