### PR TITLE
Invite create/delete event guild_id is now nullable

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
@@ -224,7 +224,7 @@ public abstract class DispatchHandlers {
     }
 
     private static Mono<InviteCreateEvent> inviteCreate(DispatchContext<InviteCreate> context) {
-        long guildId = context.getDispatch().getGuildId();
+        Long guildId = context.getDispatch().getGuildId();
         long channelId = context.getDispatch().getChannelId();
         String code = context.getDispatch().getCode();
         Instant createdAt = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(context.getDispatch().getCreatedAt(), Instant::from);
@@ -243,7 +243,7 @@ public abstract class DispatchHandlers {
     }
 
     private static Mono<InviteDeleteEvent> inviteDelete(DispatchContext<InviteDelete> context) {
-        long guildId = context.getDispatch().getGuildId();
+        Long guildId = context.getDispatch().getGuildId();
         long channelId = context.getDispatch().getChannelId();
         String code = context.getDispatch().getCode();
 

--- a/core/src/main/java/discord4j/core/event/domain/InviteCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/InviteCreateEvent.java
@@ -22,6 +22,7 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -36,7 +37,8 @@ import java.util.Optional;
  */
 public class InviteCreateEvent extends Event {
 
-    private final long guildId;
+    @Nullable
+    private final Long guildId;
     private final long channelId;
     private final String code;
     private final User inviter;
@@ -46,7 +48,7 @@ public class InviteCreateEvent extends Event {
     private final int maxAge;
     private final boolean temporary;
 
-    public InviteCreateEvent(DiscordClient client, long guildId, long channelId, String code, User inviter, Instant createdAt, int uses, int maxUses, int maxAge, boolean temporary) {
+    public InviteCreateEvent(DiscordClient client, Long guildId, long channelId, String code, User inviter, Instant createdAt, int uses, int maxUses, int maxAge, boolean temporary) {
         super(client);
         this.guildId = guildId;
         this.channelId = channelId;
@@ -60,12 +62,12 @@ public class InviteCreateEvent extends Event {
     }
 
     /**
-     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event, if present.
      *
-     * @return The ID of the guild involved.
+     * @return The ID of the guild involved, if present.
      */
-    public Snowflake getGuildId() {
-        return Snowflake.of(guildId);
+    public Optional<Snowflake> getGuildId() {
+        return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
@@ -75,7 +77,7 @@ public class InviteCreateEvent extends Event {
      * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
-        return getClient().getGuildById(getGuildId());
+        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/event/domain/InviteDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/InviteDeleteEvent.java
@@ -20,9 +20,12 @@ import discord4j.core.DiscordClient;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.object.util.Snowflake;
 import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
+
+import java.util.Optional;
 
 /**
- * Dispatched when an invite to a channel is deleted.
+ * Dispatched when an invite is deleted.
  * <p>
  * This event is dispatched by Discord.
  *
@@ -30,11 +33,12 @@ import reactor.core.publisher.Mono;
  */
 public class InviteDeleteEvent extends Event {
 
-    private final long guildId;
+    @Nullable
+    private final Long guildId;
     private final long channelId;
     private final String code;
 
-    public InviteDeleteEvent(DiscordClient client, long guildId, long channelId, String code) {
+    public InviteDeleteEvent(DiscordClient client, Long guildId, long channelId, String code) {
         super(client);
         this.guildId = guildId;
         this.channelId = channelId;
@@ -42,12 +46,12 @@ public class InviteDeleteEvent extends Event {
     }
 
     /**
-     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event.
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event, if present.
      *
-     * @return The ID of the guild involved.
+     * @return The ID of the guild involved, if present.
      */
-    public Snowflake getGuildId() {
-        return Snowflake.of(guildId);
+    public Optional<Snowflake> getGuildId() {
+        return Optional.ofNullable(guildId).map(Snowflake::of);
     }
 
     /**
@@ -57,7 +61,7 @@ public class InviteDeleteEvent extends Event {
      * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
-        return getClient().getGuildById(getGuildId());
+        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/event/domain/InviteDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/InviteDeleteEvent.java
@@ -25,7 +25,7 @@ import reactor.util.annotation.Nullable;
 import java.util.Optional;
 
 /**
- * Dispatched when an invite is deleted.
+ * Dispatched when an invite to a channel is deleted.
  * <p>
  * This event is dispatched by Discord.
  *

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/InviteCreate.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/InviteCreate.java
@@ -19,12 +19,14 @@ package discord4j.gateway.json.dispatch;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
 import discord4j.common.json.UserResponse;
+import reactor.util.annotation.Nullable;
 
 public class InviteCreate implements Dispatch {
 
+    @Nullable
     @JsonProperty("guild_id")
     @UnsignedJson
-    private long guildId;
+    private Long guildId;
     @JsonProperty("channel_id")
     @UnsignedJson
     private long channelId;
@@ -43,7 +45,8 @@ public class InviteCreate implements Dispatch {
         return inviter;
     }
 
-    public long getGuildId() {
+    @Nullable
+    public Long getGuildId() {
         return guildId;
     }
 

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/InviteDelete.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/InviteDelete.java
@@ -18,18 +18,21 @@ package discord4j.gateway.json.dispatch;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import discord4j.common.jackson.UnsignedJson;
+import reactor.util.annotation.Nullable;
 
 public class InviteDelete implements Dispatch {
 
+    @Nullable
     @JsonProperty("guild_id")
     @UnsignedJson
-    private long guildId;
+    private Long guildId;
     @JsonProperty("channel_id")
     @UnsignedJson
     private long channelId;
     private String code;
 
-    public long getGuildId() {
+    @Nullable
+    public Long getGuildId() {
         return guildId;
     }
 


### PR DESCRIPTION
**Description:** The `guild_id` field inside invite create / delete events is now nullable.

**Justification:** https://github.com/discordapp/discord-api-docs/commit/33ecdc9d9402996f82bcd01c2fe33ab1da8d6613