### PR TITLE
Update guild fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -37,6 +37,8 @@ public class BaseGuildBean implements Serializable {
     @Nullable
     private String splash;
     @Nullable
+    private String discoverySplash;
+    @Nullable
     private String banner;
     private long ownerId;
     private String region;
@@ -63,6 +65,9 @@ public class BaseGuildBean implements Serializable {
     private Long widgetChannelId;
     @Nullable
     private Long systemChannelId;
+    private int systemChannelFlags;
+    @Nullable
+    private Long rulesChannelId;
     @Nullable
     private String vanityUrlCode;
     @Nullable
@@ -77,6 +82,7 @@ public class BaseGuildBean implements Serializable {
         name = guildCreate.getName();
         icon = guildCreate.getIcon();
         splash = guildCreate.getSplash();
+        discoverySplash = guildCreate.getDiscoverySplash();
         banner = guildCreate.getBanner();
         ownerId = guildCreate.getOwnerId();
         region = guildCreate.getRegion();
@@ -104,6 +110,8 @@ public class BaseGuildBean implements Serializable {
         widgetEnabled = guildCreate.isWidgetEnabled();
         widgetChannelId = guildCreate.getWidgetChannelId();
         systemChannelId = guildCreate.getSystemChannelId();
+        systemChannelFlags = guildCreate.getSystemChannelFlags();
+        rulesChannelId = guildCreate.getRulesChannelId();
         vanityUrlCode = guildCreate.getVanityUrlCode();
         description = guildCreate.getDescription();
         maxPresences = guildCreate.getMaxPresences();
@@ -115,6 +123,7 @@ public class BaseGuildBean implements Serializable {
         name = guildUpdate.getName();
         icon = guildUpdate.getIcon();
         splash = guildUpdate.getSplash();
+        discoverySplash = guildUpdate.getDiscoverySplash();
         banner = guildUpdate.getBanner();
         ownerId = guildUpdate.getOwnerId();
         region = guildUpdate.getRegion();
@@ -141,6 +150,8 @@ public class BaseGuildBean implements Serializable {
         widgetEnabled = guildUpdate.isWidgetEnabled();
         widgetChannelId = guildUpdate.getWidgetChannelId();
         systemChannelId = guildUpdate.getSystemChannelId();
+        systemChannelFlags = guildUpdate.getSystemChannelFlags();
+        rulesChannelId = guildUpdate.getRulesChannelId();
         vanityUrlCode = guildUpdate.getVanityUrlCode();
         description = guildUpdate.getDescription();
         maxPresences = guildUpdate.getMaxPresences();
@@ -152,6 +163,7 @@ public class BaseGuildBean implements Serializable {
         name = response.getName();
         icon = response.getIcon();
         splash = response.getSplash();
+        discoverySplash = response.getDiscoverySplash();
         banner = response.getBanner();
         ownerId = response.getOwnerId();
         region = response.getRegion();
@@ -178,6 +190,8 @@ public class BaseGuildBean implements Serializable {
         widgetEnabled = response.isWidgetEnabled();
         widgetChannelId = response.getWidgetChannelId();
         systemChannelId = response.getSystemChannelId();
+        systemChannelFlags = response.getSystemChannelFlags();
+        rulesChannelId = response.getRulesChannelId();
         vanityUrlCode = response.getVanityUrlCode();
         description = response.getDescription();
         maxPresences = response.getMaxPresences();
@@ -189,6 +203,7 @@ public class BaseGuildBean implements Serializable {
         name = toCopy.getName();
         icon = toCopy.getIcon();
         splash = toCopy.getSplash();
+        discoverySplash = toCopy.getDiscoverySplash();
         banner = toCopy.getBanner();
         ownerId = toCopy.getOwnerId();
         region = toCopy.getRegion();
@@ -210,6 +225,8 @@ public class BaseGuildBean implements Serializable {
         widgetEnabled = toCopy.isWidgetEnabled();
         widgetChannelId = toCopy.getWidgetChannelId();
         systemChannelId = toCopy.getSystemChannelId();
+        systemChannelFlags = toCopy.getSystemChannelFlags();
+        rulesChannelId = toCopy.getRulesChannelId();
         vanityUrlCode = toCopy.getVanityUrlCode();
         description = toCopy.getDescription();
         maxPresences = toCopy.getMaxPresences();
@@ -248,13 +265,22 @@ public class BaseGuildBean implements Serializable {
         return splash;
     }
 
+    public void setSplash(@Nullable final String splash) {
+        this.splash = splash;
+    }
+
+    @Nullable
+    public String getDiscoverySplash() {
+        return discoverySplash;
+    }
+
+    public void setDiscoverySplash(@Nullable String discoverySplash) {
+        this.discoverySplash = discoverySplash;
+    }
+
     @Nullable
     public String getBanner() {
         return banner;
-    }
-
-    public void setSplash(@Nullable final String splash) {
-        this.splash = splash;
     }
 
     public void setBanner(@Nullable final String banner) {
@@ -407,6 +433,23 @@ public class BaseGuildBean implements Serializable {
         this.systemChannelId = systemChannelId;
     }
 
+    public int getSystemChannelFlags() {
+        return systemChannelFlags;
+    }
+
+    public void setSystemChannelFlags(int systemChannelFlags) {
+        this.systemChannelFlags = systemChannelFlags;
+    }
+
+    @Nullable
+    public Long getRulesChannelId() {
+        return rulesChannelId;
+    }
+
+    public void setRulesChannelId(@Nullable Long rulesChannelId) {
+        this.rulesChannelId = rulesChannelId;
+    }
+
     @Nullable
     public String getVanityUrlCode() {
         return vanityUrlCode;
@@ -450,6 +493,7 @@ public class BaseGuildBean implements Serializable {
                 ", name='" + name + '\'' +
                 ", icon='" + icon + '\'' +
                 ", splash='" + splash + '\'' +
+                ", discoverySplash='" + discoverySplash + '\'' +
                 ", banner='" + banner + '\'' +
                 ", ownerId=" + ownerId +
                 ", region='" + region + '\'' +
@@ -457,7 +501,8 @@ public class BaseGuildBean implements Serializable {
                 ", afkTimeout=" + afkTimeout +
                 ", embedChannelId=" + embedChannelId +
                 ", premiumTier=" + premiumTier +
-                ", preferredLocale=" + preferredLocale +
+                ", premiumSubscriptionsCount=" + premiumSubscriptionsCount +
+                ", preferredLocale='" + preferredLocale + '\'' +
                 ", verificationLevel=" + verificationLevel +
                 ", defaultMessageNotifications=" + defaultMessageNotifications +
                 ", explicitContentFilter=" + explicitContentFilter +
@@ -469,8 +514,10 @@ public class BaseGuildBean implements Serializable {
                 ", widgetEnabled=" + widgetEnabled +
                 ", widgetChannelId=" + widgetChannelId +
                 ", systemChannelId=" + systemChannelId +
-                ", vanityUrlCode=" + vanityUrlCode +
-                ", description=" + description +
+                ", systemChannelFlags=" + systemChannelFlags +
+                ", rulesChannelId=" + rulesChannelId +
+                ", vanityUrlCode='" + vanityUrlCode + '\'' +
+                ", description='" + description + '\'' +
                 ", maxPresences=" + maxPresences +
                 ", maxMembers=" + maxMembers +
                 '}';

--- a/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
+++ b/core/src/main/java/discord4j/core/object/data/stored/BaseGuildBean.java
@@ -67,8 +67,6 @@ public class BaseGuildBean implements Serializable {
     private Long systemChannelId;
     private int systemChannelFlags;
     @Nullable
-    private Long rulesChannelId;
-    @Nullable
     private String vanityUrlCode;
     @Nullable
     private String description;
@@ -111,7 +109,6 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = guildCreate.getWidgetChannelId();
         systemChannelId = guildCreate.getSystemChannelId();
         systemChannelFlags = guildCreate.getSystemChannelFlags();
-        rulesChannelId = guildCreate.getRulesChannelId();
         vanityUrlCode = guildCreate.getVanityUrlCode();
         description = guildCreate.getDescription();
         maxPresences = guildCreate.getMaxPresences();
@@ -151,7 +148,6 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = guildUpdate.getWidgetChannelId();
         systemChannelId = guildUpdate.getSystemChannelId();
         systemChannelFlags = guildUpdate.getSystemChannelFlags();
-        rulesChannelId = guildUpdate.getRulesChannelId();
         vanityUrlCode = guildUpdate.getVanityUrlCode();
         description = guildUpdate.getDescription();
         maxPresences = guildUpdate.getMaxPresences();
@@ -191,7 +187,6 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = response.getWidgetChannelId();
         systemChannelId = response.getSystemChannelId();
         systemChannelFlags = response.getSystemChannelFlags();
-        rulesChannelId = response.getRulesChannelId();
         vanityUrlCode = response.getVanityUrlCode();
         description = response.getDescription();
         maxPresences = response.getMaxPresences();
@@ -226,7 +221,6 @@ public class BaseGuildBean implements Serializable {
         widgetChannelId = toCopy.getWidgetChannelId();
         systemChannelId = toCopy.getSystemChannelId();
         systemChannelFlags = toCopy.getSystemChannelFlags();
-        rulesChannelId = toCopy.getRulesChannelId();
         vanityUrlCode = toCopy.getVanityUrlCode();
         description = toCopy.getDescription();
         maxPresences = toCopy.getMaxPresences();
@@ -442,15 +436,6 @@ public class BaseGuildBean implements Serializable {
     }
 
     @Nullable
-    public Long getRulesChannelId() {
-        return rulesChannelId;
-    }
-
-    public void setRulesChannelId(@Nullable Long rulesChannelId) {
-        this.rulesChannelId = rulesChannelId;
-    }
-
-    @Nullable
     public String getVanityUrlCode() {
         return vanityUrlCode;
     }
@@ -515,7 +500,6 @@ public class BaseGuildBean implements Serializable {
                 ", widgetChannelId=" + widgetChannelId +
                 ", systemChannelId=" + systemChannelId +
                 ", systemChannelFlags=" + systemChannelFlags +
-                ", rulesChannelId=" + rulesChannelId +
                 ", vanityUrlCode='" + vanityUrlCode + '\'' +
                 ", description='" + description + '\'' +
                 ", maxPresences=" + maxPresences +

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -16,7 +16,6 @@
  */
 package discord4j.core.object.entity;
 
-import com.sun.tools.javac.comp.Todo;
 import discord4j.common.json.GuildMemberResponse;
 import discord4j.core.DiscordClient;
 import discord4j.core.ServiceMediator;

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -523,26 +523,6 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets the ID of the channel in which a discoverable server's rules should be found, if present.
-     *
-     * @return The ID of the channel in which a discoverable server's rules should be found, if present.
-     */
-    public Optional<Snowflake> getRulesChannelId() {
-        return Optional.ofNullable(data.getRulesChannelId()).map(Snowflake::of);
-    }
-
-    /**
-     * Requests to retrieve the channel in which a discoverable server's rules should be found, if present.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} in which a
-     * discoverable server's rules should be found, if present. If an error is received, it is emitted through the
-     * {@code Mono}.
-     */
-    public Mono<TextChannel> getRulesChannel() {
-        return Mono.justOrEmpty(getRulesChannelId()).flatMap(getClient()::getChannelById).cast(TextChannel.class);
-    }
-
-    /**
      * Gets when this guild was joined at, if present.
      *
      * @return When this guild was joined at, if present.

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -38,7 +38,16 @@ public class GuildCreate implements Dispatch {
     @Nullable
     @UnsignedJson
     private Long systemChannelId;
+    @JsonProperty("system_channel_flags")
+    private int systemChannelFlags;
+    @JsonProperty("rules_channel_id")
+    @Nullable
+    @UnsignedJson
+    private Long rulesChannelId;
     private String splash;
+    @JsonProperty("discovery_splash")
+    @Nullable
+    private String discoverySplash;
     private String banner;
     private RoleResponse[] roles;
     private String region;
@@ -134,8 +143,22 @@ public class GuildCreate implements Dispatch {
         return systemChannelId;
     }
 
+    public int getSystemChannelFlags() {
+        return systemChannelFlags;
+    }
+
+    @Nullable
+    public Long getRulesChannelId() {
+        return rulesChannelId;
+    }
+
     public String getSplash() {
         return splash;
+    }
+
+    @Nullable
+    public String getDiscoverySplash() {
+        return discoverySplash;
     }
 
     public String getBanner() {
@@ -268,12 +291,12 @@ public class GuildCreate implements Dispatch {
         return "GuildCreate{" +
                 "voiceStates=" + Arrays.toString(voiceStates) +
                 ", verificationLevel=" + verificationLevel +
-                ", premiumTier=" + premiumTier +
-                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
-                ", preferredLocale=" + preferredLocale +
                 ", unavailable=" + unavailable +
                 ", systemChannelId=" + systemChannelId +
+                ", systemChannelFlags=" + systemChannelFlags +
+                ", rulesChannelId=" + rulesChannelId +
                 ", splash='" + splash + '\'' +
+                ", discoverySplash='" + discoverySplash + '\'' +
                 ", banner='" + banner + '\'' +
                 ", roles=" + Arrays.toString(roles) +
                 ", region='" + region + '\'' +
@@ -281,6 +304,9 @@ public class GuildCreate implements Dispatch {
                 ", ownerId=" + ownerId +
                 ", name='" + name + '\'' +
                 ", mfaLevel=" + mfaLevel +
+                ", premiumTier=" + premiumTier +
+                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", preferredLocale='" + preferredLocale + '\'' +
                 ", members=" + Arrays.toString(members) +
                 ", memberCount=" + memberCount +
                 ", lazy=" + lazy +
@@ -297,10 +323,10 @@ public class GuildCreate implements Dispatch {
                 ", afkTimeout=" + afkTimeout +
                 ", afkChannelId=" + afkChannelId +
                 ", embedChannelId=" + embedChannelId +
-                ", widgetEnabled=" + widgetEnabled +
                 ", widgetChannelId=" + widgetChannelId +
-                ", vanityUrlCode=" + vanityUrlCode +
-                ", description=" + description +
+                ", widgetEnabled=" + widgetEnabled +
+                ", vanityUrlCode='" + vanityUrlCode + '\'' +
+                ", description='" + description + '\'' +
                 ", maxPresences=" + maxPresences +
                 ", maxMembers=" + maxMembers +
                 '}';

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildCreate.java
@@ -40,10 +40,6 @@ public class GuildCreate implements Dispatch {
     private Long systemChannelId;
     @JsonProperty("system_channel_flags")
     private int systemChannelFlags;
-    @JsonProperty("rules_channel_id")
-    @Nullable
-    @UnsignedJson
-    private Long rulesChannelId;
     private String splash;
     @JsonProperty("discovery_splash")
     @Nullable
@@ -145,11 +141,6 @@ public class GuildCreate implements Dispatch {
 
     public int getSystemChannelFlags() {
         return systemChannelFlags;
-    }
-
-    @Nullable
-    public Long getRulesChannelId() {
-        return rulesChannelId;
     }
 
     public String getSplash() {
@@ -294,7 +285,6 @@ public class GuildCreate implements Dispatch {
                 ", unavailable=" + unavailable +
                 ", systemChannelId=" + systemChannelId +
                 ", systemChannelFlags=" + systemChannelFlags +
-                ", rulesChannelId=" + rulesChannelId +
                 ", splash='" + splash + '\'' +
                 ", discoverySplash='" + discoverySplash + '\'' +
                 ", banner='" + banner + '\'' +

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -45,7 +45,16 @@ public class GuildUpdate implements Dispatch {
     @Nullable
     @UnsignedJson
     private Long systemChannelId;
+    @JsonProperty("system_channel_flags")
+    private int systemChannelFlags;
+    @JsonProperty("rules_channel_id")
+    @Nullable
+    @UnsignedJson
+    private Long rulesChannelId;
     private String splash;
+    @JsonProperty("discovery_splash")
+    @Nullable
+    private String discoverySplash;
     private String banner;
     private RoleResponse[] roles;
     private String region;
@@ -126,8 +135,22 @@ public class GuildUpdate implements Dispatch {
         return systemChannelId;
     }
 
+    public int getSystemChannelFlags() {
+        return systemChannelFlags;
+    }
+
+    @Nullable
+    public Long getRulesChannelId() {
+        return rulesChannelId;
+    }
+
     public String getSplash() {
         return splash;
+    }
+
+    @Nullable
+    public String getDiscoverySplash() {
+        return discoverySplash;
     }
 
     public String getBanner() {
@@ -233,10 +256,13 @@ public class GuildUpdate implements Dispatch {
                 ", verificationLevel=" + verificationLevel +
                 ", premiumTier=" + premiumTier +
                 ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
-                ", preferredLocale=" + preferredLocale +
+                ", preferredLocale='" + preferredLocale + '\'' +
                 ", systemChannelId=" + systemChannelId +
+                ", systemChannelFlags=" + systemChannelFlags +
+                ", rulesChannelId=" + rulesChannelId +
                 ", splash='" + splash + '\'' +
-                ", splash='" + banner + '\'' +
+                ", discoverySplash='" + discoverySplash + '\'' +
+                ", banner='" + banner + '\'' +
                 ", roles=" + Arrays.toString(roles) +
                 ", region='" + region + '\'' +
                 ", ownerId=" + ownerId +
@@ -254,8 +280,8 @@ public class GuildUpdate implements Dispatch {
                 ", afkTimeout=" + afkTimeout +
                 ", afkChannelId=" + afkChannelId +
                 ", guildId=" + guildId +
-                ", vanityUrlCode=" + vanityUrlCode +
-                ", description=" + description +
+                ", vanityUrlCode='" + vanityUrlCode + '\'' +
+                ", description='" + description + '\'' +
                 ", maxPresences=" + maxPresences +
                 ", maxMembers=" + maxMembers +
                 '}';

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/GuildUpdate.java
@@ -47,10 +47,6 @@ public class GuildUpdate implements Dispatch {
     private Long systemChannelId;
     @JsonProperty("system_channel_flags")
     private int systemChannelFlags;
-    @JsonProperty("rules_channel_id")
-    @Nullable
-    @UnsignedJson
-    private Long rulesChannelId;
     private String splash;
     @JsonProperty("discovery_splash")
     @Nullable
@@ -137,11 +133,6 @@ public class GuildUpdate implements Dispatch {
 
     public int getSystemChannelFlags() {
         return systemChannelFlags;
-    }
-
-    @Nullable
-    public Long getRulesChannelId() {
-        return rulesChannelId;
     }
 
     public String getSplash() {
@@ -259,7 +250,6 @@ public class GuildUpdate implements Dispatch {
                 ", preferredLocale='" + preferredLocale + '\'' +
                 ", systemChannelId=" + systemChannelId +
                 ", systemChannelFlags=" + systemChannelFlags +
-                ", rulesChannelId=" + rulesChannelId +
                 ", splash='" + splash + '\'' +
                 ", discoverySplash='" + discoverySplash + '\'' +
                 ", banner='" + banner + '\'' +

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -43,11 +43,6 @@ public class GuildResponse {
     private Long systemChannelId;
     @JsonProperty("system_channel_flags")
     private int systemChannelFlags;
-    @JsonProperty("rules_channel_id")
-    @Nullable
-    @UnsignedJson
-    private Long rulesChannelId;
-    @JsonProperty("widget_channel_id")
     @Nullable
     @UnsignedJson
     private Long widgetChannelId;
@@ -133,11 +128,6 @@ public class GuildResponse {
 
     public int getSystemChannelFlags() {
         return systemChannelFlags;
-    }
-
-    @Nullable
-    public Long getRulesChannelId() {
-        return rulesChannelId;
     }
 
     @Nullable
@@ -252,7 +242,6 @@ public class GuildResponse {
                 ", afkTimeout=" + afkTimeout +
                 ", systemChannelId=" + systemChannelId +
                 ", systemChannelFlags=" + systemChannelFlags +
-                ", rulesChannelId=" + rulesChannelId +
                 ", widgetChannelId=" + widgetChannelId +
                 ", region='" + region + '\'' +
                 ", defaultMessageNotifications=" + defaultMessageNotifications +

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -41,6 +41,12 @@ public class GuildResponse {
     @Nullable
     @UnsignedJson
     private Long systemChannelId;
+    @JsonProperty("system_channel_flags")
+    private int systemChannelFlags;
+    @JsonProperty("rules_channel_id")
+    @Nullable
+    @UnsignedJson
+    private Long rulesChannelId;
     @JsonProperty("widget_channel_id")
     @Nullable
     @UnsignedJson
@@ -55,6 +61,9 @@ public class GuildResponse {
     @JsonProperty("explicit_content_filter")
     private int explicitContentFilter;
     private String splash;
+    @JsonProperty("discovery_splash")
+    @Nullable
+    private String discoverySplash;
     private String banner;
     private String[] features;
     @JsonProperty("afk_channel_id")
@@ -122,6 +131,15 @@ public class GuildResponse {
         return systemChannelId;
     }
 
+    public int getSystemChannelFlags() {
+        return systemChannelFlags;
+    }
+
+    @Nullable
+    public Long getRulesChannelId() {
+        return rulesChannelId;
+    }
+
     @Nullable
     public Long getWidgetChannelId() {
         return widgetChannelId;
@@ -146,6 +164,11 @@ public class GuildResponse {
 
     public String getSplash() {
         return splash;
+    }
+
+    @Nullable
+    public String getDiscoverySplash() {
+        return discoverySplash;
     }
 
     public String getBanner() {
@@ -222,32 +245,35 @@ public class GuildResponse {
     public String toString() {
         return "GuildResponse{" +
                 "mfaLevel=" + mfaLevel +
-                ", premiumTier=" + premiumTier +
-                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
-                ", preferredLocale=" + preferredLocale +
                 ", emojis=" + Arrays.toString(emojis) +
                 ", applicationId=" + applicationId +
                 ", name='" + name + '\'' +
                 ", roles=" + Arrays.toString(roles) +
                 ", afkTimeout=" + afkTimeout +
                 ", systemChannelId=" + systemChannelId +
+                ", systemChannelFlags=" + systemChannelFlags +
+                ", rulesChannelId=" + rulesChannelId +
                 ", widgetChannelId=" + widgetChannelId +
                 ", region='" + region + '\'' +
                 ", defaultMessageNotifications=" + defaultMessageNotifications +
                 ", embedChannelId=" + embedChannelId +
                 ", explicitContentFilter=" + explicitContentFilter +
                 ", splash='" + splash + '\'' +
+                ", discoverySplash='" + discoverySplash + '\'' +
                 ", banner='" + banner + '\'' +
                 ", features=" + Arrays.toString(features) +
                 ", afkChannelId=" + afkChannelId +
                 ", widgetEnabled=" + widgetEnabled +
                 ", verificationLevel=" + verificationLevel +
+                ", premiumTier=" + premiumTier +
+                ", premiumSubcriptionsCount=" + premiumSubcriptionsCount +
+                ", preferredLocale='" + preferredLocale + '\'' +
                 ", ownerId=" + ownerId +
                 ", embedEnabled=" + embedEnabled +
                 ", id=" + id +
                 ", icon='" + icon + '\'' +
-                ", vanityUrlCode=" + vanityUrlCode +
-                ", description=" + description +
+                ", vanityUrlCode='" + vanityUrlCode + '\'' +
+                ", description='" + description + '\'' +
                 ", maxPresences=" + maxPresences +
                 ", maxMembers=" + maxMembers +
                 '}';

--- a/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
+++ b/rest/src/main/java/discord4j/rest/json/response/GuildResponse.java
@@ -43,6 +43,7 @@ public class GuildResponse {
     private Long systemChannelId;
     @JsonProperty("system_channel_flags")
     private int systemChannelFlags;
+    @JsonProperty("widget_channel_id")
     @Nullable
     @UnsignedJson
     private Long widgetChannelId;


### PR DESCRIPTION
**Description:**
- Adds supports for `system_channel_flags` to get the flags of the system channel.
- ~~Adds supports for `rules_channel_id` to get the ID of the channel in which a discoverable server's rules should be found, if present~~.
- Adds supports for `discovery_splash` to get the the discovery splash URL of the guild, if present.

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1262