### PR TITLE
Revert "Add UNKNOWN activity type"

### DIFF
--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -211,9 +211,6 @@ public class Activity {
     /** The type of "action" for an activity. */
     public enum Type {
 
-        /** Unknown type **/
-        UNKNOWN(-1),
-
         /** "Playing {name}" */
         PLAYING(0),
 
@@ -260,7 +257,7 @@ public class Activity {
                 case 1: return STREAMING;
                 case 2: return LISTENING;
                 case 3: return WATCHING;
-                default: return UNKNOWN;
+                default: return EntityUtil.throwUnsupportedDiscordValue(value);
             }
         }
     }


### PR DESCRIPTION
Reverts Discord4J/Discord4J#572 that can break 3.0.x apps if they used, for example, `switch` on the `Activity` enum.