### PR TITLE
Permit raw RGB values in EmbedCreateSpec#setColor

### DIFF
--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
@@ -86,7 +86,7 @@ public class EmbedCreateSpec implements Spec<EmbedRequest> {
      * @return This spec.
      */
     public EmbedCreateSpec setColor(final Color color) {
-        setColor(color.getRGB());
+        return setColor(color.getRGB());
     }
     
     /**

--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
@@ -86,7 +86,17 @@ public class EmbedCreateSpec implements Spec<EmbedRequest> {
      * @return This spec.
      */
     public EmbedCreateSpec setColor(final Color color) {
-        requestBuilder.color(color.getRGB() & 0xFFFFFF);
+        setColor(color.getRGB());
+    }
+    
+    /**
+     * Sets the color of the embed.
+     *
+     * @param color An RGB color to display on the embed.
+     * @return This spec.
+     */
+    public EmbedCreateSpec setColor(int color) {
+        requestBuilder.color(color & 0xFFFFFF);
         return this;
     }
 


### PR DESCRIPTION
**Description:** Minor change. This PR adds a `setColor` method to `EmbedCreateSpec` that accepts a raw RGB integer.

**Justification:** Using `java.awt.Color` in a modular context requires `java.desktop` to be added to the module's dependencies. This is a rather hefty addition (with a module size of 11.6MB in AdoptOpenJDK 11.0.6.10), especially since it's likely going to be used for no reason other than to access `Color` constants.