### PR TITLE
Add new message flags

### DIFF
--- a/common/src/main/java/discord4j/common/json/GuildMemberResponse.java
+++ b/common/src/main/java/discord4j/common/json/GuildMemberResponse.java
@@ -31,6 +31,7 @@ public class GuildMemberResponse {
     private long[] roles;
     @JsonProperty("joined_at")
     private String joinedAt;
+    @Nullable
     @JsonProperty("premium_since")
     private String premiumSince;
     private boolean deaf;

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -490,7 +490,13 @@ public final class Message implements Entity {
         IS_CROSSPOST(1),
 
         /** Do not include any embeds when serializing this message. */
-        SUPPRESS_EMBEDS(2);
+        SUPPRESS_EMBEDS(2),
+
+        /** The source message for this crosspost has been deleted (via Channel Following). */
+        SOURCE_MESSAGE_DELETED(3),
+
+        /** This message came from the urgent message system. */
+        URGENT(4);
 
         /** The underlying value as represented by Discord. */
         private final int value;

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/MessageReactionAdd.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/MessageReactionAdd.java
@@ -64,7 +64,7 @@ public class MessageReactionAdd implements Dispatch {
 
     @Nullable
     public GuildMemberResponse getMember() {
-        return this.member;
+        return member;
     }
 
     @Override


### PR DESCRIPTION
**Description:** Add new message flags and add a missing @Nullable annotation. 
I didn't add the new `system?` User field because I don't really know how to deal with User fields. Some require OAuth and some not as discussed here: https://github.com/Discord4J/Discord4J/pull/560 and I don't know if this new field is also an Oauth field or not.

**Justification:** https://github.com/discordapp/discord-api-docs/commit/caca88a333010f13cdc5f695f93bc9974c32a77b