### PR TITLE
All POST /guilds fields are optional except name

### DIFF
--- a/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
@@ -32,21 +32,15 @@ import java.util.function.Consumer;
 /**
  * A spec used to configure and create a {@link Guild}. <b>This can only be used for bots in less than 10 guilds.</b>
  * <p>
- * This spec also has some limitations to it. The name, region, verification level, and default message notification
- * level are all required to be able to properly build the spec. The first role added, either from
- * {@link #addEveryoneRole} or {@link #addRole}, will automatically be set as the default @everyone role. Each
- * subsequent call to {@link #addEveryoneRole} will not override the first role but shift all other roles down.
+ * This spec also has some limitations to it. The name is required to be able to properly build the spec. The first role
+ * added, either from {@link #addEveryoneRole} or {@link #addRole}, will automatically be set as the default @everyone
+ * role. Each subsequent call to {@link #addEveryoneRole} will not override the first role but shift all other roles down.
  *
  * @see <a href="https://discordapp.com/developers/docs/resources/guild#create-guild">Create Guild</a>
  */
 public class GuildCreateSpec implements Spec<GuildCreateRequest> {
 
-    private String name;
-    private String region;
-    @Nullable
-    private String icon;
-    private int verificationLevel;
-    private int defaultMessageNotificationLevel;
+    private final GuildCreateRequest.Builder requestBuilder = GuildCreateRequest.builder();
     private final List<RoleCreateRequest> roles = new ArrayList<>();
     private final List<PartialChannelRequest> channels = new ArrayList<>();
 
@@ -57,7 +51,7 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec setName(String name) {
-        this.name = name;
+        requestBuilder.name(name);
         return this;
     }
 
@@ -68,7 +62,7 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec setRegion(Region region) {
-        this.region = region.getId();
+        requestBuilder.region(region.getId());
         return this;
     }
 
@@ -79,7 +73,7 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec setIcon(@Nullable Image icon) {
-        this.icon = (icon == null) ? null : icon.getData();
+        requestBuilder.icon(icon == null ? null : icon.getData());
         return this;
     }
 
@@ -90,7 +84,7 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec setVerificationLevel(Guild.VerificationLevel verificationLevel) {
-        this.verificationLevel = verificationLevel.getValue();
+        requestBuilder.verificationLevel(verificationLevel.getValue());
         return this;
     }
 
@@ -101,7 +95,7 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec setDefaultMessageNotificationLevel(Guild.NotificationLevel notificationLevel) {
-        this.defaultMessageNotificationLevel = notificationLevel.getValue();
+        requestBuilder.defaultMessageNotifications(notificationLevel.getValue());
         return this;
     }
 
@@ -151,7 +145,8 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
     public GuildCreateRequest asRequest() {
         RoleCreateRequest[] roles = this.roles.toArray(new RoleCreateRequest[this.roles.size()]);
         PartialChannelRequest[] channels = this.channels.toArray(new PartialChannelRequest[this.channels.size()]);
-        return new GuildCreateRequest(name, region, icon, verificationLevel, defaultMessageNotificationLevel, roles,
-                channels);
+        return requestBuilder.roles(roles)
+                .channels(channels)
+                .build();
     }
 }

--- a/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
+++ b/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
@@ -26,6 +26,7 @@ public class GuildCreateRequest {
 
     private final String name;
     private final Possible<String> region;
+    @Nullable
     private final Possible<String> icon;
     @JsonProperty("verification_level")
     private final Possible<Integer> verificationLevel;
@@ -54,6 +55,7 @@ public class GuildCreateRequest {
 
         private String name;
         private Possible<String> region = Possible.absent();
+        @Nullable
         private Possible<String> icon = Possible.absent();
         private Possible<Integer> verificationLevel = Possible.absent();
         private Possible<Integer> defaultMessageNotifications = Possible.absent();

--- a/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
+++ b/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
@@ -35,7 +35,7 @@ public class GuildCreateRequest {
     private final Possible<RoleCreateRequest[]> roles;
     private final Possible<PartialChannelRequest[]> channels;
 
-    public GuildCreateRequest(String name, Possible<String> region, Possible<String> icon,
+    public GuildCreateRequest(String name, Possible<String> region, @Nullable Possible<String> icon,
                               Possible<Integer> verificationLevel, Possible<Integer> defaultMessageNotifications,
                               Possible<RoleCreateRequest[]> roles, Possible<PartialChannelRequest[]> channels) {
         this.name = name;

--- a/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
+++ b/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
@@ -17,6 +17,7 @@
 package discord4j.rest.json.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import discord4j.common.jackson.Possible;
 import reactor.util.annotation.Nullable;
 
 import java.util.Arrays;
@@ -24,19 +25,18 @@ import java.util.Arrays;
 public class GuildCreateRequest {
 
     private final String name;
-    private final String region;
-    @Nullable
-    private final String icon;
+    private final Possible<String> region;
+    private final Possible<String> icon;
     @JsonProperty("verification_level")
-    private final int verificationLevel;
+    private final Possible<Integer> verificationLevel;
     @JsonProperty("default_message_notifications")
-    private final int defaultMessageNotifications;
-    private final RoleCreateRequest[] roles;
-    private final PartialChannelRequest[] channels;
+    private final Possible<Integer> defaultMessageNotifications;
+    private final Possible<RoleCreateRequest[]> roles;
+    private final Possible<PartialChannelRequest[]> channels;
 
-    public GuildCreateRequest(String name, String region, @Nullable String icon, int verificationLevel,
-                              int defaultMessageNotifications, RoleCreateRequest[] roles,
-                              PartialChannelRequest[] channels) {
+    public GuildCreateRequest(String name, Possible<String> region, Possible<String> icon,
+                              Possible<Integer> verificationLevel, Possible<Integer> defaultMessageNotifications,
+                              Possible<RoleCreateRequest[]> roles, Possible<PartialChannelRequest[]> channels) {
         this.name = name;
         this.region = region;
         this.icon = icon;
@@ -46,16 +46,71 @@ public class GuildCreateRequest {
         this.channels = channels;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private Possible<String> region = Possible.absent();
+        private Possible<String> icon = Possible.absent();
+        private Possible<Integer> verificationLevel = Possible.absent();
+        private Possible<Integer> defaultMessageNotifications = Possible.absent();
+        private Possible<RoleCreateRequest[]> roles = Possible.absent();
+        private Possible<PartialChannelRequest[]> channels = Possible.absent();
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder region(String region) {
+            this.region = Possible.of(region);
+            return this;
+        }
+
+        public Builder icon(String icon) {
+            this.icon = Possible.of(icon);
+            return this;
+        }
+
+        public Builder verificationLevel(int verificationLevel) {
+            this.verificationLevel = Possible.of(verificationLevel);
+            return this;
+        }
+
+        public Builder defaultMessageNotifications(int defaultMessageNotifications) {
+            this.defaultMessageNotifications = Possible.of(defaultMessageNotifications);
+            return this;
+        }
+
+        public Builder roles(RoleCreateRequest[] roles) {
+            this.roles = Possible.of(roles);
+            return this;
+        }
+
+        public Builder channels(PartialChannelRequest[] channels) {
+            this.channels = Possible.of(channels);
+            return this;
+        }
+
+        public GuildCreateRequest build() {
+            return new GuildCreateRequest(name, region, icon, verificationLevel, defaultMessageNotifications, roles,
+                    channels);
+        }
+    }
+
     @Override
     public String toString() {
         return "GuildCreateRequest{" +
                 "name='" + name + '\'' +
-                ", region='" + region + '\'' +
-                ", icon='" + icon + '\'' +
+                ", region=" + region +
+                ", icon=" + icon +
                 ", verificationLevel=" + verificationLevel +
                 ", defaultMessageNotifications=" + defaultMessageNotifications +
-                ", roles=" + Arrays.toString(roles) +
-                ", channels=" + Arrays.toString(channels) +
+                ", roles=" + roles +
+                ", channels=" + channels +
                 '}';
     }
 }

--- a/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
+++ b/rest/src/main/java/discord4j/rest/json/request/GuildCreateRequest.java
@@ -72,7 +72,7 @@ public class GuildCreateRequest {
             return this;
         }
 
-        public Builder icon(String icon) {
+        public Builder icon(@Nullable String icon) {
             this.icon = Possible.of(icon);
             return this;
         }


### PR DESCRIPTION
**Description:** Updates `GuildCreateRequest` and `GuildCreateSpec` to make all fields optional except `name`.

**Justification:** https://github.com/discordapp/discord-api-docs/pull/1312