### PR TITLE
Update activity fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/data/stored/ActivityBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/ActivityBean.java
@@ -29,6 +29,7 @@ public class ActivityBean implements Serializable {
     private int type;
     @Nullable
     private String url;
+    private long createdAt;
     @Nullable
     private Long start;
     @Nullable
@@ -70,6 +71,7 @@ public class ActivityBean implements Serializable {
         this.name = response.getName();
         this.type = response.getType();
         this.url = Possible.orElseNull(response.getUrl());
+        this.createdAt = response.getCreatedAt();
 
         ActivityResponse.Timestamps timestamps = Possible.orElseNull(response.getTimestamps());
         if (timestamps == null) {
@@ -159,6 +161,14 @@ public class ActivityBean implements Serializable {
 
     public void setUrl(@Nullable String url) {
         this.url = url;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(long createdAt) {
+        this.createdAt = createdAt;
     }
 
     @Nullable
@@ -331,6 +341,7 @@ public class ActivityBean implements Serializable {
             "name='" + name + '\'' +
             ", type=" + type +
             ", url='" + url + '\'' +
+            ", createdAt=" + createdAt +
             ", start=" + start +
             ", end=" + end +
             ", applicationId=" + applicationId +

--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -88,6 +88,15 @@ public class Activity {
     }
 
     /**
+     * Gets the UNIX time of when the activity was added to the user's session.
+     *
+     * @return The UNIX time of when the activity was added to the user's session.
+     */
+    public Instant getCreatedAt() {
+        return Instant.ofEpochMilli(data.getCreatedAt());
+    }
+
+    /**
      * Gets the UNIX time (in milliseconds) of when the activity started, if present.
      *
      * @return The UNIX time (in milliseconds) of when the activity started, if present.

--- a/gateway/src/main/java/discord4j/gateway/json/response/ActivityResponse.java
+++ b/gateway/src/main/java/discord4j/gateway/json/response/ActivityResponse.java
@@ -36,6 +36,8 @@ public class ActivityResponse {
     private int type;
     @Nullable
     private Possible<String> url = Possible.absent();
+    @JsonProperty("created_at")
+    private long createdAt;
     private Possible<Timestamps> timestamps = Possible.absent();
     @JsonProperty("application_id")
     @UnsignedJson
@@ -66,6 +68,10 @@ public class ActivityResponse {
     @Nullable
     public Possible<String> getUrl() {
         return url;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
     }
 
     public Possible<Timestamps> getTimestamps() {
@@ -127,6 +133,7 @@ public class ActivityResponse {
             "name='" + name + '\'' +
             ", type=" + type +
             ", url=" + url +
+            ", createdAt=" + createdAt +
             ", timestamps=" + timestamps +
             ", applicationId=" + applicationId +
             ", details=" + details +


### PR DESCRIPTION
This pull request is currently a draft because the `created_at` field is not optional in a response as explained in the documentation. However, this field is not required to be sent when updating bot's presence leading to, for example, `Activity.LISTENING.getCreatedAt()` being null and I don't know how to solve this.

**Description:** 
- Adds support for `created_at` to get the UNIX time of when the activity was added to the user's session.

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1208

**Reference:** https://github.com/Discord4J/Discord4J/issues/596