### PR TITLE
Add member and guild id to starting type event

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/TypingStartEvent.java
@@ -17,12 +17,16 @@
 package discord4j.core.event.domain.channel;
 
 import discord4j.core.DiscordClient;
+import discord4j.core.object.entity.Guild;
+import discord4j.core.object.entity.Member;
 import discord4j.core.object.entity.MessageChannel;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Dispatched when a user starts typing in a message channel.
@@ -34,23 +38,39 @@ import java.time.Instant;
 public class TypingStartEvent extends ChannelEvent {
 
     private final long channelId;
+    @Nullable
+    private final Long guildId;
     private final long userId;
     private final Instant startTime;
+    @Nullable
+    private final Member member;
 
-    public TypingStartEvent(DiscordClient client, long channelId, long userId, Instant startTime) {
+    public TypingStartEvent(DiscordClient client, long channelId, @Nullable Long guildId, long userId,
+                            Instant startTime, @Nullable Member member) {
         super(client);
         this.channelId = channelId;
+        this.guildId = guildId;
         this.userId = userId;
         this.startTime = startTime;
+        this.member = member;
     }
 
     /**
      * Gets the {@link Snowflake} ID of the {@link MessageChannel} the user has started typing in.
      *
-     * @return the ID of the {@link MessageChannel} the {@link User} is typing in.
+     * @return The ID of the {@link MessageChannel} the {@link User} is typing in.
      */
     public Snowflake getChannelId() {
         return Snowflake.of(channelId);
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Guild} the user has started typing in, if this happened in a guild.
+     *
+     * @return The {@link Snowflake} ID of the {@link Guild} the user has started typing in, if this happened in a guild.
+     */
+    public Optional<Snowflake> getGuildId() {
+       return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
@@ -91,12 +111,23 @@ public class TypingStartEvent extends ChannelEvent {
         return startTime;
     }
 
+    /**
+     * Gets the {@link Member} who started typing, if this happened in a guild.
+     *
+     * @return The {@link Member} who started typing, if this happened in a guild.
+     */
+    public Optional<Member> getMember() {
+        return Optional.ofNullable(member);
+    }
+
     @Override
     public String toString() {
         return "TypingStartEvent{" +
                 "channelId=" + channelId +
+                ", guildId=" + guildId +
                 ", userId=" + userId +
                 ", startTime=" + startTime +
+                ", member=" + member +
                 '}';
     }
 }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/TypingStart.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/TypingStart.java
@@ -18,6 +18,7 @@ package discord4j.gateway.json.dispatch;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
+import discord4j.common.json.GuildMemberResponse;
 import reactor.util.annotation.Nullable;
 
 public class TypingStart implements Dispatch {
@@ -33,6 +34,8 @@ public class TypingStart implements Dispatch {
     @UnsignedJson
     private long userId;
     private int timestamp;
+    @Nullable
+    private GuildMemberResponse member;
 
     public long getChannelId() {
         return channelId;
@@ -51,6 +54,11 @@ public class TypingStart implements Dispatch {
         return timestamp;
     }
 
+    @Nullable
+    public GuildMemberResponse getMember() {
+        return member;
+    }
+
     @Override
     public String toString() {
         return "TypingStart{" +
@@ -58,6 +66,7 @@ public class TypingStart implements Dispatch {
                 ", guildId=" + guildId +
                 ", userId=" + userId +
                 ", timestamp=" + timestamp +
+                ", member=" + member +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:** Add member and guild id to starting type event

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1220

**Reference:** https://github.com/Discord4J/Discord4J/issues/596