### PR TITLE
Change return type of getResponseTime to Duration

### DIFF
--- a/core/src/main/java/discord4j/core/DiscordClient.java
+++ b/core/src/main/java/discord4j/core/DiscordClient.java
@@ -39,6 +39,7 @@ import discord4j.rest.json.response.GatewayResponse;
 import discord4j.rest.json.response.UserGuildResponse;
 import discord4j.rest.util.RouteUtils;
 import discord4j.store.api.util.LongLongTuple2;
+import java.time.Duration;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.Logger;
@@ -371,9 +372,9 @@ public final class DiscordClient {
     /**
      * Gets the amount of time it last took Discord Gateway to respond to a heartbeat with an ack.
      *
-     * @return the time in milliseconds took Discord to respond to the last heartbeat with an ack.
+     * @return the duration which Discord took to respond to the last heartbeat with an ack.
      */
-    public long getResponseTime() {
+    public Duration getResponseTime() {
         return serviceMediator.getGatewayClient().getResponseTime();
     }
 

--- a/gateway/src/main/java/discord4j/gateway/DefaultGatewayClient.java
+++ b/gateway/src/main/java/discord4j/gateway/DefaultGatewayClient.java
@@ -451,12 +451,7 @@ public class DefaultGatewayClient implements GatewayClient {
     }
 
     @Override
-    public long getResponseTime() {
-        return TimeUnit.NANOSECONDS.toMillis(responseTime.get());
-    }
-
-    // TODO: getResponseTime for 3.1
-    Duration getResponseTimeDuration() {
+    public Duration getResponseTime() {
         return Duration.ofNanos(responseTime.get());
     }
 

--- a/gateway/src/main/java/discord4j/gateway/GatewayClient.java
+++ b/gateway/src/main/java/discord4j/gateway/GatewayClient.java
@@ -20,6 +20,7 @@ package discord4j.gateway;
 import discord4j.gateway.json.GatewayPayload;
 import discord4j.gateway.json.dispatch.Dispatch;
 import io.netty.buffer.ByteBuf;
+import java.time.Duration;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -156,7 +157,7 @@ public interface GatewayClient {
     /**
      * Gets the amount of time it last took Discord to respond to a heartbeat with an ack.
      *
-     * @return the time in milliseconds took Discord to respond to the last heartbeat with an ack.
+     * @return the duration which Discord took to respond to the last heartbeat with an ack.
      */
-    long getResponseTime();
+    Duration getResponseTime();
 }

--- a/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
+++ b/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
@@ -115,7 +115,7 @@ public abstract class PayloadHandlers {
 
     private static void handleHeartbeatAck(PayloadContext<?> context) {
         context.getClient().ackHeartbeat();
-        log(context).debug("Heartbeat acknowledged after {}", context.getClient().getResponseTimeDuration());
+        log(context).debug("Heartbeat acknowledged after {}", context.getClient().getResponseTime());
     }
 
     private static Logger log(PayloadContext<?> context) {


### PR DESCRIPTION
**Description:**
Change the return type of GatewayClient#getResponseTime() and DiscordClient#getResponseTime() to Duration and remove DefaultGatewayClient#getResponseTimeDuration()

**Justification:**
This change was requested in issue #517 