### PR TITLE
Add premium_since field to Member Update Event

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -338,6 +338,7 @@ class GuildDispatchHandlers {
 
         long[] currentRoles = context.getDispatch().getRoles();
         String currentNick = context.getDispatch().getNick();
+        String currentPremiumSince = context.getDispatch().getPremiumSince();
 
         LongLongTuple2 key = LongLongTuple2.of(guildId, memberId);
 
@@ -352,10 +353,11 @@ class GuildDispatchHandlers {
                     return serviceMediator.getStateHolder().getMemberStore()
                             .save(key, newBean)
                             .thenReturn(new MemberUpdateEvent(client, guildId, memberId, old, currentRoles,
-                                    currentNick));
+                                    currentNick, currentPremiumSince));
                 });
 
-        return update.defaultIfEmpty(new MemberUpdateEvent(client, guildId, memberId, null, currentRoles, currentNick));
+        return update.defaultIfEmpty(new MemberUpdateEvent(client, guildId, memberId, null, currentRoles,
+            currentNick, currentPremiumSince));
     }
 
     static Mono<RoleCreateEvent> guildRoleCreate(DispatchContext<GuildRoleCreate> context) {

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -132,9 +132,9 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Gets when the user used their Nitro boost on the server, if present.
+     * Gets when the user used their Nitro boost on the guild, if present.
      *
-     * @return When the user used their Nitro boost on the server, if present.
+     * @return When the user used their Nitro boost on the guild, if present.
      */
     public Optional<Instant> getCurrentPremiumSince() {
         return Optional.ofNullable(currentPremiumSince)

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -23,6 +23,8 @@ import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
@@ -46,9 +48,11 @@ public class MemberUpdateEvent extends GuildEvent {
     private final long[] currentRoles;
     @Nullable
     private final String currentNickname;
+    @Nullable
+    private final String currentPremiumSince;
 
     public MemberUpdateEvent(DiscordClient client, long guildId, long memberId, @Nullable Member old,
-                             long[] currentRoles, @Nullable String currentNickname) {
+                             long[] currentRoles, @Nullable String currentNickname, @Nullable String currentPremiumSince) {
         super(client);
 
         this.guildId = guildId;
@@ -56,6 +60,7 @@ public class MemberUpdateEvent extends GuildEvent {
         this.old = old;
         this.currentRoles = currentRoles;
         this.currentNickname = currentNickname;
+        this.currentPremiumSince = currentPremiumSince;
     }
 
     /**
@@ -126,6 +131,16 @@ public class MemberUpdateEvent extends GuildEvent {
         return Optional.ofNullable(currentNickname);
     }
 
+    /**
+     * Gets when the user used their Nitro boost on the server, if present.
+     *
+     * @return When the user used their Nitro boost on the server, if present.
+     */
+    public Optional<Instant> getCurrentPremiumSince() {
+        return Optional.ofNullable(currentPremiumSince)
+            .map(timestamp -> DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(timestamp, Instant::from));
+    }
+
     @Override
     public String toString() {
         return "MemberUpdateEvent{" +
@@ -134,6 +149,7 @@ public class MemberUpdateEvent extends GuildEvent {
                 ", old=" + old +
                 ", currentRoles=" + Arrays.toString(currentRoles) +
                 ", currentNickname='" + currentNickname + '\'' +
+                ", currentPremiumSince='" + currentPremiumSince + '\'' +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/data/stored/MemberBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/MemberBean.java
@@ -56,7 +56,7 @@ public final class MemberBean implements Serializable {
         nick = update.getNick();
         roles = update.getRoles();
         joinedAt = toCopy.getJoinedAt();
-        premiumSince = toCopy.getPremiumSince();
+        premiumSince = update.getPremiumSince();
     }
 
     public MemberBean(final MemberBean toCopy) {

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildMemberUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildMemberUpdate.java
@@ -19,6 +19,7 @@ package discord4j.gateway.json.dispatch;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
 import discord4j.common.json.UserResponse;
+import reactor.util.annotation.Nullable;
 
 import java.util.Arrays;
 
@@ -31,6 +32,9 @@ public class GuildMemberUpdate implements Dispatch {
     private long[] roles;
     private UserResponse user;
     private String nick;
+    @Nullable
+    @JsonProperty("premium_since")
+    private String premiumSince;
 
     public long getGuildId() {
         return guildId;
@@ -48,6 +52,11 @@ public class GuildMemberUpdate implements Dispatch {
         return nick;
     }
 
+    @Nullable
+    public String getPremiumSince() {
+        return premiumSince;
+    }
+
     @Override
     public String toString() {
         return "GuildMemberUpdate{" +
@@ -55,6 +64,7 @@ public class GuildMemberUpdate implements Dispatch {
                 ", roles=" + Arrays.toString(roles) +
                 ", user=" + user +
                 ", nick='" + nick + '\'' +
+                ", premiumSince='" + premiumSince + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:** Add `premium_since` field to Member Update Event

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1261

**Reference:** https://github.com/Discord4J/Discord4J/issues/596