### PR TITLE
Update Activity fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -83,6 +83,15 @@ public class Activity {
     }
 
     /**
+     * Gets unix timestamp of when the activity was added to the user's session.
+     *
+     * @return The unix timestamp of when the activity was added to the user's session.
+     */
+    public Instant getCreatedAt() {
+        return Instant.ofEpochMilli(data.createdAt());
+    }
+
+    /**
      * Gets the UNIX time (in milliseconds) of when the activity started, if present.
      *
      * @return The UNIX time (in milliseconds) of when the activity started, if present.
@@ -208,16 +217,31 @@ public class Activity {
             .flatMap(assets -> assets.smallText().toOptional());
     }
 
+    /**
+     * Gets the secret for joining a party, if present.
+     *
+     * @return The secret for joining a party, if present.
+     */
     public Optional<String> getJoinSecret() {
         return data.secrets().toOptional()
             .flatMap(secrets -> secrets.join().toOptional());
     }
 
+    /**
+     * Gets the secret for spectating a game, if present.
+     *
+     * @return The secret for spectating a game, if present.
+     */
     public Optional<String> getSpectateSecret() {
         return data.secrets().toOptional()
             .flatMap(secrets -> secrets.spectate().toOptional());
     }
 
+    /**
+     * Gets the secret for a specific instanced match, if present.
+     *
+     * @return The secret for a specific instanced match, if present.
+     */
     public Optional<String> getMatchSecret() {
         return data.secrets().toOptional()
             .flatMap(secrets -> secrets.match().toOptional());
@@ -241,10 +265,9 @@ public class Activity {
     /**
      * Gets whether or not the activity is an instanced game session.
      *
-     * @return Whether or not the activity is an instanced game session
+     * @return Whether or not the activity is an instanced game session.
      */
     public boolean isInstance() {
-//        return Optional.ofNullable(data.getInstance()).orElse(false);
         return data.instance().toOptional().orElse(false);
     }
 


### PR DESCRIPTION
**Description:** Supports `Activity#createdAt()` and adds some documentations

**Justification:** Closes https://github.com/Discord4J/Discord4J/issues/611