### PR TITLE
Added abstraction for REST request queue

### DIFF
--- a/rest/src/main/java/discord4j/rest/request/ProcessorRequestQueueFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/ProcessorRequestQueueFactory.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.rest.request;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.FluxSink;
+
+import java.util.function.Supplier;
+
+class ProcessorRequestQueueFactory implements RequestQueueFactory {
+
+    private final Supplier<FluxProcessor<Object, Object>> processorSupplier;
+    private final FluxSink.OverflowStrategy overflowStrategy;
+
+    ProcessorRequestQueueFactory(Supplier<FluxProcessor<Object, Object>> processorSupplier,
+                                 FluxSink.OverflowStrategy overflowStrategy) {
+        this.processorSupplier = processorSupplier;
+        this.overflowStrategy = overflowStrategy;
+    }
+
+    @Override
+    public <T> RequestQueue<T> create() {
+        return new RequestQueue<T>() {
+
+            private final FluxProcessor<Object, Object> processor = processorSupplier.get();
+            private final FluxSink<Object> sink = processor.sink(overflowStrategy);
+
+            @Override
+            public void push(T request) {
+                sink.next(request);
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public Flux<T> requests() {
+                return (Flux<T>) processor; // Safe because elements can only be inserted via push(T)
+            }
+        };
+    }
+}

--- a/rest/src/main/java/discord4j/rest/request/RequestQueue.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestQueue.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.rest.request;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * Abstraction for a REST request queue.
+ *
+ * @param <T> the type of queue elements materializing the requests.
+ */
+public interface RequestQueue<T> {
+
+    /**
+     * Pushes a new request to the queue.
+     *
+     * @param request the request to push.
+     */
+    void push(T request);
+
+    /**
+     * Exposes a Flux that continuously emits requests available in queue.
+     *
+     * @return a Flux of requests.
+     */
+    Flux<T> requests();
+}

--- a/rest/src/main/java/discord4j/rest/request/RequestQueueFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestQueueFactory.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.rest.request;
+
+import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.FluxSink;
+
+import java.util.function.Supplier;
+
+/**
+ * Factory to create {@link RequestQueue} instances.
+ */
+public interface RequestQueueFactory {
+
+    /**
+     * Creates a new {@link RequestQueue} instance.
+     *
+     * @param <T> the desired generic type of {@link RequestQueue}
+     * @return the freshly instanciated {@link RequestQueue}
+     */
+    <T> RequestQueue<T> create();
+
+    /**
+     * Returns a factory of {@link RequestQueue} backed by a {@link FluxProcessor}.
+     *
+     * @param processorSupplier a Supplier that provides a processor. The Supplier <b>must</b> provide a new instance
+     *                          every time it is called, and the processor must not be pre-filled with any elements,
+     *                          otherwise it may lead to non-deterministic behavior.
+     * @param overflowStrategy  the overflow strategy to apply on the processor
+     * @return a {@link RequestQueueFactory} backed by a {@link FluxProcessor}
+     */
+    public static RequestQueueFactory backedByProcessor(Supplier<FluxProcessor<Object, Object>> processorSupplier,
+                                                        FluxSink.OverflowStrategy overflowStrategy) {
+        return new ProcessorRequestQueueFactory(processorSupplier, overflowStrategy);
+    }
+}


### PR DESCRIPTION
**Description:**

This PR exposes a `RequestQueue<T>` interface to add an abstraction level to the REST request queuing logic. Providing a custom queue implementation is done via a generic factory pattern and configurable via `RouterOptions`.

A single `RequestQueueFactory` object has the ability to create `RequestQueue<T>` instances of any type `T`. This magic is possible by placing the `<T>` on the `create()` method instead of the `RequestQueueFactory` class:

```java
public interface RequestQueueFactory {
    <T> RequestQueue<T> create();
}
```
It's then up to the implementor of this factory to guarantee that the create method works for any `T` without causing cast problems. The default implementation is `ProcessorRequestQueueFactory` which simply creates a queue backed by a custom `FluxProcessor`, that class is package-private but can be instantiated via `RequestQueueFactory#backedByProcessor(Supplier, OverflowStrategy)`.
It will still use `EmitterProcessor` with buffering strategy if no `RequestQueueFactory` is set.

**Justification:**

The default router uses an `EmitterProcessor` to queue requests on each REST bucket. Since this processor does not have a size limit, if the REST client gets stuck on a request for whatever reason (network congestion, outage), requests will keep queuing and may result in a `OutOfMemoryError` (it almost happened to me). It is currently not possible to provide a custom queue implementation and possibly use one that has bounded size.