### PR TITLE
Update invite fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/ExtendedInvite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedInvite.java
@@ -45,25 +45,6 @@ public final class ExtendedInvite extends Invite {
     }
 
     /**
-     * Gets the ID of the user who created the invite.
-     *
-     * @return The ID of the user who created the invite.
-     */
-    public Snowflake getInviterId() {
-        return Snowflake.of(getData().getInviterId());
-    }
-
-    /**
-     * Requests to retrieve the user who created the invite.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User user} who created the invite. If
-     * an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<User> getInviter() {
-        return getClient().getUserById(getInviterId());
-    }
-
-    /**
      * Gets the number of times this invite has been used.
      *
      * @return The number of times this invite has been used.

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -145,6 +145,15 @@ public class Invite implements DiscordObject {
     }
 
     /**
+     * Gets the type of target user for this invite, if present.
+     *
+     * @return The type of target user for this invite, if present.
+     */
+    public final Optional<Type> getTargetUserType() {
+        return Optional.ofNullable(data.getTargetUserType()).map(Type::of);
+    }
+
+    /**
      * Gets an approximate count of online members (only present when the target user is set) of the guild this invite
      * is associated to, if present.
      *
@@ -198,6 +207,52 @@ public class Invite implements DiscordObject {
      */
     InviteBean getData() {
         return data;
+    }
+
+    /** Represents the various types of target user for an invite. */
+    public enum Type {
+
+        /** Unknown type */
+        UNKNOWN(-1),
+
+        /** Stream */
+        STREAM(1);
+
+        /** The underlying value as represented by Discord. */
+        private final int value;
+
+        /**
+         * Constructs a {@code Invite.Type}.
+         *
+         * @param value The underlying value as represented by Discord.
+         */
+        Type(final int value) {
+            this.value = value;
+        }
+
+        /**
+         * Gets the underlying value as represented by Discord.
+         *
+         * @return The underlying value as represented by Discord.
+         */
+        public int getValue() {
+            return value;
+        }
+
+        /**
+         * Gets the type of target user. It is guaranteed that invoking {@link #getValue()} from the returned enum
+         * will be equal ({@code ==}) to the supplied {@code value}.
+         *
+         * @param value The underlying value as represented by Discord.
+         * @return The type of target user.
+         */
+        public static Type of(final int value) {
+            switch (value) {
+                case 1: return STREAM;
+                default: return UNKNOWN;
+            }
+        }
+
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -106,6 +106,25 @@ public class Invite implements DiscordObject {
     }
 
     /**
+     * Gets the ID of the user who created the invite, if present.
+     *
+     * @return The ID of the user who created the invite, if present.
+     */
+    public final Optional<Snowflake> getInviterId() {
+        return Optional.ofNullable(getData().getInviterId()).map(Snowflake::of);
+    }
+
+    /**
+     * Requests to retrieve the user who created the invite.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User user} who created the invite. If
+     * an error is received, it is emitted through the {@code Mono}.
+     */
+    public final Mono<User> getInviter() {
+        return getInviterId().map(getClient()::getUserById).orElse(Mono.empty());
+    }
+
+    /**
      * Gets the ID of the target user this invite is associated to, if present.
      *
      * @return The ID of the target user this invite is associated to, if present.

--- a/core/src/main/java/discord4j/core/object/data/ExtendedInviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/ExtendedInviteBean.java
@@ -24,7 +24,6 @@ public final class ExtendedInviteBean extends InviteBean {
 
     private static final long serialVersionUID = -3024688485065214682L;
 
-    private long inviterId;
     private int uses;
     private int maxUses;
     private int maxAge;
@@ -33,7 +32,6 @@ public final class ExtendedInviteBean extends InviteBean {
 
     public ExtendedInviteBean(final InviteResponse response) {
         super(response);
-        inviterId = Objects.requireNonNull(response.getInviter()).getId();
         uses = Objects.requireNonNull(response.getUses());
         maxUses = Objects.requireNonNull(response.getMaxUses());
         maxAge = Objects.requireNonNull(response.getMaxAge());
@@ -42,14 +40,6 @@ public final class ExtendedInviteBean extends InviteBean {
     }
 
     public ExtendedInviteBean() {}
-
-    public long getInviterId() {
-        return inviterId;
-    }
-
-    public void setInviterId(final long inviterId) {
-        this.inviterId = inviterId;
-    }
 
     public int getUses() {
         return uses;
@@ -94,8 +84,7 @@ public final class ExtendedInviteBean extends InviteBean {
     @Override
     public String toString() {
         return "ExtendedInviteBean{" +
-                "inviterId=" + inviterId +
-                ", uses=" + uses +
+                "uses=" + uses +
                 ", maxUses=" + maxUses +
                 ", maxAge=" + maxAge +
                 ", temporary=" + temporary +

--- a/core/src/main/java/discord4j/core/object/data/InviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/InviteBean.java
@@ -33,6 +33,8 @@ public class InviteBean implements Serializable {
     @Nullable
     private Long targetUserId;
     @Nullable
+    private Integer targetUserType;
+    @Nullable
     private Integer approximatePresenceCount;
     @Nullable
     private Integer approximateMemberCount;
@@ -43,6 +45,7 @@ public class InviteBean implements Serializable {
         channelId = response.getChannel().getId();
         inviterId = response.getInviter() == null ? null : response.getInviter().getId();
         targetUserId = response.getTargetUser() == null ? null : response.getTargetUser().getId();
+        targetUserType = response.getTargetUserType();
         approximatePresenceCount = response.getApproximatePresenceCount();
         approximateMemberCount = response.getApproximateMemberCount();
     }
@@ -92,6 +95,15 @@ public class InviteBean implements Serializable {
     }
 
     @Nullable
+    public Integer getTargetUserType() {
+        return targetUserType;
+    }
+
+    public void setTargetUserType(@Nullable Integer targetUserType) {
+        this.targetUserType = targetUserType;
+    }
+
+    @Nullable
     public final Integer getApproximatePresenceCount() {
         return approximatePresenceCount;
     }
@@ -117,6 +129,7 @@ public class InviteBean implements Serializable {
                 ", channelId=" + channelId +
                 ", inviterId=" + inviterId +
                 ", targetUserId=" + targetUserId +
+                ", targetUserType=" + targetUserType +
                 ", approximatePresenceCount=" + approximatePresenceCount +
                 ", approximateMemberCount=" + approximateMemberCount +
                 '}';

--- a/core/src/main/java/discord4j/core/object/data/InviteBean.java
+++ b/core/src/main/java/discord4j/core/object/data/InviteBean.java
@@ -29,6 +29,8 @@ public class InviteBean implements Serializable {
     private long guildId;
     private long channelId;
     @Nullable
+    private Long inviterId;
+    @Nullable
     private Long targetUserId;
     @Nullable
     private Integer approximatePresenceCount;
@@ -39,6 +41,7 @@ public class InviteBean implements Serializable {
         code = response.getCode();
         guildId = response.getGuild().getId();
         channelId = response.getChannel().getId();
+        inviterId = response.getInviter() == null ? null : response.getInviter().getId();
         targetUserId = response.getTargetUser() == null ? null : response.getTargetUser().getId();
         approximatePresenceCount = response.getApproximatePresenceCount();
         approximateMemberCount = response.getApproximateMemberCount();
@@ -68,6 +71,15 @@ public class InviteBean implements Serializable {
 
     public final void setChannelId(final long channelId) {
         this.channelId = channelId;
+    }
+
+    @Nullable
+    public Long getInviterId() {
+        return inviterId;
+    }
+
+    public void setInviterId(@Nullable Long inviterId) {
+        this.inviterId = inviterId;
     }
 
     @Nullable
@@ -103,6 +115,7 @@ public class InviteBean implements Serializable {
                 "code='" + code + '\'' +
                 ", guildId=" + guildId +
                 ", channelId=" + channelId +
+                ", inviterId=" + inviterId +
                 ", targetUserId=" + targetUserId +
                 ", approximatePresenceCount=" + approximatePresenceCount +
                 ", approximateMemberCount=" + approximateMemberCount +

--- a/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
@@ -25,6 +25,8 @@ public class InviteResponse {
     private String code;
     private GuildResponse guild;
     private ChannelResponse channel;
+    @Nullable
+    private UserResponse inviter;
     @JsonProperty("target_user")
     @Nullable
     private UserResponse targetUser;
@@ -34,8 +36,6 @@ public class InviteResponse {
     @JsonProperty("approximate_member_count")
     @Nullable
     private Integer approximateMemberCount;
-    @Nullable
-    private UserResponse inviter;
     @Nullable
     private Integer uses;
     @JsonProperty("max_uses")
@@ -63,6 +63,11 @@ public class InviteResponse {
     }
 
     @Nullable
+    public UserResponse getInviter() {
+        return inviter;
+    }
+
+    @Nullable
     public UserResponse getTargetUser() {
         return targetUser;
     }
@@ -75,11 +80,6 @@ public class InviteResponse {
     @Nullable
     public Integer getApproximateMemberCount() {
         return approximateMemberCount;
-    }
-
-    @Nullable
-    public UserResponse getInviter() {
-        return inviter;
     }
 
     @Nullable
@@ -113,10 +113,10 @@ public class InviteResponse {
                 "code='" + code + '\'' +
                 ", guild=" + guild +
                 ", channel=" + channel +
+                ", inviter=" + inviter +
                 ", targetUser=" + targetUser +
                 ", approximatePresenceCount=" + approximatePresenceCount +
                 ", approximateMemberCount=" + approximateMemberCount +
-                ", inviter=" + inviter +
                 ", uses=" + uses +
                 ", maxUses=" + maxUses +
                 ", maxAge=" + maxAge +

--- a/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/InviteResponse.java
@@ -30,6 +30,9 @@ public class InviteResponse {
     @JsonProperty("target_user")
     @Nullable
     private UserResponse targetUser;
+    @JsonProperty("target_user_type")
+    @Nullable
+    private Integer targetUserType;
     @JsonProperty("approximate_presence_count")
     @Nullable
     private Integer approximatePresenceCount;
@@ -70,6 +73,11 @@ public class InviteResponse {
     @Nullable
     public UserResponse getTargetUser() {
         return targetUser;
+    }
+
+    @Nullable
+    public Integer getTargetUserType() {
+        return targetUserType;
     }
 
     @Nullable
@@ -115,6 +123,7 @@ public class InviteResponse {
                 ", channel=" + channel +
                 ", inviter=" + inviter +
                 ", targetUser=" + targetUser +
+                ", targetUserType=" + targetUserType +
                 ", approximatePresenceCount=" + approximatePresenceCount +
                 ", approximateMemberCount=" + approximateMemberCount +
                 ", uses=" + uses +


### PR DESCRIPTION
**Description:**
- Moves `inviter` to invite object instead of extended invite object.
- Adds supports for `target_user_type` to get the type of target user for an invite, if present.

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1270 and https://discordapp.com/developers/docs/resources/invite#invite-object