### PR TITLE
Support missing activity fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/data/stored/RichActivityBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/RichActivityBean.java
@@ -17,6 +17,7 @@
 package discord4j.core.object.data.stored;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import discord4j.common.json.EmojiResponse;
 import discord4j.gateway.json.response.GameAssetsResponse;
 import discord4j.gateway.json.response.GamePartyResponse;
 import discord4j.gateway.json.response.GameResponse;
@@ -45,6 +46,10 @@ public final class RichActivityBean extends ActivityBean implements Serializable
     @Nullable
     private String state;
     @Nullable
+    private EmojiResponse emoji;
+    @Nullable
+    private Boolean instance;
+    @Nullable
     private Integer flags;
     @Nullable
     private String partyId;
@@ -72,6 +77,8 @@ public final class RichActivityBean extends ActivityBean implements Serializable
         details = response.getDetails();
         syncId = response.getSyncId();
         state = response.getState();
+        emoji = response.getEmoji();
+        instance = response.getInstance();
         flags = response.getFlags();
         final GamePartyResponse party = response.getParty();
         partyId = (party == null) ? null : party.getId();
@@ -152,6 +159,24 @@ public final class RichActivityBean extends ActivityBean implements Serializable
 
     public void setState(@Nullable String state) {
         this.state = state;
+    }
+
+    @Nullable
+    public EmojiResponse getEmoji() {
+        return emoji;
+    }
+
+    public void setEmoji(@Nullable EmojiResponse emoji) {
+        this.emoji = emoji;
+    }
+
+    @Nullable
+    public Boolean getInstance() {
+        return instance;
+    }
+
+    public void setInstance(@Nullable Boolean instance) {
+        this.instance = instance;
     }
 
     @Nullable
@@ -236,6 +261,8 @@ public final class RichActivityBean extends ActivityBean implements Serializable
                 ", details='" + details + '\'' +
                 ", syncId='" + syncId + '\'' +
                 ", state='" + state + '\'' +
+                ", emoji=" + emoji +
+                ", instance=" + instance +
                 ", flags=" + flags +
                 ", partyId='" + partyId + '\'' +
                 ", currentPartySize=" + currentPartySize +

--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -128,9 +128,9 @@ public class Activity {
     }
 
     /**
-     * Gets the user's current party status or custom status text, if present.
+     * Gets the user's current party status, if present.
      *
-     * @return The user's current party status or custom status text, if present.
+     * @return The user's current party status, if present.
      */
     public Optional<String> getState() {
         return Optional.ofNullable(richData).map(RichActivityBean::getState);
@@ -246,7 +246,7 @@ public class Activity {
         /** "Watching {name}" */
         WATCHING(3),
 
-        /** {emoji} {state} */
+        /** {emoji} {name} */
         CUSTOM(4);
 
         /** The underlying value as represented by Discord. */

--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -18,6 +18,7 @@ package discord4j.core.object.presence;
 
 import discord4j.core.object.data.stored.ActivityBean;
 import discord4j.core.object.data.stored.RichActivityBean;
+import discord4j.core.object.reaction.ReactionEmoji;
 import discord4j.core.object.util.Snowflake;
 import discord4j.core.util.EntityUtil;
 import reactor.util.annotation.Nullable;
@@ -136,6 +137,25 @@ public class Activity {
     }
 
     /**
+     * Gets the emoji used for a custom status, if present.
+     *
+     * @return The emoji used for a custom status, if present.
+     */
+    public Optional<ReactionEmoji> getEmoji() {
+        return Optional.ofNullable(richData).map(RichActivityBean::getEmoji)
+            .map(emoji -> ReactionEmoji.of(emoji.getId(), emoji.getName(), emoji.getAnimated() != null && emoji.getAnimated()));
+    }
+
+    /**
+     * Gets whether or not the activity is an instanced game session.
+     *
+     * @return Whether or not the activity is an instanced game session
+     */
+    public boolean isInstance() {
+        return Optional.ofNullable(richData).map(RichActivityBean::getInstance).orElse(false);
+    }
+
+    /**
      * Gets the ID of the party, if present.
      *
      * @return The ID of the party, if present.
@@ -224,7 +244,10 @@ public class Activity {
         LISTENING(2),
 
         /** "Watching {name}" */
-        WATCHING(3);
+        WATCHING(3),
+
+        /** {emoji} {state} */
+        CUSTOM(4);
 
         /** The underlying value as represented by Discord. */
         private final int value;
@@ -260,6 +283,7 @@ public class Activity {
                 case 1: return STREAMING;
                 case 2: return LISTENING;
                 case 3: return WATCHING;
+                case 4: return CUSTOM;
                 default: return UNKNOWN;
             }
         }

--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -128,9 +128,9 @@ public class Activity {
     }
 
     /**
-     * Gets the user's current party status, if present.
+     * Gets the user's current party status or custom status text, if present.
      *
-     * @return The user's current party status, if present.
+     * @return The user's current party status or custom status text, if present.
      */
     public Optional<String> getState() {
         return Optional.ofNullable(richData).map(RichActivityBean::getState);

--- a/gateway/src/main/java/discord4j/gateway/json/response/GameResponse.java
+++ b/gateway/src/main/java/discord4j/gateway/json/response/GameResponse.java
@@ -18,6 +18,7 @@ package discord4j.gateway.json.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
+import discord4j.common.json.EmojiResponse;
 import reactor.util.annotation.Nullable;
 
 public class GameResponse {
@@ -42,6 +43,10 @@ public class GameResponse {
     private String syncId;
     @Nullable
     private String state;
+    @Nullable
+    private EmojiResponse emoji;
+    @Nullable
+    private Boolean instance;
     @Nullable
     private Integer flags;
     @Nullable
@@ -93,6 +98,16 @@ public class GameResponse {
     }
 
     @Nullable
+    public EmojiResponse getEmoji() {
+        return emoji;
+    }
+
+    @Nullable
+    public Boolean getInstance() {
+        return instance;
+    }
+
+    @Nullable
     public Integer getFlags() {
         return flags;
     }
@@ -119,6 +134,8 @@ public class GameResponse {
                 ", details='" + details + '\'' +
                 ", syncId='" + syncId + '\'' +
                 ", state='" + state + '\'' +
+                ", emoji=" + emoji +
+                ", instance=" + instance +
                 ", flags=" + flags +
                 ", party=" + party +
                 ", assets=" + assets +


### PR DESCRIPTION
**Description:**
- Adds support for `instance` to get whether or not the activity is an instanced game session.
- Adds support for `emoji` to get the emoji used for a custom status, if present.
- Adds support for `CUSTOM` activity type.

**Justification:** 
Support all activity missing fields: https://github.com/discordapp/discord-api-docs/blob/8c70711e39df52a66de9672f1a4025a201ff0176/docs/topics/Gateway.md#activity-structure