### PR TITLE
Add premium_since and nick fields to presence update event

### DIFF
--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/PresenceUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/PresenceUpdate.java
@@ -46,6 +46,12 @@ public class PresenceUpdate implements Dispatch {
     private ActivityResponse[] activities;
     @JsonProperty("client_status")
     private ClientStatus clientStatus;
+    @Nullable
+    @JsonProperty("premium_since")
+    private String premiumSince;
+    @Nullable
+    @JsonProperty("nick")
+    private String nick;
 
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<>();
@@ -78,6 +84,16 @@ public class PresenceUpdate implements Dispatch {
 
     public ClientStatus getClientStatus() {
         return clientStatus;
+    }
+
+    @Nullable
+    public String getPremiumSince() {
+        return premiumSince;
+    }
+
+    @Nullable
+    public String getNick() {
+        return nick;
     }
 
     @JsonAnyGetter


### PR DESCRIPTION
**Description:** Add premium_since and nick fields to presence update event. I didn't add corresponding methods in PresenceUpdate because I don't know how to do this. In fact, a lot of fields from the PresenceUpdate class are just ignored and not accessible.

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1222

**Reference:** #596