### PR TITLE
Fix NoSuchElementException in GuildDeleteEvent

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -196,7 +196,7 @@ class GuildDispatchHandlers {
         StateHolder stateHolder = context.getStateHolder();
 
         long guildId = Long.parseUnsignedLong(context.getDispatch().guild().id());
-        boolean unavailable = context.getDispatch().guild().unavailable().get();
+        boolean unavailable = context.getDispatch().guild().unavailable().toOptional().orElse(false);
 
         Mono<Void> deleteGuild = stateHolder.getGuildStore().delete(guildId);
 


### PR DESCRIPTION
**Description:** 
Quoting DAPI documentation about guild delete event: 
`Sent when a guild becomes unavailable during a guild outage, or when the user leaves or is removed from a guild. The inner payload is an unavailable guild object. If the unavailable field is not set, the user was removed from the guild.`

If the bot has been removed from the guild, unavailable field is not present so .get() throws an exception. It can be fixed by assuming a default value or by returning an Optional<Boolean> for unavailable field to inform when the bot has been kicked.

This pull request is assuming a default value to false but discussion is opened.

EDIT: After discussing with xaanit, it seems that `false` value is never set, this field is either true or empty. In this case, a default value set to false is sufficient.

**Justification:** https://discordapp.com/developers/docs/topics/gateway#guild-delete