### PR TITLE
Defer reading HTTP response body

### DIFF
--- a/rest/src/main/java/discord4j/rest/http/EmptyReaderStrategy.java
+++ b/rest/src/main/java/discord4j/rest/http/EmptyReaderStrategy.java
@@ -16,8 +16,8 @@
  */
 package discord4j.rest.http;
 
+import io.netty.buffer.ByteBuf;
 import reactor.core.publisher.Mono;
-import reactor.netty.ByteBufMono;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -27,11 +27,11 @@ public class EmptyReaderStrategy implements ReaderStrategy<Void> {
 
     @Override
     public boolean canRead(@Nullable Class<?> type, @Nullable String contentType) {
-        return type != null && type == Void.class;
+        return type == Void.class;
     }
 
     @Override
-    public Mono<Void> read(ByteBufMono content, Class<Void> responseType) {
+    public Mono<Void> read(Mono<ByteBuf> content, Class<Void> responseType) {
         return Mono.empty();
     }
 }

--- a/rest/src/main/java/discord4j/rest/http/JacksonReaderStrategy.java
+++ b/rest/src/main/java/discord4j/rest/http/JacksonReaderStrategy.java
@@ -19,9 +19,10 @@ package discord4j.rest.http;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.IllegalReferenceCountException;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
-import reactor.netty.ByteBufMono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
@@ -32,9 +33,9 @@ import java.lang.reflect.Type;
 /**
  * Read a response into JSON and convert to an Object of type {@code <Res>} using Jackson.
  *
- * @param <Res> the type of object in the read response
+ * @param <T> the type of object in the read response
  */
-public class JacksonReaderStrategy<Res> implements ReaderStrategy<Res> {
+public class JacksonReaderStrategy<T> implements ReaderStrategy<T> {
 
     private static final Logger log = Loggers.getLogger(JacksonReaderStrategy.class);
 
@@ -54,9 +55,13 @@ public class JacksonReaderStrategy<Res> implements ReaderStrategy<Res> {
         return !CharSequence.class.isAssignableFrom(type) && objectMapper.canDeserialize(getJavaType(type));
     }
 
+    private JavaType getJavaType(Type type) {
+        return objectMapper.getTypeFactory().constructType(type);
+    }
+
     @Override
-    public Mono<Res> read(ByteBufMono content, Class<Res> responseType) {
-        return content.asByteArray()
+    public Mono<T> read(Mono<ByteBuf> content, Class<T> responseType) {
+        return content.as(JacksonReaderStrategy::byteArray)
                 .map(bytes -> {
                     try {
                         return objectMapper.readValue(bytes, responseType);
@@ -78,7 +83,15 @@ public class JacksonReaderStrategy<Res> implements ReaderStrategy<Res> {
                 });
     }
 
-    private JavaType getJavaType(Type type) {
-        return objectMapper.getTypeFactory().constructType(type);
+    private static Mono<byte[]> byteArray(Mono<ByteBuf> byteBufMono) {
+        return byteBufMono.handle((buf, sink) -> {
+            try {
+                byte[] bytes = new byte[buf.readableBytes()];
+                buf.readBytes(bytes);
+                sink.next(bytes);
+            } catch (IllegalReferenceCountException e) {
+                sink.complete();
+            }
+        });
     }
 }

--- a/rest/src/main/java/discord4j/rest/http/ReaderStrategy.java
+++ b/rest/src/main/java/discord4j/rest/http/ReaderStrategy.java
@@ -16,17 +16,17 @@
  */
 package discord4j.rest.http;
 
+import io.netty.buffer.ByteBuf;
 import reactor.core.publisher.Mono;
-import reactor.netty.ByteBufMono;
 import reactor.util.annotation.Nullable;
 
 /**
  * Strategy for reading from a {@link reactor.netty.http.client.HttpClientResponse} and decoding the stream of bytes
  * to an Object of type {@code <Res>}.
  *
- * @param <Res> the type of object in the read response
+ * @param <T> the type of object in the read response
  */
-public interface ReaderStrategy<Res> {
+public interface ReaderStrategy<T> {
 
     /**
      * Whether the given object type is supported by this reader.
@@ -45,5 +45,5 @@ public interface ReaderStrategy<Res> {
      * #canRead(Class, String)}
      * @return a Mono for the resolved response, according to the given response type
      */
-    Mono<Res> read(ByteBufMono content, Class<Res> responseType);
+    Mono<T> read(Mono<ByteBuf> content, Class<T> responseType);
 }

--- a/rest/src/main/java/discord4j/rest/http/WriterStrategy.java
+++ b/rest/src/main/java/discord4j/rest/http/WriterStrategy.java
@@ -24,9 +24,9 @@ import reactor.util.annotation.Nullable;
  * Strategy for encoding an object of type {@code <Req>} and writing the encoded stream of bytes to an {@link
  * reactor.netty.http.client.HttpClientRequest}.
  *
- * @param <Req> the type of object in the body
+ * @param <R> the type of object in the body
  */
-public interface WriterStrategy<Req> {
+public interface WriterStrategy<R> {
 
     /**
      * Whether the given object type is supported by this writer.
@@ -44,5 +44,5 @@ public interface WriterStrategy<Req> {
      * @param body the object to write
      * @return indicates completion or error
      */
-    Mono<HttpClient.ResponseReceiver<?>> write(HttpClient.RequestSender sender, @Nullable Req body);
+    Mono<HttpClient.ResponseReceiver<?>> write(HttpClient.RequestSender sender, @Nullable R body);
 }

--- a/rest/src/main/java/discord4j/rest/http/client/ClientRequest.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientRequest.java
@@ -17,31 +17,34 @@
 
 package discord4j.rest.http.client;
 
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.route.Route;
 import discord4j.rest.util.RouteUtils;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import reactor.util.annotation.Nullable;
 
 import java.util.Optional;
 
 /**
- * An adapted request definition from an original {@link DiscordRequest}.
+ * An adapted request definition from an original {@link DiscordWebRequest}.
  */
 public class ClientRequest {
 
-    private final DiscordRequest<?> request;
+    private final String id;
+    private final DiscordWebRequest request;
     private final String url;
     private final HttpHeaders headers;
+    private final Object body;
 
     /**
      * Create a new {@link ClientRequest} from the given request template.
      *
-     * @param request the {@link DiscordRequest} template
+     * @param request the {@link DiscordWebRequest} template
      */
-    public ClientRequest(DiscordRequest<?> request) {
+    public ClientRequest(DiscordWebRequest request) {
         this.request = request;
         this.url = RouteUtils.expandQuery(request.getCompleteUri(), request.getQueryParams());
         this.headers = Optional.ofNullable(request.getHeaders())
@@ -52,6 +55,17 @@ public class ClientRequest {
                             return headers;
                         }, HttpHeaders::add))
                 .orElse(new DefaultHttpHeaders());
+        this.body = request.getBody();
+        this.id = Integer.toHexString(System.identityHashCode(this));
+    }
+
+    /**
+     * Return this request's ID for correlation.
+     *
+     * @return this request's ID
+     */
+    public String getId() {
+        return id;
     }
 
     /**
@@ -82,11 +96,21 @@ public class ClientRequest {
     }
 
     /**
+     * Return the body to encode while processing this request.
+     *
+     * @return the request body, can be {@code null}
+     */
+    @Nullable
+    public Object getBody() {
+        return body;
+    }
+
+    /**
      * Return the original request template.
      *
-     * @return the {@link DiscordRequest} template that created this {@link ClientRequest}
+     * @return the {@link DiscordWebRequest} template that created this {@link ClientRequest}
      */
-    public DiscordRequest<?> getDiscordRequest() {
+    public DiscordWebRequest getDiscordRequest() {
         return request;
     }
 
@@ -95,7 +119,7 @@ public class ClientRequest {
      *
      * @return the {@link Route} requested by this {@link ClientRequest}
      */
-    public Route<?> getRoute() {
+    public Route getRoute() {
         return request.getRoute();
     }
 
@@ -105,6 +129,8 @@ public class ClientRequest {
                 "method=" + getMethod() +
                 ", url='" + url + '\'' +
                 ", headers=" + headers.copy().remove(HttpHeaderNames.AUTHORIZATION).toString() +
+                ", body=" + body +
+                ", id=" + id +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/http/client/ClientResponse.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientResponse.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.http.client;
+
+import discord4j.rest.http.ExchangeStrategies;
+import discord4j.rest.http.ReaderStrategy;
+import discord4j.rest.json.response.ErrorResponse;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.ReferenceCounted;
+import reactor.core.publisher.Mono;
+import reactor.netty.NettyInbound;
+import reactor.netty.http.client.HttpClientResponse;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An HTTP response encapsulating status, headers and accessors to the response body for consumption.
+ * <p>
+ * Make sure you call {@link #bodyToMono(Class)}, {@link #skipBody()} or similar and actually consume the response
+ * body. It is possible to use {@code bodyToMono(Void.class)} if the response is empty.
+ */
+public class ClientResponse {
+
+    private static final Logger log = Loggers.getLogger(ClientResponse.class);
+
+    private final HttpClientResponse response;
+    private final NettyInbound inbound;
+    private final ExchangeStrategies exchangeStrategies;
+    private final ClientRequest clientRequest;
+    private final AtomicBoolean reject = new AtomicBoolean();
+
+    ClientResponse(HttpClientResponse response, NettyInbound inbound, ExchangeStrategies exchangeStrategies,
+                   ClientRequest clientRequest) {
+        this.response = response;
+        this.inbound = inbound;
+        this.exchangeStrategies = exchangeStrategies;
+        this.clientRequest = clientRequest;
+    }
+
+    /**
+     * Return the underlying {@link HttpClientResponse} from where you can access the response headers, status and
+     * context.
+     *
+     * @return this response {@link HttpClientResponse}
+     */
+    public HttpClientResponse getResponse() {
+        return response;
+    }
+
+    /**
+     * Return the body of this response as a {@link Mono} of {@link ByteBuf}. If this {@link Mono} is cancelled, then
+     * it will not be possible to consume the body again.
+     *
+     * @return the response body contents
+     */
+    public Mono<ByteBuf> getBody() {
+        return inbound.receive()
+                .aggregate()
+                .doOnSubscribe(s -> {
+                    if (reject.get()) {
+                        throw new IllegalStateException("Response body can only be consumed once");
+                    }
+                })
+                .doOnCancel(() -> reject.set(true))
+                .map(ByteBuf::retain)
+                .doOnNext(buf -> buf.touch("discord4j.client.response"));
+    }
+
+    /**
+     * Read the response body and extract it to a single object according to the {@code responseType} given. If the
+     * response has an HTTP error (status codes 4xx and 5xx) the produced object will be a {@link ClientException}.
+     *
+     * @param responseType the target type this response body should be converted into
+     * @param <T> the response type
+     * @return a {@link Mono} containing the response body extracted into the given {@code T} type. If a network or
+     * read error had occurred, it will be emitted through the {@link Mono}.
+     */
+    public <T> Mono<T> bodyToMono(Class<T> responseType) {
+        String responseContentType = response.responseHeaders().get(HttpHeaderNames.CONTENT_TYPE);
+        Optional<ReaderStrategy<?>> readerStrategy = exchangeStrategies.readers().stream()
+                .filter(s -> s.canRead(responseType, responseContentType))
+                .findFirst();
+        Mono<ByteBuf> content = getBody().doOnDiscard(ByteBuf.class, buf -> {
+            log.info("Releasing buffer on element discard");
+            buf.release();
+        });
+        if (response.status().code() >= 400) {
+            return Mono.justOrEmpty(readerStrategy)
+                    .map(ClientResponse::<ErrorResponse>cast)
+                    .flatMap(s -> s.read(content, ErrorResponse.class))
+                    .flatMap(s -> Mono.<T>error(clientException(clientRequest, response, s)))
+                    .switchIfEmpty(Mono.error(clientException(clientRequest, response, null)));
+        } else {
+            return readerStrategy.map(ClientResponse::<T>cast)
+                    .map(s -> s.read(content, responseType))
+                    .orElseGet(() -> Mono.error(noReaderException(responseType, responseContentType)));
+        }
+    }
+
+    /**
+     * Consume and release the response body then return and empty {@link Mono}.
+     *
+     * @return an empty {@link Mono} indicating response body consumption and release
+     */
+    public Mono<Void> skipBody() {
+        return getBody().map(ReferenceCounted::release).then();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ReaderStrategy<T> cast(ReaderStrategy<?> strategy) {
+        return (ReaderStrategy<T>) strategy;
+    }
+
+    private static ClientException clientException(ClientRequest request, HttpClientResponse response,
+                                                   @Nullable ErrorResponse errorResponse) {
+        return new ClientException(request, response, errorResponse);
+    }
+
+    private static RuntimeException noReaderException(Object body, String contentType) {
+        return new RuntimeException("No strategies to read this response: " + body + " - " + contentType);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientResponse{" +
+                "response=" + response +
+                '}';
+    }
+}

--- a/rest/src/main/java/discord4j/rest/request/DiscordWebRequest.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordWebRequest.java
@@ -16,10 +16,8 @@
  */
 package discord4j.rest.request;
 
-import discord4j.common.LogUtil;
 import discord4j.rest.route.Route;
 import discord4j.rest.util.RouteUtils;
-import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.util.LinkedHashMap;
@@ -30,13 +28,10 @@ import java.util.function.Predicate;
 
 /**
  * Template encoding all of the needed information to make an HTTP request to Discord.
- *
- * @param <T> The response type.
- * @since 3.0
  */
-public class DiscordRequest<T> {
+public class DiscordWebRequest {
 
-    private final Route<T> route;
+    private final Route route;
     private final String completeUri;
     private final Map<String, String> uriVariableMap;
 
@@ -50,12 +45,12 @@ public class DiscordRequest<T> {
     private Map<String, Set<String>> headers;
 
     /**
-     * Create a new {@link DiscordRequest} template based on a {@link Route} and its compiled URI.
+     * Create a new {@link DiscordWebRequest} template based on a {@link Route} and its compiled URI.
      *
      * @param route the API resource targeted by this request
      * @param uriVars the values to expand each template parameter
      */
-    public DiscordRequest(Route<T> route, Object... uriVars) {
+    public DiscordWebRequest(Route route, Object... uriVars) {
         this.route = route;
         this.completeUri = RouteUtils.expand(route.getUriTemplate(), uriVars);
         this.uriVariableMap = RouteUtils.createVariableMap(route.getUriTemplate(), uriVars);
@@ -64,9 +59,9 @@ public class DiscordRequest<T> {
     /**
      * Return the API endpoint targeted by this request.
      *
-     * @return the {@link Route} of this {@link DiscordRequest}
+     * @return the {@link Route} of this {@link DiscordWebRequest}
      */
-    public Route<T> getRoute() {
+    public Route getRoute() {
         return route;
     }
 
@@ -115,7 +110,7 @@ public class DiscordRequest<T> {
      * @param body the object to set as request body
      * @return this request
      */
-    public DiscordRequest<T> body(Object body) {
+    public DiscordWebRequest body(Object body) {
         this.body = body;
         return this;
     }
@@ -127,7 +122,7 @@ public class DiscordRequest<T> {
      * @param value the query parameter value
      * @return this request
      */
-    public DiscordRequest<T> query(String key, Object value) {
+    public DiscordWebRequest query(String key, Object value) {
         if (queryParams == null) {
             queryParams = new LinkedHashMap<>();
         }
@@ -141,7 +136,7 @@ public class DiscordRequest<T> {
      * @param params a map of query parameter names to values
      * @return this request
      */
-    public DiscordRequest<T> query(Map<String, Object> params) {
+    public DiscordWebRequest query(Map<String, Object> params) {
         params.forEach(this::query);
         return this;
     }
@@ -153,7 +148,7 @@ public class DiscordRequest<T> {
      * @param value the header value
      * @return this request
      */
-    public DiscordRequest<T> header(String key, String value) {
+    public DiscordWebRequest header(String key, String value) {
         if (headers == null) {
             headers = new LinkedHashMap<>();
         }
@@ -169,7 +164,7 @@ public class DiscordRequest<T> {
      * @param value the header value
      * @return this request
      */
-    public DiscordRequest<T> optionalHeader(String key, @Nullable String value) {
+    public DiscordWebRequest optionalHeader(String key, @Nullable String value) {
         return (value == null) ? this : header(key, value);
     }
 
@@ -183,9 +178,8 @@ public class DiscordRequest<T> {
      * @param router a router that performs this request
      * @return the result of this request
      */
-    public Mono<T> exchange(Router router) {
-        return router.exchange(this)
-                .subscriberContext(ctx -> ctx.put(LogUtil.KEY_REQUEST_ID, Integer.toHexString(hashCode())));
+    public DiscordWebResponse exchange(Router router) {
+        return router.exchange(this);
     }
 
     @Override

--- a/rest/src/main/java/discord4j/rest/request/DiscordWebResponse.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordWebResponse.java
@@ -28,7 +28,7 @@ public class DiscordWebResponse {
 
     private final Mono<ClientResponse> responseMono;
 
-    DiscordWebResponse(Mono<ClientResponse> responseMono) {
+    public DiscordWebResponse(Mono<ClientResponse> responseMono) {
         this.responseMono = responseMono;
     }
 

--- a/rest/src/main/java/discord4j/rest/request/DiscordWebResponse.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordWebResponse.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.request;
+
+import discord4j.rest.http.client.ClientException;
+import discord4j.rest.http.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * Wrapper for a {@link Mono} of {@link ClientResponse} to condense post-exchange calls.
+ */
+public class DiscordWebResponse {
+
+    private final Mono<ClientResponse> responseMono;
+
+    DiscordWebResponse(Mono<ClientResponse> responseMono) {
+        this.responseMono = responseMono;
+    }
+
+    /**
+     * Read the response body and extract it to a single object according to the {@code responseType} given. If the
+     * response has an HTTP error (status codes 4xx and 5xx) the produced object will be a {@link ClientException}.
+     *
+     * @param responseClass the target type this response body should be converted into
+     * @param <T> the response type
+     * @return a {@link Mono} containing the response body extracted into the given {@code T} type. If a network or
+     * read error had occurred, it will be emitted through the {@link Mono}.
+     */
+    public <T> Mono<T> bodyToMono(Class<T> responseClass) {
+        return responseMono.flatMap(res -> res.bodyToMono(responseClass));
+    }
+
+    /**
+     * Consume and release the response body then return and empty {@link Mono}.
+     *
+     * @return an empty {@link Mono} indicating response body consumption and release
+     */
+    public Mono<Void> skipBody() {
+        return responseMono.flatMap(ClientResponse::skipBody);
+    }
+
+    /**
+     * Return the underlying {@link Mono} of {@link ClientResponse}.
+     *
+     * @return the original {@link Mono} this response wrapper accesses
+     */
+    public Mono<ClientResponse> mono() {
+        return responseMono;
+    }
+}

--- a/rest/src/main/java/discord4j/rest/request/DiscordWebResponse.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscordWebResponse.java
@@ -22,7 +22,7 @@ import discord4j.rest.http.client.ClientResponse;
 import reactor.core.publisher.Mono;
 
 /**
- * Wrapper for a {@link Mono} of {@link ClientResponse} to condense post-exchange calls.
+ * Contract to handle a {@link Mono} of {@link ClientResponse} after a network exchange is done.
  */
 public class DiscordWebResponse {
 

--- a/rest/src/main/java/discord4j/rest/request/RequestCorrelation.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestCorrelation.java
@@ -22,17 +22,17 @@ import reactor.util.context.Context;
 
 class RequestCorrelation<T> {
 
-    private final DiscordRequest<T> request;
+    private final DiscordWebRequest request;
     private final MonoProcessor<T> response;
     private final Context context;
 
-    RequestCorrelation(DiscordRequest<T> request, MonoProcessor<T> response, Context context) {
+    RequestCorrelation(DiscordWebRequest request, MonoProcessor<T> response, Context context) {
         this.request = request;
         this.response = response;
         this.context = context;
     }
 
-    public DiscordRequest<T> getRequest() {
+    public DiscordWebRequest getRequest() {
         return request;
     }
 

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -19,6 +19,7 @@ package discord4j.rest.request;
 import discord4j.common.LogUtil;
 import discord4j.rest.http.client.ClientException;
 import discord4j.rest.http.client.ClientRequest;
+import discord4j.rest.http.client.ClientResponse;
 import discord4j.rest.http.client.DiscordWebClient;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.*;
@@ -37,19 +38,17 @@ import java.util.function.Function;
 import static discord4j.common.LogUtil.format;
 
 /**
- * A stream of {@link DiscordRequest DiscordRequests}. Any number of items may be {@link #push(RequestCorrelation)}
+ * A stream of {@link DiscordWebRequest DiscordRequests}. Any number of items may be {@link #push(RequestCorrelation)}
  * written to the stream. However, the {@link RequestSubscriber} ensures that only one is read at a time. This
  * serialization ensures proper rate limit handling.
  * <p>
  * The flow of a request through the stream is as follows:
  *
  * <img src="{@docRoot}img/RequestStream_Flow.png">
- *
- * @param <T> The type of items in the stream.
  */
-class RequestStream<T> {
+class RequestStream {
 
-    private final EmitterProcessor<RequestCorrelation<T>> backing = EmitterProcessor.create(false);
+    private final EmitterProcessor<RequestCorrelation<ClientResponse>> backing = EmitterProcessor.create(false);
     private final BucketKey id;
     private final DiscordWebClient httpClient;
     private final GlobalRateLimiter globalRateLimiter;
@@ -84,7 +83,7 @@ class RequestStream<T> {
                 });
     }
 
-    void push(RequestCorrelation<T> request) {
+    void push(RequestCorrelation<ClientResponse> request) {
         backing.onNext(request);
     }
 
@@ -100,7 +99,7 @@ class RequestStream<T> {
      * @see #sleepTime
      * @see #rateLimitHandler
      */
-    private class RequestSubscriber extends BaseSubscriber<RequestCorrelation<T>> {
+    private class RequestSubscriber extends BaseSubscriber<RequestCorrelation<ClientResponse>> {
 
         private volatile Duration sleepTime = Duration.ZERO;
         private final Consumer<HttpClientResponse> rateLimitHandler;
@@ -130,43 +129,34 @@ class RequestStream<T> {
         }
 
         @Override
-        protected void hookOnNext(RequestCorrelation<T> correlation) {
-            DiscordRequest<T> request = correlation.getRequest();
-            MonoProcessor<T> callback = correlation.getResponse();
+        protected void hookOnNext(RequestCorrelation<ClientResponse> correlation) {
+            DiscordWebRequest request = correlation.getRequest();
+            ClientRequest clientRequest = new ClientRequest(request);
+            MonoProcessor<ClientResponse> callback = correlation.getResponse();
 
             if (tracesLog.isDebugEnabled()) {
                 tracesLog.debug("Accepting request in bucket {}: {}", id.toString(), request);
             }
 
-            Class<T> responseType = request.getRoute().getResponseType();
-
             globalRateLimiter.withLimiter(
-                    Mono.fromCallable(() -> new ClientRequest(request))
+                    Mono.just(clientRequest)
                             .doOnEach(s -> requestLog.debug(format(s.getContext(), "{}"), s))
-                            .flatMap(r -> httpClient.exchange(r, request.getBody(), responseType, rateLimitHandler))
+                            .flatMap(httpClient::exchange)
                             .doOnEach(s -> responseLog.debug(format(s.getContext(), "{}"), s))
+                            .doOnNext(res -> rateLimitHandler.accept(res.getResponse()))
                             .subscriberContext(ctx -> ctx
                                     .putAll(correlation.getContext())
+                                    .put(LogUtil.KEY_REQUEST_ID, clientRequest.getId())
                                     .put(LogUtil.KEY_BUCKET_ID, id.toString()))
                             .retryWhen(rateLimitRetryOperator::apply)
                             .transform(getResponseTransformers(request))
                             .retryWhen(serverErrorRetryFactory())
                             .doFinally(this::next))
-                    .materialize()
-                    .subscribe(signal -> {
-                        if (signal.isOnSubscribe()) {
-                            callback.onSubscribe(signal.getSubscription());
-                        } else if (signal.isOnNext()) {
-                            callback.onNext(signal.get());
-                        } else if (signal.isOnError()) {
-                            callback.onError(signal.getThrowable());
-                        } else if (signal.isOnComplete()) {
-                            callback.onComplete();
-                        }
-                    });
+                    .subscribeWith(callback)
+                    .subscribe(null, t -> log.error("Error while processing {}", request, t));
         }
 
-        private Function<Mono<T>, Mono<T>> getResponseTransformers(DiscordRequest<T> discordRequest) {
+        private Function<Mono<ClientResponse>, Mono<ClientResponse>> getResponseTransformers(DiscordWebRequest discordRequest) {
             return routerOptions.getResponseTransformers()
                     .stream()
                     .map(rt -> rt.transform(discordRequest))

--- a/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
+++ b/rest/src/main/java/discord4j/rest/request/RouteMatcher.java
@@ -26,23 +26,23 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 /**
- * A predicate that can match a given {@link DiscordRequest}. You can create instances of this class using the
+ * A predicate that can match a given {@link DiscordWebRequest}. You can create instances of this class using the
  * {@link #route(Route)} factory, or through {@link #any()} to provide a catch-all matcher.
  */
 @Experimental
 public class RouteMatcher {
 
     @Nullable
-    private final DiscordRequest<?> request;
+    private final DiscordWebRequest request;
 
     @Nullable
     private final Predicate<Map<String, String>> requestVariableMatcher;
 
-    private RouteMatcher(DiscordRequest<?> request) {
+    private RouteMatcher(DiscordWebRequest request) {
         this(request, null);
     }
 
-    public RouteMatcher(DiscordRequest<?> request, Predicate<Map<String, String>> requestVariableMatcher) {
+    public RouteMatcher(DiscordWebRequest request, Predicate<Map<String, String>> requestVariableMatcher) {
         this.request = request;
         this.requestVariableMatcher = requestVariableMatcher;
     }
@@ -63,7 +63,7 @@ public class RouteMatcher {
      * @param route the {@link Route} to be matched by this instance
      * @return a new {@link RouteMatcher}
      */
-    public static RouteMatcher route(Route<?> route) {
+    public static RouteMatcher route(Route route) {
         return new RouteMatcher(route.newRequest());
     }
 
@@ -72,35 +72,35 @@ public class RouteMatcher {
      * a given {@link Predicate} of URI variables.
      * <p>
      * The given predicate will receive a {@link Map} of {@code String} URI template parameters as keys and {@code
-     * String} values used to compile the URI for a {@link DiscordRequest}. This means you would expect keys as
+     * String} values used to compile the URI for a {@link DiscordWebRequest}. This means you would expect keys as
      * {@code guild.id}, {@code channel.id}, {@code message.id}, {@code user.id}, among others. Refer to the actual
      * {@link Route} instances declared in the {@link Routes} class for the exact template keys used in the requests
      * you want to match.
      *
      * @param route the {@link Route} to be matched by this instance
      * @param requestVariableMatcher a {@link Map} of {@code String} keys and values representing the URI template and
-     * the completed value for a given {@link DiscordRequest}, respectively
+     * the completed value for a given {@link DiscordWebRequest}, respectively
      * @return a new {@link RouteMatcher}
      */
-    public static RouteMatcher route(Route<?> route, Predicate<Map<String, String>> requestVariableMatcher) {
+    public static RouteMatcher route(Route route, Predicate<Map<String, String>> requestVariableMatcher) {
         return new RouteMatcher(route.newRequest(), requestVariableMatcher);
     }
 
     /**
-     * Tests this matcher against the given {@link DiscordRequest}.
+     * Tests this matcher against the given {@link DiscordWebRequest}.
      *
-     * @param otherRequest the {@link DiscordRequest} argument
+     * @param otherRequest the {@link DiscordWebRequest} argument
      * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
      */
-    public boolean matches(DiscordRequest<?> otherRequest) {
+    public boolean matches(DiscordWebRequest otherRequest) {
         return matchesRoute(otherRequest) && matchesVariables(otherRequest);
     }
 
-    private boolean matchesRoute(DiscordRequest<?> otherRequest) {
+    private boolean matchesRoute(DiscordWebRequest otherRequest) {
         return request == null || request.getRoute().equals(otherRequest.getRoute());
     }
 
-    private boolean matchesVariables(DiscordRequest<?> otherRequest) {
+    private boolean matchesVariables(DiscordWebRequest otherRequest) {
         return requestVariableMatcher == null || otherRequest.matchesVariables(requestVariableMatcher);
     }
 }

--- a/rest/src/main/java/discord4j/rest/request/Router.java
+++ b/rest/src/main/java/discord4j/rest/request/Router.java
@@ -26,7 +26,7 @@ public interface Router {
      * Queues a request for execution.
      *
      * @param request the request to queue.
-     * @return a mono that receives signals based on the request's response.
+     * @return a {@link DiscordWebResponse} specifying a contract to operate on the response
      */
     DiscordWebResponse exchange(DiscordWebRequest request);
 }

--- a/rest/src/main/java/discord4j/rest/request/Router.java
+++ b/rest/src/main/java/discord4j/rest/request/Router.java
@@ -17,10 +17,8 @@
 
 package discord4j.rest.request;
 
-import reactor.core.publisher.Mono;
-
 /**
- * Represents a connector executing {@link discord4j.rest.request.DiscordRequest} objects against the Discord REST API.
+ * Represents a connector executing {@link DiscordWebRequest} objects against the Discord REST API.
  */
 public interface Router {
 
@@ -28,8 +26,7 @@ public interface Router {
      * Queues a request for execution.
      *
      * @param request the request to queue.
-     * @param <T> the request's response type.
      * @return a mono that receives signals based on the request's response.
      */
-    <T> Mono<T> exchange(DiscordRequest<T> request);
+    DiscordWebResponse exchange(DiscordWebRequest request);
 }

--- a/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/EmptyResponseTransformer.java
@@ -18,7 +18,8 @@
 package discord4j.rest.response;
 
 import discord4j.common.annotations.Experimental;
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.http.client.ClientResponse;
+import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
 
@@ -45,7 +46,7 @@ public class EmptyResponseTransformer implements ResponseFunction {
     }
 
     @Override
-    public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
+    public Function<Mono<ClientResponse>, Mono<ClientResponse>> transform(DiscordWebRequest request) {
         if (routeMatcher.matches(request)) {
             return mono -> mono.onErrorResume(predicate, t -> Mono.empty());
         }

--- a/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
+++ b/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
@@ -19,7 +19,8 @@ package discord4j.rest.response;
 
 import discord4j.common.annotations.Experimental;
 import discord4j.rest.http.client.ClientException;
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.http.client.ClientResponse;
+import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.request.RouteMatcher;
 import discord4j.rest.request.Router;
 import discord4j.rest.request.RouterOptions;
@@ -30,7 +31,7 @@ import java.time.Duration;
 import java.util.function.Function;
 
 /**
- * A transformation function used while processing {@link DiscordRequest} objects.
+ * A transformation function used while processing {@link DiscordWebRequest} objects.
  * <p>
  * Using {@link ResponseFunction} objects is targeted to supporting {@link Router} implementations that allow enrichment
  * of a response {@link Mono} pipeline, allowing cross-cutting behavior for specialized error handling or retrying under
@@ -45,14 +46,13 @@ import java.util.function.Function;
 public interface ResponseFunction {
 
     /**
-     * Transform a {@link Mono} pipeline using the given {@link DiscordRequest} as hint for parameterization of the
+     * Transform a {@link Mono} pipeline using the given {@link DiscordWebRequest} as hint for parameterization of the
      * resulting transformation.
      *
      * @param request the {@code DiscordRequest} used for the targeted {@code Mono} sequence
-     * @param <T> the type of the sequence
      * @return a {@link Function} that allows immediately mapping this {@code Mono} into a target {@code Mono} instance
      */
-    <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request);
+    Function<Mono<ClientResponse>, Mono<ClientResponse>> transform(DiscordWebRequest request);
 
     /**
      * Transform every HTTP 404 status code into an empty response into an empty sequence, effectively suppressing

--- a/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/ResumingTransformer.java
@@ -18,7 +18,8 @@
 package discord4j.rest.response;
 
 import discord4j.common.annotations.Experimental;
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.http.client.ClientResponse;
+import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
 
@@ -43,7 +44,7 @@ public class ResumingTransformer implements ResponseFunction {
     }
 
     @Override
-    public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
+    public Function<Mono<ClientResponse>, Mono<ClientResponse>> transform(DiscordWebRequest request) {
         if (routeMatcher.matches(request)) {
             return mono -> mono.onErrorResume(predicate, adaptFallback(fallback));
         }

--- a/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
@@ -18,7 +18,8 @@
 package discord4j.rest.response;
 
 import discord4j.common.annotations.Experimental;
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.http.client.ClientResponse;
+import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
 import reactor.retry.Retry;
@@ -40,7 +41,7 @@ public class RetryingTransformer implements ResponseFunction {
     }
 
     @Override
-    public <T> Function<Mono<T>, Mono<T>> transform(DiscordRequest<T> request) {
+    public Function<Mono<ClientResponse>, Mono<ClientResponse>> transform(DiscordWebRequest request) {
         if (routeMatcher.matches(request)) {
             return mono -> mono.retryWhen(retryFactory);
         }

--- a/rest/src/main/java/discord4j/rest/route/Route.java
+++ b/rest/src/main/java/discord4j/rest/route/Route.java
@@ -16,7 +16,7 @@
  */
 package discord4j.rest.route;
 
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.DiscordWebRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import reactor.util.annotation.Nullable;
 
@@ -24,40 +24,35 @@ import java.util.Objects;
 
 /**
  * Provides a mapping between a Discord API endpoint and its response type.
- *
- * @param <T> the response type
- * @since 3.0
  */
-public class Route<T> {
+public class Route {
 
     private final HttpMethod method;
     private final String uriTemplate;
-    private final Class<T> responseType;
 
-    private Route(HttpMethod method, String uriTemplate, Class<T> responseType) {
+    private Route(HttpMethod method, String uriTemplate) {
         this.method = method;
         this.uriTemplate = uriTemplate;
-        this.responseType = responseType;
     }
 
-    public static <T> Route<T> get(String uri, Class<T> responseType) {
-        return new Route<>(HttpMethod.GET, uri, responseType);
+    public static Route get(String uri) {
+        return new Route(HttpMethod.GET, uri);
     }
 
-    public static <T> Route<T> post(String uri, Class<T> responseType) {
-        return new Route<>(HttpMethod.POST, uri, responseType);
+    public static Route post(String uri) {
+        return new Route(HttpMethod.POST, uri);
     }
 
-    public static <T> Route<T> put(String uri, Class<T> responseType) {
-        return new Route<>(HttpMethod.PUT, uri, responseType);
+    public static Route put(String uri) {
+        return new Route(HttpMethod.PUT, uri);
     }
 
-    public static <T> Route<T> patch(String uri, Class<T> responseType) {
-        return new Route<>(HttpMethod.PATCH, uri, responseType);
+    public static Route patch(String uri) {
+        return new Route(HttpMethod.PATCH, uri);
     }
 
-    public static <T> Route<T> delete(String uri, Class<T> responseType) {
-        return new Route<>(HttpMethod.DELETE, uri, responseType);
+    public static Route delete(String uri) {
+        return new Route(HttpMethod.DELETE, uri);
     }
 
     /**
@@ -70,23 +65,14 @@ public class Route<T> {
     }
 
     /**
-     * Return the route's response type. Can be {@link Void} if the {@link Route} has no response body.
-     *
-     * @return the response type of this {@link Route}
-     */
-    public Class<T> getResponseType() {
-        return responseType;
-    }
-
-    /**
      * Prepare a request, expanding this route template URI with the given parameters.
      *
      * @param uriVars the values to expand each template parameter
      * @return a request that is ready to be routed
-     * @see discord4j.rest.request.DiscordRequest#exchange
+     * @see DiscordWebRequest#exchange
      */
-    public DiscordRequest<T> newRequest(Object... uriVars) {
-        return new DiscordRequest<>(this, uriVars);
+    public DiscordWebRequest newRequest(Object... uriVars) {
+        return new DiscordWebRequest(this, uriVars);
     }
 
     /**
@@ -100,7 +86,7 @@ public class Route<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(method, responseType, uriTemplate);
+        return Objects.hash(method, uriTemplate);
     }
 
     @Override
@@ -115,8 +101,7 @@ public class Route<T> {
 
         Route other = (Route) obj;
 
-        return other.method.equals(method) && other.responseType.equals(responseType)
-                && other.uriTemplate.equals(uriTemplate);
+        return other.method.equals(method) && other.uriTemplate.equals(uriTemplate);
     }
 
     @Override
@@ -124,7 +109,6 @@ public class Route<T> {
         return "Route{" +
                 "method=" + method +
                 ", uriTemplate='" + uriTemplate + '\'' +
-                ", responseType=" + responseType +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -17,8 +17,6 @@
 package discord4j.rest.route;
 
 import discord4j.common.annotations.Experimental;
-import discord4j.common.json.*;
-import discord4j.rest.json.response.*;
 
 /**
  * A collection of {@link discord4j.rest.route.Route} object definitions.
@@ -47,7 +45,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/topics/gateway#get-gateway">
      *         https://discordapp.com/developers/docs/topics/gateway#get-gateway</a>
      */
-    public static final Route<GatewayResponse> GATEWAY_GET = Route.get("/gateway", GatewayResponse.class);
+    public static final Route GATEWAY_GET = Route.get("/gateway");
 
     /**
      * Returns an object with the same information as Get Gateway, plus a shards key, containing the recommended number
@@ -60,7 +58,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/topics/gateway#get-gateway-bot">
      *         https://discordapp.com/developers/docs/topics/gateway#get-gateway-bot</a>
      */
-    public static final Route<GatewayResponse> GATEWAY_BOT_GET = Route.get("/gateway/bot", GatewayResponse.class);
+    public static final Route GATEWAY_BOT_GET = Route.get("/gateway/bot");
 
     //////////////////////////////////////////////
     ////////////// Audit Log Resource ////////////
@@ -72,8 +70,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log">
      *         https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log</a>
      */
-    public static final Route<AuditLogResponse> AUDIT_LOG_GET = Route.get("/guilds/{guild.id}/audit-logs",
-            AuditLogResponse.class);
+    public static final Route AUDIT_LOG_GET = Route.get("/guilds/{guild.id}/audit-logs");
 
     //////////////////////////////////////////////
     ////////////// Channel Resource //////////////
@@ -85,7 +82,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#get-channel">
      *         https://discordapp.com/developers/docs/resources/channel#get-channel</a>
      */
-    public static final Route<ChannelResponse> CHANNEL_GET = Route.get("/channels/{channel.id}", ChannelResponse.class);
+    public static final Route CHANNEL_GET = Route.get("/channels/{channel.id}");
 
     /**
      * Update a channels settings. Requires the 'MANAGE_CHANNELS' permission for the guild. Returns a guild channel on
@@ -94,8 +91,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#modify-channel">
      *         https://discordapp.com/developers/docs/resources/channel#modify-channel</a>
      */
-    public static final Route<ChannelResponse> CHANNEL_MODIFY = Route.put("/channels/{channel.id}",
-            ChannelResponse.class);
+    public static final Route CHANNEL_MODIFY = Route.put("/channels/{channel.id}");
 
     /**
      * Update a channels settings. Requires the 'MANAGE_CHANNELS' permission for the guild. Returns a guild channel on
@@ -105,8 +101,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#modify-channel">
      *         https://discordapp.com/developers/docs/resources/channel#modify-channel</a>
      */
-    public static final Route<ChannelResponse> CHANNEL_MODIFY_PARTIAL = Route.patch("/channels/{channel.id}",
-            ChannelResponse.class);
+    public static final Route CHANNEL_MODIFY_PARTIAL = Route.patch("/channels/{channel.id}");
 
     /**
      * Delete a guild channel, or close a private message. Requires the 'MANAGE_CHANNELS' permission for the guild.
@@ -115,8 +110,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#deleteclose-channel">
      *         https://discordapp.com/developers/docs/resources/channel#deleteclose-channel</a>
      */
-    public static final Route<ChannelResponse> CHANNEL_DELETE = Route.delete("/channels/{channel.id}",
-            ChannelResponse.class);
+    public static final Route CHANNEL_DELETE = Route.delete("/channels/{channel.id}");
 
     /**
      * Returns the messages for a channel. If operating on a guild channel, this endpoint requires the 'READ_MESSAGES'
@@ -125,8 +119,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#get-channel-messages">
      *         https://discordapp.com/developers/docs/resources/channel#get-channel-messages</a>
      */
-    public static final Route<MessageResponse[]> MESSAGES_GET = Route.get("/channels/{channel.id}/messages",
-            MessageResponse[].class);
+    public static final Route MESSAGES_GET = Route.get("/channels/{channel.id}/messages");
 
     /**
      * Returns a specific message in the channel. If operating on a guild channel, this endpoints requires the
@@ -135,8 +128,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#get-channel-message">
      *         https://discordapp.com/developers/docs/resources/channel#get-channel-message</a>
      */
-    public static final Route<MessageResponse> MESSAGE_GET = Route.get("/channels/{channel.id}/messages/{message.id}",
-            MessageResponse.class);
+    public static final Route MESSAGE_GET = Route.get("/channels/{channel.id}/messages/{message.id}");
 
     /**
      * Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the
@@ -151,8 +143,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#create-message">
      *         https://discordapp.com/developers/docs/resources/channel#create-message</a>
      */
-    public static final Route<MessageResponse> MESSAGE_CREATE = Route.post("/channels/{channel.id}/messages",
-            MessageResponse.class);
+    public static final Route MESSAGE_CREATE = Route.post("/channels/{channel.id}/messages");
 
     /**
      * Create a reaction for the message. This endpoint requires the 'READ_MESSAGE_HISTORY' permission to be present on
@@ -163,8 +154,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#create-reaction">
      *         https://discordapp.com/developers/docs/resources/channel#create-reaction</a>
      */
-    public static final Route<Void> REACTION_CREATE = Route.put(
-            "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", Void.class);
+    public static final Route REACTION_CREATE = Route.put("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me");
 
     /**
      * Delete a reaction the current user has made for the message. Returns a 204 empty response on success.
@@ -172,8 +162,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#delete-own-reaction">
      *         https://discordapp.com/developers/docs/resources/channel#delete-own-reaction</a>
      */
-    public static final Route<Void> REACTION_DELETE_OWN = Route.delete(
-            "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", Void.class);
+    public static final Route REACTION_DELETE_OWN = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me");
 
     /**
      * Deletes another user's reaction. This endpoint requires the 'MANAGE_MESSAGES' permission to be present on the
@@ -182,8 +171,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#delete-user-reaction">
      *         https://discordapp.com/developers/docs/resources/channel#delete-user-reaction</a>
      */
-    public static final Route<Void> REACTION_DELETE = Route.delete(
-            "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user.id}", Void.class);
+    public static final Route REACTION_DELETE = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user.id}");
 
     /**
      * Get a list of users that reacted with this emoji. Returns an array of user objects on success.
@@ -191,8 +179,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#get-reactions">
      *         https://discordapp.com/developers/docs/resources/channel#get-reactions</a>
      */
-    public static final Route<UserResponse[]> REACTIONS_GET = Route.get(
-            "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", UserResponse[].class);
+    public static final Route REACTIONS_GET = Route.get("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}");
 
     /**
      * Deletes all reactions on a message. This endpoint requires the 'MANAGE_MESSAGES' permission to be present on the
@@ -201,8 +188,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#delete-all-reactions">
      *         https://discordapp.com/developers/docs/resources/channel#delete-all-reactions</a>
      */
-    public static final Route<Void> REACTIONS_DELETE_ALL = Route.delete(
-            "/channels/{channel.id}/messages/{message.id}/reactions", Void.class);
+    public static final Route REACTIONS_DELETE_ALL = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions");
 
     /**
      * Edit a previously sent message. You can only edit messages that have been sent by the current user. Returns a
@@ -211,8 +197,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#edit-message">
      *         https://discordapp.com/developers/docs/resources/channel#edit-message</a>
      */
-    public static final Route<MessageResponse> MESSAGE_EDIT = Route.patch(
-            "/channels/{channel.id}/messages/{message.id}", MessageResponse.class);
+    public static final Route MESSAGE_EDIT = Route.patch("/channels/{channel.id}/messages/{message.id}");
 
     /**
      * Delete a message. If operating on a guild channel and trying to delete a message that was not sent by the
@@ -222,8 +207,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#delete-message">
      *         https://discordapp.com/developers/docs/resources/channel#delete-message</a>
      */
-    public static final Route<Void> MESSAGE_DELETE = Route.delete("/channels/{channel.id}/messages/{message.id}",
-            Void.class);
+    public static final Route MESSAGE_DELETE = Route.delete("/channels/{channel.id}/messages/{message.id}");
 
     /**
      * Delete multiple messages in a single request. This endpoint can only be used on guild channels and requires the
@@ -240,8 +224,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages">
      *         https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages</a>
      */
-    public static final Route<Void> MESSAGE_DELETE_BULK = Route.post("/channels/{channel.id}/messages/bulk-delete",
-            Void.class);
+    public static final Route MESSAGE_DELETE_BULK = Route.post("/channels/{channel.id}/messages/bulk-delete");
 
     /**
      * Enable/disable suppression of embeds on a Message. This endpoint requires the 'MANAGE_MESSAGES' permission to
@@ -253,8 +236,7 @@ public abstract class Routes {
      *         https://discordapp.com/developers/docs/resources/channel#suppress-message-embeds</a>
      */
     @Experimental
-    public static final Route<Void> MESSAGE_SUPPRESS_EMBEDS = Route.post(
-            "/channels/{channel.id}/messages/{message.id}/suppress-embeds", Void.class);
+    public static final Route MESSAGE_SUPPRESS_EMBEDS = Route.post("/channels/{channel.id}/messages/{message.id}/suppress-embeds");
 
     /**
      * Edit the channel permission overwrites for a user or role in a channel. Only usable for guild channels. Requires
@@ -264,8 +246,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions">
      *         https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions</a>
      */
-    public static final Route<Void> CHANNEL_PERMISSIONS_EDIT = Route.put(
-            "/channels/{channel.id}/permissions/{overwrite.id}", Void.class);
+    public static final Route CHANNEL_PERMISSIONS_EDIT = Route.put("/channels/{channel.id}/permissions/{overwrite.id}");
 
     /**
      * Returns a list of invite objects (with invite metadata) for the channel. Only usable for guild channels.
@@ -274,8 +255,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#get-channel-invites">
      *         https://discordapp.com/developers/docs/resources/channel#get-channel-invites</a>
      */
-    public static final Route<InviteResponse[]> CHANNEL_INVITES_GET = Route.get("/channels/{channel.id}/invites",
-            InviteResponse[].class);
+    public static final Route CHANNEL_INVITES_GET = Route.get("/channels/{channel.id}/invites");
 
     /**
      * Create a new invite object for the channel. Only usable for guild channels. Requires the CREATE_INSTANT_INVITE
@@ -285,8 +265,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#create-channel-invite">
      *         https://discordapp.com/developers/docs/resources/channel#create-channel-invite</a>
      */
-    public static final Route<InviteResponse> CHANNEL_INVITE_CREATE = Route.post("/channels/{channel.id}/invites",
-            InviteResponse.class);
+    public static final Route CHANNEL_INVITE_CREATE = Route.post("/channels/{channel.id}/invites");
 
     /**
      * Delete a channel permission overwrite for a user or role in a channel. Only usable for guild channels. Requires
@@ -296,8 +275,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#delete-channel-permission">
      *         https://discordapp.com/developers/docs/resources/channel#delete-channel-permission</a>
      */
-    public static final Route<Void> CHANNEL_PERMISSION_DELETE = Route.delete(
-            "/channels/{channel.id}/permissions/{overwrite.id}", Void.class);
+    public static final Route CHANNEL_PERMISSION_DELETE = Route.delete("/channels/{channel.id}/permissions/{overwrite.id}");
 
     /**
      * Post a typing indicator for the specified channel. Generally bots should not implement this route. However, if a
@@ -308,7 +286,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#trigger-typing-indicator">
      *         https://discordapp.com/developers/docs/resources/channel#trigger-typing-indicator</a>
      */
-    public static final Route<Void> TYPING_INDICATOR_TRIGGER = Route.post("/channels/{channel.id}/typing", Void.class);
+    public static final Route TYPING_INDICATOR_TRIGGER = Route.post("/channels/{channel.id}/typing");
 
     /**
      * Returns all pinned messages in the channel as an array of message objects.
@@ -316,8 +294,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#get-pinned-messages">
      *         https://discordapp.com/developers/docs/resources/channel#get-pinned-messages</a>
      */
-    public static final Route<MessageResponse[]> MESSAGES_PINNED_GET = Route.get("/channels/{channel.id}/pins",
-            MessageResponse[].class);
+    public static final Route MESSAGES_PINNED_GET = Route.get("/channels/{channel.id}/pins");
 
     /**
      * Pin a message in a channel. Requires the 'MANAGE_MESSAGES' permission. Returns a 204 empty response on success.
@@ -325,8 +302,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#add-pinned-channel-message">
      *         https://discordapp.com/developers/docs/resources/channel#add-pinned-channel-message</a>
      */
-    public static final Route<Void> MESSAGES_PINNED_ADD = Route.put("/channels/{channel.id}/pins/{message.id}",
-            Void.class);
+    public static final Route MESSAGES_PINNED_ADD = Route.put("/channels/{channel.id}/pins/{message.id}");
 
     /**
      * Delete a pinned message in a channel. Requires the 'MANAGE_MESSAGES' permission. Returns a 204 empty response on
@@ -335,8 +311,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#delete-pinned-channel-message">
      *         https://discordapp.com/developers/docs/resources/channel#delete-pinned-channel-message</a>
      */
-    public static final Route<Void> MESSAGES_PINNED_DELETE = Route.delete("/channels/{channel.id}/pins/{message.id}",
-            Void.class);
+    public static final Route MESSAGES_PINNED_DELETE = Route.delete("/channels/{channel.id}/pins/{message.id}");
 
     /**
      * Adds a recipient to a Group DM using their access token.
@@ -344,8 +319,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#group-dm-add-recipient">
      *         https://discordapp.com/developers/docs/resources/channel#group-dm-add-recipient</a>
      */
-    public static final Route<Void> GROUP_DM_RECIPIENT_ADD = Route.put("/channels/{channel.id}/recipients/{user.id}",
-            Void.class);
+    public static final Route GROUP_DM_RECIPIENT_ADD = Route.put("/channels/{channel.id}/recipients/{user.id}");
 
     /**
      * Removes a recipient from a Group DM.
@@ -353,8 +327,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/channel#group-dm-remove-recipient">
      *         https://discordapp.com/developers/docs/resources/channel#group-dm-remove-recipient</a>
      */
-    public static final Route<Void> GROUP_DM_RECIPIENT_DELETE = Route.delete(
-            "/channels/{channel.id}/recipients/{user.id}", Void.class);
+    public static final Route GROUP_DM_RECIPIENT_DELETE = Route.delete("/channels/{channel.id}/recipients/{user.id}");
 
     ////////////////////////////////////////////
     ////////////// Emoji Resource //////////////
@@ -366,8 +339,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/emoji#list-guild-emojis">
      *         https://discordapp.com/developers/docs/resources/emoji#list-guild-emojis</a>
      */
-    public static final Route<GuildEmojiResponse[]> GUILD_EMOJIS_GET = Route.get("/guilds/{guild.id}/emojis",
-            GuildEmojiResponse[].class);
+    public static final Route GUILD_EMOJIS_GET = Route.get("/guilds/{guild.id}/emojis");
 
     /**
      * Returns an emoji object for the given guild and emoji IDs.
@@ -375,8 +347,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/emoji#get-guild-emoji">
      *         https://discordapp.com/developers/docs/resources/emoji#get-guild-emoji</a>
      */
-    public static final Route<GuildEmojiResponse> GUILD_EMOJI_GET = Route.get("/guilds/{guild.id}/emojis/{emoji.id}",
-            GuildEmojiResponse.class);
+    public static final Route GUILD_EMOJI_GET = Route.get("/guilds/{guild.id}/emojis/{emoji.id}");
 
     /**
      * Create a new emoji for the guild. Returns the new emoji object on success. Fires a Guild Emojis Update Gateway
@@ -385,8 +356,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji">
      *         https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji</a>
      */
-    public static final Route<GuildEmojiResponse> GUILD_EMOJI_CREATE = Route.post("/guilds/{guild.id}/emojis",
-            GuildEmojiResponse.class);
+    public static final Route GUILD_EMOJI_CREATE = Route.post("/guilds/{guild.id}/emojis");
 
     /**
      * Modify the given emoji. Returns the updated emoji object on success. Fires a Guild Emojis Update Gateway event.
@@ -394,8 +364,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/emoji#modify-guild-emoji">
      *         https://discordapp.com/developers/docs/resources/emoji#modify-guild-emoji</a>
      */
-    public static final Route<GuildEmojiResponse> GUILD_EMOJI_MODIFY = Route.patch(
-            "/guilds/{guild.id}/emojis/{emoji.id}", GuildEmojiResponse.class);
+    public static final Route GUILD_EMOJI_MODIFY = Route.patch("/guilds/{guild.id}/emojis/{emoji.id}");
 
     /**
      * Delete the given emoji. Returns 204 No Content on success. Fires a Guild Emojis Update Gateway event.
@@ -403,8 +372,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/emoji#delete-guild-emoji">
      *         https://discordapp.com/developers/docs/resources/emoji#delete-guild-emoji</a>
      */
-    public static final Route<Void> GUILD_EMOJI_DELETE = Route.delete("/guilds/{guild.id}/emojis/{emoji.id}",
-            Void.class);
+    public static final Route GUILD_EMOJI_DELETE = Route.delete("/guilds/{guild.id}/emojis/{emoji.id}");
 
     ////////////////////////////////////////////
     ////////////// Guild Resource //////////////
@@ -419,7 +387,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#create-guild">
      *         https://discordapp.com/developers/docs/resources/guild#create-guild</a>
      */
-    public static final Route<GuildResponse> GUILD_CREATE = Route.post("/guilds", GuildResponse.class);
+    public static final Route GUILD_CREATE = Route.post("/guilds");
 
     /**
      * Returns the guild object for the given id.
@@ -427,7 +395,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild</a>
      */
-    public static final Route<GuildResponse> GUILD_GET = Route.get("/guilds/{guild.id}", GuildResponse.class);
+    public static final Route GUILD_GET = Route.get("/guilds/{guild.id}");
 
     /**
      * Modify a guild's settings. Returns the updated guild object on success. Fires a Guild Update Gateway event.
@@ -435,7 +403,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild</a>
      */
-    public static final Route<GuildResponse> GUILD_MODIFY = Route.patch("/guilds/{guild.id}", GuildResponse.class);
+    public static final Route GUILD_MODIFY = Route.patch("/guilds/{guild.id}");
 
     /**
      * Delete a guild permanently. User must be owner. Returns 204 No Content on success. Fires a Guild Delete Gateway
@@ -444,7 +412,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#delete-guild">
      *         https://discordapp.com/developers/docs/resources/guild#delete-guild</a>
      */
-    public static final Route<Void> GUILD_DELETE = Route.delete("/guilds/{guild.id}", Void.class);
+    public static final Route GUILD_DELETE = Route.delete("/guilds/{guild.id}");
 
     /**
      * Returns a list of guild channel objects.
@@ -452,8 +420,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-channels">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-channels</a>
      */
-    public static final Route<ChannelResponse[]> GUILD_CHANNELS_GET = Route.get("/guilds/{guild.id}/channels",
-            ChannelResponse[].class);
+    public static final Route GUILD_CHANNELS_GET = Route.get("/guilds/{guild.id}/channels");
 
     /**
      * Create a new channel object for the guild. Requires the 'MANAGE_CHANNELS' permission. Returns the new channel
@@ -462,8 +429,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#create-guild-channel">
      *         https://discordapp.com/developers/docs/resources/guild#create-guild-channel</a>
      */
-    public static final Route<ChannelResponse> GUILD_CHANNEL_CREATE = Route.post("/guilds/{guild.id}/channels",
-            ChannelResponse.class);
+    public static final Route GUILD_CHANNEL_CREATE = Route.post("/guilds/{guild.id}/channels");
 
     /**
      * Modify the positions of a set of role objects for the guild. Requires the 'MANAGE_ROLES' permission. Returns a
@@ -472,8 +438,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions</a>
      */
-    public static final Route<RoleResponse[]> GUILD_CHANNEL_POSITIONS_MODIFY = Route.patch(
-            "/guilds/{guild.id}/channels", RoleResponse[].class);
+    public static final Route GUILD_CHANNEL_POSITIONS_MODIFY = Route.patch("/guilds/{guild.id}/channels");
 
     /**
      * Returns a guild member object for the specified user.
@@ -481,8 +446,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-member">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-member</a>
      */
-    public static final Route<GuildMemberResponse> GUILD_MEMBER_GET = Route.get(
-            "/guilds/{guild.id}/members/{user.id}", GuildMemberResponse.class);
+    public static final Route GUILD_MEMBER_GET = Route.get("/guilds/{guild.id}/members/{user.id}");
 
     /**
      * Returns a list of guild member objects that are members of the guild.
@@ -490,8 +454,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#list-guild-members">
      *         https://discordapp.com/developers/docs/resources/guild#list-guild-members</a>
      */
-    public static final Route<GuildMemberResponse[]> GUILD_MEMBERS_LIST = Route.get("/guilds/{guild.id}/members",
-            GuildMemberResponse[].class);
+    public static final Route GUILD_MEMBERS_LIST = Route.get("/guilds/{guild.id}/members");
 
     /**
      * Adds a user to the guild, provided you have a valid oauth2 access token for the user with the guilds.join scope.
@@ -501,8 +464,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#add-guild-member">
      *         https://discordapp.com/developers/docs/resources/guild#add-guild-member</a>
      */
-    public static final Route<GuildMemberResponse> GUILD_MEMBER_ADD = Route.put(
-            "/guilds/{guild.id}/members/{user.id}", GuildMemberResponse.class);
+    public static final Route GUILD_MEMBER_ADD = Route.put("/guilds/{guild.id}/members/{user.id}");
 
     /**
      * Modify attributes of a guild member. Returns a 204 empty response on success. Fires a Guild Member Update
@@ -511,8 +473,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-member">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-member</a>
      */
-    public static final Route<Void> GUILD_MEMBER_MODIFY = Route.patch("/guilds/{guild.id}/members/{user.id}",
-            Void.class);
+    public static final Route GUILD_MEMBER_MODIFY = Route.patch("/guilds/{guild.id}/members/{user.id}");
 
     /**
      * Modifies the nickname of the current user in a guild. Returns a 200 with the nickname on success. Fires a Guild
@@ -521,8 +482,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-current-user-nick">
      *         https://discordapp.com/developers/docs/resources/guild#modify-current-user-nick</a>
      */
-    public static final Route<NicknameModifyResponse> NICKNAME_MODIFY_OWN = Route.patch(
-            "/guilds/{guild.id}/members/@me/nick", NicknameModifyResponse.class);
+    public static final Route NICKNAME_MODIFY_OWN = Route.patch("/guilds/{guild.id}/members/@me/nick");
 
     /**
      * Adds a role to a guild member. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success.
@@ -531,8 +491,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#add-guild-member-role">
      *         https://discordapp.com/developers/docs/resources/guild#add-guild-member-role</a>
      */
-    public static final Route<Void> GUILD_MEMBER_ROLE_ADD = Route.put(
-            "/guilds/{guild.id}/members/{user.id}/roles/{role.id}", Void.class);
+    public static final Route GUILD_MEMBER_ROLE_ADD = Route.put("/guilds/{guild.id}/members/{user.id}/roles/{role.id}");
 
     /**
      * Removes a role from a guild member. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on
@@ -541,8 +500,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#remove-guild-member-role">
      *         https://discordapp.com/developers/docs/resources/guild#remove-guild-member-role</a>
      */
-    public static final Route<Void> GUILD_MEMBER_ROLE_REMOVE = Route.delete(
-            "/guilds/{guild.id}/members/{user.id}/roles/{role.id}", Void.class);
+    public static final Route GUILD_MEMBER_ROLE_REMOVE = Route.delete("/guilds/{guild.id}/members/{user.id}/roles/{role.id}");
 
     /**
      * Remove a member from a guild. Requires 'KICK_MEMBERS' permission. Returns a 204 empty response on success. Fires
@@ -551,8 +509,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#remove-guild-member">
      *         https://discordapp.com/developers/docs/resources/guild#remove-guild-member</a>
      */
-    public static final Route<Void> GUILD_MEMBER_REMOVE = Route.delete("/guilds/{guild.id}/members/{user.id}",
-            Void.class);
+    public static final Route GUILD_MEMBER_REMOVE = Route.delete("/guilds/{guild.id}/members/{user.id}");
 
     /**
      * Returns a list of ban objects for the users banned from this guild. Requires the 'BAN_MEMBERS' permission.
@@ -560,7 +517,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-bans">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-bans</a>
      */
-    public static final Route<BanResponse[]> GUILD_BANS_GET = Route.get("/guilds/{guild.id}/bans", BanResponse[].class);
+    public static final Route GUILD_BANS_GET = Route.get("/guilds/{guild.id}/bans");
 
     /**
      * Returns a ban object for the given user or a 404 not found if the ban cannot be found. Requires the 'BAN_MEMBERS'
@@ -569,8 +526,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-ban">
      *     https://discordapp.com/developers/docs/resources/guild#get-guild-ban</a>
      */
-    public static final Route<BanResponse> GUILD_BAN_GET = Route.get("/guilds/{guild.id}/bans/{user.id}",
-            BanResponse.class);
+    public static final Route GUILD_BAN_GET = Route.get("/guilds/{guild.id}/bans/{user.id}");
 
     /**
      * Create a guild ban, and optionally delete previous messages sent by the banned user. Requires the 'BAN_MEMBERS'
@@ -579,7 +535,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#create-guild-ban">
      *         https://discordapp.com/developers/docs/resources/guild#create-guild-ban</a>
      */
-    public static final Route<Void> GUILD_BAN_CREATE = Route.put("/guilds/{guild.id}/bans/{user.id}", Void.class);
+    public static final Route GUILD_BAN_CREATE = Route.put("/guilds/{guild.id}/bans/{user.id}");
 
     /**
      * Remove the ban for a user. Requires the 'BAN_MEMBERS' permissions. Returns a 204 empty response on success.
@@ -588,7 +544,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#remove-guild-ban">
      *         https://discordapp.com/developers/docs/resources/guild#remove-guild-ban</a>
      */
-    public static final Route<Void> GUILD_BAN_REMOVE = Route.delete("/guilds/{guild.id}/bans/{user.id}", Void.class);
+    public static final Route GUILD_BAN_REMOVE = Route.delete("/guilds/{guild.id}/bans/{user.id}");
 
     /**
      * Returns a list of role objects for the guild. Requires the 'MANAGE_ROLES' permission.
@@ -596,8 +552,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-roles">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-roles</a>
      */
-    public static final Route<RoleResponse[]> GUILD_ROLES_GET = Route.get("/guilds/{guild.id}/roles",
-            RoleResponse[].class);
+    public static final Route GUILD_ROLES_GET = Route.get("/guilds/{guild.id}/roles");
 
     /**
      * Create a new role for the guild. Requires the 'MANAGE_ROLES' permission. Returns the new role object on success.
@@ -606,8 +561,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#create-guild-role">
      *         https://discordapp.com/developers/docs/resources/guild#create-guild-role</a>
      */
-    public static final Route<RoleResponse> GUILD_ROLE_CREATE = Route.post("/guilds/{guild.id}/roles",
-            RoleResponse.class);
+    public static final Route GUILD_ROLE_CREATE = Route.post("/guilds/{guild.id}/roles");
 
     /**
      * Modify the positions of a set of role objects for the guild. Requires the 'MANAGE_ROLES' permission. Returns a
@@ -616,8 +570,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions</a>
      */
-    public static final Route<RoleResponse[]> GUILD_ROLE_POSITIONS_MODIFY = Route.patch("/guilds/{guild.id}/roles",
-            RoleResponse[].class);
+    public static final Route GUILD_ROLE_POSITIONS_MODIFY = Route.patch("/guilds/{guild.id}/roles");
 
     /**
      * Modify a guild role. Requires the 'MANAGE_ROLES' permission. Returns the updated role on success. Fires a Guild
@@ -626,8 +579,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-role">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-role</a>
      */
-    public static final Route<RoleResponse> GUILD_ROLE_MODIFY = Route.patch("/guilds/{guild.id}/roles/{role.id}",
-            RoleResponse.class);
+    public static final Route GUILD_ROLE_MODIFY = Route.patch("/guilds/{guild.id}/roles/{role.id}");
 
     /**
      * Delete a guild role. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. Fires a
@@ -636,7 +588,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#delete-guild-role">
      *         https://discordapp.com/developers/docs/resources/guild#delete-guild-role</a>
      */
-    public static final Route<Void> GUILD_ROLE_DELETE = Route.delete("/guilds/{guild.id}/roles/{role.id}", Void.class);
+    public static final Route GUILD_ROLE_DELETE = Route.delete("/guilds/{guild.id}/roles/{role.id}");
 
     /**
      * Returns an object with one 'pruned' key indicating the number of members that would be removed in a prune
@@ -645,8 +597,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count</a>
      */
-    public static final Route<PruneResponse> GUILD_PRUNE_COUNT_GET = Route.get("/guilds/{guild.id}/prune",
-            PruneResponse.class);
+    public static final Route GUILD_PRUNE_COUNT_GET = Route.get("/guilds/{guild.id}/prune");
 
     /**
      * Begin a prune operation. Requires the 'KICK_MEMBERS' permission. Returns an object with one 'pruned' key
@@ -656,8 +607,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#begin-guild-prune">
      *         https://discordapp.com/developers/docs/resources/guild#begin-guild-prune</a>
      */
-    public static final Route<PruneResponse> GUILD_PRUNE_BEGIN = Route.post("/guilds/{guild.id}/prune",
-            PruneResponse.class);
+    public static final Route GUILD_PRUNE_BEGIN = Route.post("/guilds/{guild.id}/prune");
 
     /**
      * Returns a list of voice region objects for the guild. Unlike the similar /voice route, this returns VIP servers
@@ -666,8 +616,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-voice-regions">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-voice-regions</a>
      */
-    public static final Route<VoiceRegionResponse[]> GUILD_VOICE_REGIONS_GET = Route.get(
-            "/guilds/{guild.id}/regions", VoiceRegionResponse[].class);
+    public static final Route GUILD_VOICE_REGIONS_GET = Route.get("/guilds/{guild.id}/regions");
 
     /**
      * Returns a list of invite objects (with invite metadata) for the guild. Requires the 'MANAGE_GUILD' permission.
@@ -675,8 +624,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-invites">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-invites</a>
      */
-    public static final Route<InviteResponse[]> GUILD_INVITES_GET = Route.get("/guilds/{guild.id}/invites",
-            InviteResponse[].class);
+    public static final Route GUILD_INVITES_GET = Route.get("/guilds/{guild.id}/invites");
 
     /**
      * Returns a list of integration objects for the guild. Requires the 'MANAGE_GUILD' permission.
@@ -684,8 +632,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-integrations">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-integrations</a>
      */
-    public static final Route<IntegrationResponse[]> GUILD_INTEGRATIONS_GET = Route.get(
-            "/guilds/{guild.id}/integrations", IntegrationResponse[].class);
+    public static final Route GUILD_INTEGRATIONS_GET = Route.get("/guilds/{guild.id}/integrations");
 
     /**
      * Attach an integration object from the current user to the guild. Requires the 'MANAGE_GUILD' permission. Returns
@@ -694,8 +641,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#create-guild-integration">
      *         https://discordapp.com/developers/docs/resources/guild#create-guild-integration</a>
      */
-    public static final Route<Void> GUILD_INTEGRATION_CREATE = Route.post("/guilds/{guild.id}/integrations",
-            Void.class);
+    public static final Route GUILD_INTEGRATION_CREATE = Route.post("/guilds/{guild.id}/integrations");
 
     /**
      * Modify the behavior and settings of a integration object for the guild. Requires the 'MANAGE_GUILD' permission.
@@ -704,8 +650,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-integration">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-integration</a>
      */
-    public static final Route<Void> GUILD_INTEGRATION_MODIFY = Route.patch(
-            "/guilds/{guild.id}/integrations/{integration.id}", Void.class);
+    public static final Route GUILD_INTEGRATION_MODIFY = Route.patch("/guilds/{guild.id}/integrations/{integration.id}");
 
     /**
      * Delete the attached integration object for the guild. Requires the 'MANAGE_GUILD' permission. Returns a 204
@@ -714,8 +659,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#delete-guild-integration">
      *         https://discordapp.com/developers/docs/resources/guild#delete-guild-integration</a>
      */
-    public static final Route<Void> GUILD_INTEGRATION_DELETE = Route.delete(
-            "/guilds/{guild.id}/integrations/{integration.id}", Void.class);
+    public static final Route GUILD_INTEGRATION_DELETE = Route.delete("/guilds/{guild.id}/integrations/{integration.id}");
 
     /**
      * Sync an integration. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success.
@@ -723,8 +667,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#sync-guild-integration">
      *         https://discordapp.com/developers/docs/resources/guild#sync-guild-integration</a>
      */
-    public static final Route<Void> GUILD_INTEGRATION_SYNC = Route.post(
-            "/guilds/{guild.id}/integrations/{integration.id}/sync", Void.class);
+    public static final Route GUILD_INTEGRATION_SYNC = Route.post("/guilds/{guild.id}/integrations/{integration.id}/sync");
 
     /**
      * Returns the guild embed object. Requires the 'MANAGE_GUILD' permission.
@@ -732,8 +675,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-embed">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-embed</a>
      */
-    public static final Route<GuildEmbedResponse> GUILD_EMBED_GET = Route.get("/guilds/{guild.id}/embed",
-            GuildEmbedResponse.class);
+    public static final Route GUILD_EMBED_GET = Route.get("/guilds/{guild.id}/embed");
 
     /**
      * Modify a guild embed object for the guild. All attributes may be passed in with JSON and modified. Requires the
@@ -742,8 +684,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-embed">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-embed</a>
      */
-    public static final Route<GuildEmbedResponse> GUILD_EMBED_MODIFY = Route.patch("/guilds/{guild.id}/embed",
-            GuildEmbedResponse.class);
+    public static final Route GUILD_EMBED_MODIFY = Route.patch("/guilds/{guild.id}/embed");
 
     /////////////////////////////////////////////
     ////////////// Invite Resource //////////////
@@ -755,7 +696,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/invite#get-invite">
      *         https://discordapp.com/developers/docs/resources/invite#get-invite</a>
      */
-    public static final Route<InviteResponse> INVITE_GET = Route.get("/invites/{invite.code}", InviteResponse.class);
+    public static final Route INVITE_GET = Route.get("/invites/{invite.code}");
 
     /**
      * Delete an invite. Requires the MANAGE_CHANNELS permission. Returns an invite object on success.
@@ -763,8 +704,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/invite#delete-invite">
      *         https://discordapp.com/developers/docs/resources/invite#delete-invite</a>
      */
-    public static final Route<InviteResponse> INVITE_DELETE = Route.delete("/invites/{invite.code}",
-            InviteResponse.class);
+    public static final Route INVITE_DELETE = Route.delete("/invites/{invite.code}");
 
     /**
      * Accept an invite. This requires the guilds.join OAuth2 scope to be able to accept invites on behalf of normal
@@ -773,8 +713,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/invite#accept-invite">
      *         https://discordapp.com/developers/docs/resources/invite#accept-invite</a>
      */
-    public static final Route<InviteResponse> INVITE_ACCEPT = Route.post("/invites/{invite.code}",
-            InviteResponse.class);
+    public static final Route INVITE_ACCEPT = Route.post("/invites/{invite.code}");
 
     ///////////////////////////////////////////
     ////////////// User Resource //////////////
@@ -787,7 +726,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#get-current-user">
      *         https://discordapp.com/developers/docs/resources/user#get-current-user</a>
      */
-    public static final Route<UserResponse> CURRENT_USER_GET = Route.get("/users/@me", UserResponse.class);
+    public static final Route CURRENT_USER_GET = Route.get("/users/@me");
 
     /**
      * Returns a user object for a given user ID.
@@ -795,7 +734,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#get-user">
      *         https://discordapp.com/developers/docs/resources/user#get-user</a>
      */
-    public static final Route<UserResponse> USER_GET = Route.get("/users/{user.id}", UserResponse.class);
+    public static final Route USER_GET = Route.get("/users/{user.id}");
 
     /**
      * Modify the requester's user account settings. Returns a user object on success.
@@ -803,7 +742,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#modify-current-user">
      *         https://discordapp.com/developers/docs/resources/user#modify-current-user</a>
      */
-    public static final Route<UserResponse> CURRENT_USER_MODIFY = Route.patch("/users/@me", UserResponse.class);
+    public static final Route CURRENT_USER_MODIFY = Route.patch("/users/@me");
 
     /**
      * Returns a list of partial guild objects the current user is a member of. Requires the guilds OAuth2 scope.
@@ -811,8 +750,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#get-current-user-guilds">
      *         https://discordapp.com/developers/docs/resources/user#get-current-user-guilds</a>
      */
-    public static final Route<UserGuildResponse[]> CURRENT_USER_GUILDS_GET = Route.get("/users/@me/guilds",
-            UserGuildResponse[].class);
+    public static final Route CURRENT_USER_GUILDS_GET = Route.get("/users/@me/guilds");
 
     /**
      * Leave a guild. Returns a 204 empty response on success.
@@ -820,7 +758,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#leave-guild">
      *         https://discordapp.com/developers/docs/resources/user#leave-guild</a>
      */
-    public static final Route<Void> GUILD_LEAVE = Route.delete("/users/@me/guilds/{guild.id}", Void.class);
+    public static final Route GUILD_LEAVE = Route.delete("/users/@me/guilds/{guild.id}");
 
     /**
      * Returns a list of DM channel objects.
@@ -828,8 +766,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#get-user-dms">
      *         https://discordapp.com/developers/docs/resources/user#get-user-dms</a>
      */
-    public static final Route<ChannelResponse[]> USER_DMS_GET = Route.get("/users/@me/channels",
-            ChannelResponse[].class);
+    public static final Route USER_DMS_GET = Route.get("/users/@me/channels");
 
     /**
      * Create a new DM channel with a user. Returns a DM channel object.
@@ -837,8 +774,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#create-dm">
      *         https://discordapp.com/developers/docs/resources/user#create-dm</a>
      */
-    public static final Route<ChannelResponse> USER_DM_CREATE = Route.post("/users/@me/channels",
-            ChannelResponse.class);
+    public static final Route USER_DM_CREATE = Route.post("/users/@me/channels");
 
     /**
      * Create a new group DM channel with multiple users. Returns a DM channel object.
@@ -846,8 +782,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#create-group-dm">
      *         https://discordapp.com/developers/docs/resources/user#create-group-dm</a>
      */
-    public static final Route<ChannelResponse> GROUP_DM_CREATE = Route.post("/users/@me/channels",
-            ChannelResponse.class);
+    public static final Route GROUP_DM_CREATE = Route.post("/users/@me/channels");
 
     /**
      * Returns a list of connection objects. Requires the connections OAuth2 scope.
@@ -855,8 +790,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/user#get-user-connections">
      *         https://discordapp.com/developers/docs/resources/user#get-user-connections</a>
      */
-    public static final Route<ConnectionResponse[]> USER_CONNECTIONS_GET = Route.get("/users/@me/connections",
-            ConnectionResponse[].class);
+    public static final Route USER_CONNECTIONS_GET = Route.get("/users/@me/connections");
 
     ////////////////////////////////////////////
     ////////////// Voice Resource //////////////
@@ -868,8 +802,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/voice#list-voice-regions">
      *         https://discordapp.com/developers/docs/resources/voice#list-voice-regions</a>
      */
-    public static final Route<VoiceRegionResponse[]> VOICE_REGION_LIST = Route.get("/voice/regions",
-            VoiceRegionResponse[].class);
+    public static final Route VOICE_REGION_LIST = Route.get("/voice/regions");
 
     //////////////////////////////////////////////
     ////////////// Webhook Resource //////////////
@@ -881,8 +814,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#create-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#create-webhook</a>
      */
-    public static final Route<WebhookResponse> CHANNEL_WEBHOOK_CREATE = Route.post("/channels/{channel.id}/webhooks",
-            WebhookResponse.class);
+    public static final Route CHANNEL_WEBHOOK_CREATE = Route.post("/channels/{channel.id}/webhooks");
 
     /**
      * Returns a list of channel webhook objects.
@@ -890,8 +822,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#get-channel-webhooks">
      *         https://discordapp.com/developers/docs/resources/webhook#get-channel-webhooks</a>
      */
-    public static final Route<WebhookResponse[]> CHANNEL_WEBHOOKS_GET = Route.get("/channels/{channel.id}/webhooks",
-            WebhookResponse[].class);
+    public static final Route CHANNEL_WEBHOOKS_GET = Route.get("/channels/{channel.id}/webhooks");
 
     /**
      * Returns a list of guild webhook objects.
@@ -899,8 +830,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#get-guild-webhooks">
      *         https://discordapp.com/developers/docs/resources/webhook#get-guild-webhooks</a>
      */
-    public static final Route<WebhookResponse[]> GUILD_WEBHOOKS_GET = Route.get("/guilds/{guild.id}/webhooks",
-            WebhookResponse[].class);
+    public static final Route GUILD_WEBHOOKS_GET = Route.get("/guilds/{guild.id}/webhooks");
 
     /**
      * Returns the new webhook object for the given id.
@@ -908,7 +838,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#get-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#get-webhook</a>
      */
-    public static final Route<WebhookResponse> WEBHOOK_GET = Route.get("/webhooks/{webhook.id}", WebhookResponse.class);
+    public static final Route WEBHOOK_GET = Route.get("/webhooks/{webhook.id}");
 
     /**
      * Same as {@link #WEBHOOK_GET}, except this call does not require authentication and returns no user in the
@@ -917,8 +847,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#get-webhook-with-token"
      *         >https://discordapp.com/developers/docs/resources/webhook#get-webhook-with-token</a>
      */
-    public static final Route<WebhookResponse> WEBHOOK_TOKEN_GET = Route.get(
-            "/webhooks/{webhook.id}/{webhook.token}", WebhookResponse.class);
+    public static final Route WEBHOOK_TOKEN_GET = Route.get("/webhooks/{webhook.id}/{webhook.token}");
 
     /**
      * Modify a webhook. Returns the updated webhook object on success. All parameters to this endpoint are optional.
@@ -926,8 +855,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#modify-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#modify-webhook</a>
      */
-    public static final Route<WebhookResponse> WEBHOOK_MODIFY = Route.patch("/webhooks/{webhook.id}",
-            WebhookResponse.class);
+    public static final Route WEBHOOK_MODIFY = Route.patch("/webhooks/{webhook.id}");
 
     /**
      * Same as {@link #WEBHOOK_MODIFY}, except this call does not require authentication and returns no user in the
@@ -936,8 +864,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token">
      *         https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token</a>
      */
-    public static final Route<WebhookResponse> WEBHOOK_TOKEN_MODIFY = Route.patch(
-            "/webhooks/{webhook.id}/{webhook.token}", WebhookResponse.class); // TODO: return type wrong
+    public static final Route WEBHOOK_TOKEN_MODIFY = Route.patch("/webhooks/{webhook.id}/{webhook.token}");
 
     /**
      * Delete a webhook permanently. User must be owner. Returns a 204 NO CONTENT response on success.
@@ -945,7 +872,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#delete-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#delete-webhook</a>
      */
-    public static final Route<Void> WEBHOOK_DELETE = Route.delete("/webhooks/{webhook.id}", Void.class);
+    public static final Route WEBHOOK_DELETE = Route.delete("/webhooks/{webhook.id}");
 
     /**
      * Same as above, except this call does not require authentication.
@@ -953,8 +880,7 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#delete-webhook-with-token">
      *         https://discordapp.com/developers/docs/resources/webhook#delete-webhook-with-token</a>
      */
-    public static final Route<Void> WEBHOOK_TOKEN_DELETE = Route.delete("/webhooks/{webhook.id}/{webhook.token}",
-            Void.class);
+    public static final Route WEBHOOK_TOKEN_DELETE = Route.delete("/webhooks/{webhook.id}/{webhook.token}");
 
     /**
      * This endpoint supports both JSON and form data bodies. It does require multipart/form-data requests instead of
@@ -965,21 +891,19 @@ public abstract class Routes {
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#execute-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#execute-webhook</a>
      */
-    public static final Route<Void> WEBHOOK_EXECUTE = Route.post("/webhooks/{webhook.id}/{webhook.token}", Void.class);
+    public static final Route WEBHOOK_EXECUTE = Route.post("/webhooks/{webhook.id}/{webhook.token}");
 
     /**
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook</a>
      */
-    public static final Route<Void> WEBHOOK_EXECUTE_SLACK = Route.post(
-            "/webhooks/{webhook.id}/{webhook.token}/slack", Void.class);
+    public static final Route WEBHOOK_EXECUTE_SLACK = Route.post("/webhooks/{webhook.id}/{webhook.token}/slack");
 
     /**
      * @see <a href="https://discordapp.com/developers/docs/resources/webhook#execute-githubcompatible-webhook">
      *         https://discordapp.com/developers/docs/resources/webhook#execute-githubcompatible-webhook</a>
      */
-    public static final Route<Void> WEBHOOK_EXECUTE_GITHUB = Route.post("/webhooks/{webhook.id}/{webhook.token}/github",
-            Void.class);
+    public static final Route WEBHOOK_EXECUTE_GITHUB = Route.post("/webhooks/{webhook.id}/{webhook.token}/github");
 
     /**
      * Returns the bot's OAuth2 application info.
@@ -987,6 +911,5 @@ public abstract class Routes {
      * @see <a href=https://discordapp.com/developers/docs/topics/oauth2#get-current-application-information>
      *         https://discordapp.com/developers/docs/topics/oauth2#get-current-application-information</a>
      */
-    public static final Route<ApplicationInfoResponse> APPLICATION_INFO_GET = Route.get("/oauth2/applications/@me",
-            ApplicationInfoResponse.class);
+    public static final Route APPLICATION_INFO_GET = Route.get("/oauth2/applications/@me");
 }

--- a/rest/src/main/java/discord4j/rest/service/ApplicationService.java
+++ b/rest/src/main/java/discord4j/rest/service/ApplicationService.java
@@ -29,6 +29,7 @@ public class ApplicationService extends RestService {
 
     public Mono<ApplicationInfoResponse> getCurrentApplicationInfo() {
         return Routes.APPLICATION_INFO_GET.newRequest()
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ApplicationInfoResponse.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/AuditLogService.java
+++ b/rest/src/main/java/discord4j/rest/service/AuditLogService.java
@@ -32,6 +32,7 @@ public class AuditLogService extends RestService {
     public Mono<AuditLogResponse> getAuditLog(long guildId, Map<String, Object> queryParams) {
         return Routes.AUDIT_LOG_GET.newRequest(guildId)
                 .query(queryParams)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(AuditLogResponse.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -40,54 +40,63 @@ public class ChannelService extends RestService {
 
     public Mono<ChannelResponse> getChannel(long channelId) {
         return Routes.CHANNEL_GET.newRequest(channelId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ChannelResponse.class);
     }
 
     public Mono<ChannelResponse> modifyChannel(long channelId, ChannelModifyRequest request, @Nullable String reason) {
         return Routes.CHANNEL_MODIFY_PARTIAL.newRequest(channelId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ChannelResponse.class);
     }
 
     public Mono<ChannelResponse> deleteChannel(long channelId, @Nullable String reason) {
         return Routes.CHANNEL_DELETE.newRequest(channelId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ChannelResponse.class);
     }
 
     public Flux<MessageResponse> getMessages(long channelId, Map<String, Object> queryParams) {
         return Routes.MESSAGES_GET.newRequest(channelId)
                 .query(queryParams)
                 .exchange(getRouter())
+                .bodyToMono(MessageResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<MessageResponse> getMessage(long channelId, long messageId) {
         return Routes.MESSAGE_GET.newRequest(channelId, messageId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(MessageResponse.class);
     }
 
     public Mono<MessageResponse> createMessage(long channelId, MultipartRequest request) {
         return Routes.MESSAGE_CREATE.newRequest(channelId)
                 .header("content-type", request.getFiles().isEmpty() ? "application/json" : "multipart/form-data")
                 .body(Objects.requireNonNull(request.getFiles().isEmpty() ? request.getCreateRequest() : request))
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(MessageResponse.class);
     }
 
     public Mono<Void> createReaction(long channelId, long messageId, String emoji) {
         return Routes.REACTION_CREATE.newRequest(channelId, messageId, emoji)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> deleteOwnReaction(long channelId, long messageId, String emoji) {
         return Routes.REACTION_DELETE_OWN.newRequest(channelId, messageId, emoji)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> deleteReaction(long channelId, long messageId, String emoji, long userId) {
         return Routes.REACTION_DELETE.newRequest(channelId, messageId, emoji, userId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<UserResponse> getReactions(long channelId, long messageId, String emoji,
@@ -95,30 +104,35 @@ public class ChannelService extends RestService {
         return Routes.REACTIONS_GET.newRequest(channelId, messageId, emoji)
                 .query(queryParams)
                 .exchange(getRouter())
+                .bodyToMono(UserResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<Void> deleteAllReactions(long channelId, long messageId) {
         return Routes.REACTIONS_DELETE_ALL.newRequest(channelId, messageId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<MessageResponse> editMessage(long channelId, long messageId, MessageEditRequest request) {
         return Routes.MESSAGE_EDIT.newRequest(channelId, messageId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(MessageResponse.class);
     }
 
     public Mono<Void> deleteMessage(long channelId, long messageId, @Nullable String reason) {
         return Routes.MESSAGE_DELETE.newRequest(channelId, messageId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> bulkDeleteMessages(long channelId, BulkDeleteRequest request) {
         return Routes.MESSAGE_DELETE_BULK.newRequest(channelId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     @Experimental
@@ -126,19 +140,22 @@ public class ChannelService extends RestService {
         return Routes.MESSAGE_SUPPRESS_EMBEDS.newRequest(channelId,messageId)
                 .header("content-type", "application/json")
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> editChannelPermissions(long channelId, long overwriteId, PermissionsEditRequest request, @Nullable String reason) {
         return Routes.CHANNEL_PERMISSIONS_EDIT.newRequest(channelId, overwriteId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<InviteResponse> getChannelInvites(long channelId) {
         return Routes.CHANNEL_INVITES_GET.newRequest(channelId)
                 .exchange(getRouter())
+                .bodyToMono(InviteResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
@@ -146,44 +163,52 @@ public class ChannelService extends RestService {
         return Routes.CHANNEL_INVITE_CREATE.newRequest(channelId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(InviteResponse.class);
     }
 
     public Mono<Void> deleteChannelPermission(long channelId, long overwriteId, @Nullable String reason) {
         return Routes.CHANNEL_PERMISSION_DELETE.newRequest(channelId, overwriteId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> triggerTypingIndicator(long channelId) {
         return Routes.TYPING_INDICATOR_TRIGGER.newRequest(channelId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<MessageResponse> getPinnedMessages(long channelId) {
         return Routes.MESSAGES_PINNED_GET.newRequest(channelId)
                 .exchange(getRouter())
+                .bodyToMono(MessageResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<Void> addPinnedMessage(long channelId, long messageId) {
         return Routes.MESSAGES_PINNED_ADD.newRequest(channelId, messageId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> deletePinnedMessage(long channelId, long messageId) {
         return Routes.MESSAGES_PINNED_DELETE.newRequest(channelId, messageId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> addGroupDMRecipient(long channelId, long userId, GroupAddRecipientRequest request) {
         return Routes.GROUP_DM_RECIPIENT_ADD.newRequest(channelId, userId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> deleteGroupDMRecipient(long channelId, long userId) {
         return Routes.GROUP_DM_RECIPIENT_DELETE.newRequest(channelId, userId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/EmojiService.java
+++ b/rest/src/main/java/discord4j/rest/service/EmojiService.java
@@ -34,31 +34,36 @@ public class EmojiService extends RestService {
     public Flux<GuildEmojiResponse> getGuildEmojis(long guildId) {
         return Routes.GUILD_EMOJIS_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(GuildEmojiResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<GuildEmojiResponse> getGuildEmoji(long guildId, long emojiID) {
         return Routes.GUILD_EMOJI_GET.newRequest(guildId, emojiID)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildEmojiResponse.class);
     }
 
     public Mono<GuildEmojiResponse> createGuildEmoji(long guildId, GuildEmojiCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_EMOJI_CREATE.newRequest(guildId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildEmojiResponse.class);
     }
 
     public Mono<GuildEmojiResponse> modifyGuildEmoji(long guildId, long emojiId, GuildEmojiModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_EMOJI_MODIFY.newRequest(guildId, emojiId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildEmojiResponse.class);
     }
 
     public Mono<Void> deleteGuildEmoji(long guildId, long emojiId, @Nullable String reason) {
         return Routes.GUILD_EMOJI_DELETE.newRequest(guildId, emojiId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/GatewayService.java
+++ b/rest/src/main/java/discord4j/rest/service/GatewayService.java
@@ -29,12 +29,14 @@ public class GatewayService extends RestService {
 
     public Mono<GatewayResponse> getGateway() {
         return Routes.GATEWAY_GET.newRequest()
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GatewayResponse.class);
     }
 
     public Mono<GatewayResponse> getGatewayBot() {
         return Routes.GATEWAY_BOT_GET.newRequest()
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GatewayResponse.class);
     }
 
 }

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -37,29 +37,34 @@ public class GuildService extends RestService {
     public Mono<GuildResponse> createGuild(GuildCreateRequest request) {
         return Routes.GUILD_CREATE.newRequest()
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildResponse.class);
     }
 
     public Mono<GuildResponse> getGuild(long guildId) {
         return Routes.GUILD_GET.newRequest(guildId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildResponse.class);
     }
 
     public Mono<GuildResponse> modifyGuild(long guildId, GuildModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_MODIFY.newRequest(guildId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildResponse.class);
     }
 
     public Mono<Void> deleteGuild(long guildId) {
         return Routes.GUILD_DELETE.newRequest(guildId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<ChannelResponse> getGuildChannels(long guildId) {
         return Routes.GUILD_CHANNELS_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(ChannelResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
@@ -67,92 +72,107 @@ public class GuildService extends RestService {
         return Routes.GUILD_CHANNEL_CREATE.newRequest(guildId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ChannelResponse.class);
     }
 
     public Flux<RoleResponse> modifyGuildChannelPositions(long guildId, PositionModifyRequest[] request) {
         return Routes.GUILD_CHANNEL_POSITIONS_MODIFY.newRequest(guildId)
                 .body(request)
                 .exchange(getRouter())
+                .bodyToMono(RoleResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<GuildMemberResponse> getGuildMember(long guildId, long userId) {
         return Routes.GUILD_MEMBER_GET.newRequest(guildId, userId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildMemberResponse.class);
     }
 
     public Flux<GuildMemberResponse> getGuildMembers(long guildId, Map<String, Object> queryParams) {
         return Routes.GUILD_MEMBERS_LIST.newRequest(guildId)
                 .query(queryParams)
                 .exchange(getRouter())
+                .bodyToMono(GuildMemberResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<GuildMemberResponse> addGuildMember(long guildId, long userId, GuildMemberAddRequest request) {
         return Routes.GUILD_MEMBER_ADD.newRequest(guildId, userId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildMemberResponse.class);
     }
 
     public Mono<Void> modifyGuildMember(long guildId, long userId, GuildMemberModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_MEMBER_MODIFY.newRequest(guildId, userId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<NicknameModifyResponse> modifyOwnNickname(long guildId, NicknameModifyRequest request) {
         return Routes.NICKNAME_MODIFY_OWN.newRequest(guildId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(NicknameModifyResponse.class);
     }
 
     public Mono<Void> addGuildMemberRole(long guildId, long userId, long roleId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_ROLE_ADD.newRequest(guildId, userId, roleId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> removeGuildMemberRole(long guildId, long userId, long roleId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_ROLE_REMOVE.newRequest(guildId, userId, roleId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> removeGuildMember(long guildId, long userId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_REMOVE.newRequest(guildId, userId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<BanResponse> getGuildBans(long guildId) {
         return Routes.GUILD_BANS_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(BanResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<BanResponse> getGuildBan(long guildId, long userId) {
         return Routes.GUILD_BAN_GET.newRequest(guildId, userId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(BanResponse.class);
     }
 
     public Mono<Void> createGuildBan(long guildId, long userId, Map<String, Object> queryParams, @Nullable String reason) {
         return Routes.GUILD_BAN_CREATE.newRequest(guildId, userId)
                 .query(queryParams)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> removeGuildBan(long guildId, long userId, @Nullable String reason) {
         return Routes.GUILD_BAN_REMOVE.newRequest(guildId, userId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<RoleResponse> getGuildRoles(long guildId) {
         return Routes.GUILD_ROLES_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(RoleResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
@@ -160,13 +180,15 @@ public class GuildService extends RestService {
         return Routes.GUILD_ROLE_CREATE.newRequest(guildId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(RoleResponse.class);
     }
 
     public Flux<RoleResponse> modifyGuildRolePositions(long guildId, PositionModifyRequest[] request) {
         return Routes.GUILD_ROLE_POSITIONS_MODIFY.newRequest(guildId)
                 .body(request)
                 .exchange(getRouter())
+                .bodyToMono(RoleResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
@@ -174,76 +196,89 @@ public class GuildService extends RestService {
         return Routes.GUILD_ROLE_MODIFY.newRequest(guildId, roleId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(RoleResponse.class);
     }
 
     public Mono<Void> deleteGuildRole(long guildId, long roleId, @Nullable String reason) {
         return Routes.GUILD_ROLE_DELETE.newRequest(guildId, roleId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<PruneResponse> getGuildPruneCount(long guildId, Map<String, Object> queryParams) {
         return Routes.GUILD_PRUNE_COUNT_GET.newRequest(guildId)
                 .query(queryParams)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(PruneResponse.class);
     }
 
     public Mono<PruneResponse> beginGuildPrune(long guildId, Map<String, Object> queryParams, @Nullable String reason) {
         return Routes.GUILD_PRUNE_BEGIN.newRequest(guildId)
                 .query(queryParams)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(PruneResponse.class);
     }
 
     public Flux<VoiceRegionResponse> getGuildVoiceRegions(long guildId) {
         return Routes.GUILD_VOICE_REGIONS_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(VoiceRegionResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Flux<InviteResponse> getGuildInvites(long guildId) {
         return Routes.GUILD_INVITES_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(InviteResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Flux<IntegrationResponse> getGuildIntegrations(long guildId) {
         return Routes.GUILD_INTEGRATIONS_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(IntegrationResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<Void> createGuildIntegration(long guildId, IntegrationCreateRequest request) {
         return Routes.GUILD_INTEGRATION_CREATE.newRequest(guildId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> modifyGuildIntegration(long guildId, long integrationId, IntegrationModifyRequest request) {
         return Routes.GUILD_INTEGRATION_MODIFY.newRequest(guildId, integrationId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> deleteGuildIntegration(long guildId, long integrationId) {
         return Routes.GUILD_INTEGRATION_DELETE.newRequest(guildId, integrationId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<Void> syncGuildIntegration(long guildId, long integrationId) {
         return Routes.GUILD_INTEGRATION_SYNC.newRequest(guildId, integrationId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Mono<GuildEmbedResponse> getGuildEmbed(long guildId) {
         return Routes.GUILD_EMBED_GET.newRequest(guildId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildEmbedResponse.class);
     }
 
     public Mono<GuildEmbedResponse> modifyGuildEmbed(long guildId, GuildEmbedModifyRequest request) {
         return Routes.GUILD_EMBED_MODIFY.newRequest(guildId)
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(GuildEmbedResponse.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/InviteService.java
+++ b/rest/src/main/java/discord4j/rest/service/InviteService.java
@@ -30,12 +30,14 @@ public class InviteService extends RestService {
 
     public Mono<InviteResponse> getInvite(String inviteCode) {
         return Routes.INVITE_GET.newRequest(inviteCode)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(InviteResponse.class);
     }
 
     public Mono<InviteResponse> deleteInvite(String inviteCode, @Nullable String reason) {
         return Routes.INVITE_DELETE.newRequest(inviteCode)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(InviteResponse.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/UserService.java
+++ b/rest/src/main/java/discord4j/rest/service/UserService.java
@@ -38,53 +38,62 @@ public class UserService extends RestService {
 
     public Mono<UserResponse> getCurrentUser() {
         return Routes.CURRENT_USER_GET.newRequest()
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(UserResponse.class);
     }
 
     public Mono<UserResponse> getUser(long userId) {
         return Routes.USER_GET.newRequest(userId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(UserResponse.class);
     }
 
     public Mono<UserResponse> modifyCurrentUser(UserModifyRequest request) {
         return Routes.CURRENT_USER_MODIFY.newRequest()
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(UserResponse.class);
     }
 
     public Flux<UserGuildResponse> getCurrentUserGuilds(Map<String, Object> queryParams) {
         return Routes.CURRENT_USER_GUILDS_GET.newRequest()
                 .query(queryParams)
                 .exchange(getRouter())
+                .bodyToMono(UserGuildResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<Void> leaveGuild(long guildId) {
         return Routes.GUILD_LEAVE.newRequest(guildId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 
     public Flux<ChannelResponse> getUserDMs() {
         return Routes.USER_DMS_GET.newRequest()
                 .exchange(getRouter())
+                .bodyToMono(ChannelResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<ChannelResponse> createDM(DMCreateRequest request) {
         return Routes.USER_DM_CREATE.newRequest()
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ChannelResponse.class);
     }
 
     public Mono<ChannelResponse> createGroupDM(GroupDMCreateRequest request) {
         return Routes.GROUP_DM_CREATE.newRequest()
                 .body(request)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(ChannelResponse.class);
     }
 
     public Flux<ConnectionResponse> getUserConnections() {
         return Routes.USER_CONNECTIONS_GET.newRequest()
                 .exchange(getRouter())
+                .bodyToMono(ConnectionResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/VoiceService.java
+++ b/rest/src/main/java/discord4j/rest/service/VoiceService.java
@@ -30,6 +30,7 @@ public class VoiceService extends RestService {
     public Flux<VoiceRegionResponse> getVoiceRegions() {
         return Routes.VOICE_REGION_LIST.newRequest()
                 .exchange(getRouter())
+                .bodyToMono(VoiceRegionResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/WebhookService.java
+++ b/rest/src/main/java/discord4j/rest/service/WebhookService.java
@@ -35,36 +35,42 @@ public class WebhookService extends RestService {
         return Routes.CHANNEL_WEBHOOK_CREATE.newRequest(channelId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(WebhookResponse.class);
     }
 
     public Flux<WebhookResponse> getChannelWebhooks(long channelId) {
         return Routes.CHANNEL_WEBHOOKS_GET.newRequest(channelId)
                 .exchange(getRouter())
+                .bodyToMono(WebhookResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Flux<WebhookResponse> getGuildWebhooks(long guildId) {
         return Routes.GUILD_WEBHOOKS_GET.newRequest(guildId)
                 .exchange(getRouter())
+                .bodyToMono(WebhookResponse[].class)
                 .flatMapMany(Flux::fromArray);
     }
 
     public Mono<WebhookResponse> getWebhook(long webhookId) {
         return Routes.WEBHOOK_GET.newRequest(webhookId)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(WebhookResponse.class);
     }
 
     public Mono<WebhookResponse> modifyWebhook(long webhookId, WebhookModifyRequest request, @Nullable String reason) {
         return Routes.WEBHOOK_MODIFY.newRequest(webhookId)
                 .body(request)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(WebhookResponse.class);
     }
 
     public Mono<Void> deleteWebhook(long webhookId, @Nullable String reason) {
         return Routes.WEBHOOK_DELETE.newRequest(webhookId)
                 .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter());
+                .exchange(getRouter())
+                .bodyToMono(Void.class);
     }
 }

--- a/rest/src/test/java/discord4j/rest/http/RouterTest.java
+++ b/rest/src/test/java/discord4j/rest/http/RouterTest.java
@@ -56,8 +56,8 @@ public class RouterTest {
         Routes.MESSAGE_CREATE.newRequest(channelId)
                 .body(body)
                 .exchange(router)
+                .mono()
                 .subscribe(response -> System.out.println("complete response"));
-
 
         TimeUnit.SECONDS.sleep(1);
     }
@@ -80,6 +80,7 @@ public class RouterTest {
             Routes.MESSAGE_CREATE.newRequest(channelId)
                     .body(body)
                     .exchange(router)
+                    .bodyToMono(MessageResponse.class)
                     .subscribe(response -> System.out.println("response " + a + ": " + response.getContent()));
         }
 
@@ -98,7 +99,8 @@ public class RouterTest {
 
         Mono<MessageResponse> mono = Routes.MESSAGE_CREATE.newRequest(channelId)
                 .body(body)
-                .exchange(router);
+                .exchange(router)
+                .bodyToMono(MessageResponse.class);
 
         mono.subscribe();
         mono.subscribe();
@@ -125,6 +127,7 @@ public class RouterTest {
             Routes.MESSAGE_CREATE.newRequest(channelId)
                     .body(body)
                     .exchange(router)
+                    .bodyToMono(MessageResponse.class)
                     .publishOn(thread)
                     .cancelOn(thread)
                     .subscribeOn(thread)
@@ -149,6 +152,7 @@ public class RouterTest {
         Routes.MESSAGE_CREATE.newRequest(channelId)
                 .body(body0)
                 .exchange(router)
+                .mono()
                 .block();
 
         MessageCreateRequest body1 = new MessageCreateRequest(cid + " 1 at" + Instant.now(), null, false, null);
@@ -156,6 +160,7 @@ public class RouterTest {
         Routes.MESSAGE_CREATE.newRequest(channelId)
                 .body(body1)
                 .exchange(router)
+                .mono()
                 .block();
     }
 }

--- a/rest/src/test/java/discord4j/rest/http/WebClientTest.java
+++ b/rest/src/test/java/discord4j/rest/http/WebClientTest.java
@@ -18,9 +18,10 @@
 package discord4j.rest.http;
 
 import discord4j.common.JacksonResources;
+import discord4j.common.LogUtil;
 import discord4j.rest.http.client.DiscordWebClient;
 import discord4j.rest.request.DefaultRouter;
-import discord4j.rest.request.DiscordRequest;
+import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.request.Router;
 import discord4j.rest.route.Route;
 import org.junit.AfterClass;
@@ -78,10 +79,12 @@ public class WebClientTest {
         ExchangeStrategies ex2 = ExchangeStrategies.jackson(new JacksonResources().getObjectMapper());
         DiscordWebClient webClient = new DiscordWebClient(HttpClient.create(),
                 ex2, null); // no token, it's not a discord request
-        Route<String> fakeRoute = Route.get("http://0.0.0.0:" + PORT + "/html", String.class);
+        Route fakeRoute = Route.get("http://0.0.0.0:" + PORT + "/html");
         Router router = new DefaultRouter(webClient);
-        String response = router.exchange(new DiscordRequest<>(fakeRoute))
+        String response = router.exchange(new DiscordWebRequest(fakeRoute))
+                .bodyToMono(String.class)
                 .log()
+                .subscriberContext(ctx -> ctx.put(LogUtil.KEY_SHARD_ID, 123))
                 .block();
         log.info("{}", response);
     }


### PR DESCRIPTION
### Motivation
This is the first part of preparing the [rest] module to process responses without relying on `*Response` pojos.

We will manually convert a JSON tree into one of the new immutable `*Data` containers and to achieve this without using the current `Route<T>` API (which would mean using a Jackson type in almost every route), we need to refactor how our response reading process works.

### Description
This PR covers the following:
- Make `Route` non-generic
- Update API affected by the above (`DiscordRequest`, `RequestStream`, etc)
- Make `Router` return a handler to consume the body downstream
- `ReaderStrategy` API update to read from `Mono<ByteBuf>`
- Introduce `ClientResponse` to encapsulate responses

This PR also changes the signature of classes like `DiscordWebClient` which is essential to also build a reactive, network-based, distributed `Router` implementation.
