### PR TITLE
Fix requests never completing when discarded by backpressure

### DIFF
--- a/rest/src/main/java/discord4j/rest/request/DiscardedRequestException.java
+++ b/rest/src/main/java/discord4j/rest/request/DiscardedRequestException.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.rest.request;
+
+/**
+ * Thrown when a REST request is discarded because of a queue overflow.
+ */
+public class DiscardedRequestException extends RuntimeException {
+    private static final long serialVersionUID = 304693810623154812L;
+
+    public DiscardedRequestException(DiscordRequest<?> request) {
+        super("Request discarded due to backpressure: " + request);
+    }
+}

--- a/rest/src/main/java/discord4j/rest/request/ProcessorRequestQueueFactory.java
+++ b/rest/src/main/java/discord4j/rest/request/ProcessorRequestQueueFactory.java
@@ -38,7 +38,7 @@ class ProcessorRequestQueueFactory implements RequestQueueFactory {
         return new RequestQueue<T>() {
 
             private final FluxProcessor<Object, Object> processor = processorSupplier.get();
-            private final FluxSink<Object> sink = processor.sink(overflowStrategy);
+            private final FluxSink<Object> sink = processor.sink(FluxSink.OverflowStrategy.BUFFER);
 
             @Override
             public void push(T request) {
@@ -48,7 +48,7 @@ class ProcessorRequestQueueFactory implements RequestQueueFactory {
             @SuppressWarnings("unchecked")
             @Override
             public Flux<T> requests() {
-                return (Flux<T>) processor; // Safe because elements can only be inserted via push(T)
+                return (Flux<T>) Flux.create(sink -> processor.subscribe(sink::next), overflowStrategy);
             }
         };
     }

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -138,8 +138,7 @@ class RequestStream<T> {
     }
 
     private void onDiscard(RequestCorrelation<?> requestCorrelation) {
-        requestCorrelation.getResponse().onComplete();
-        log.debug("Request completed early due to backpressure: {}", requestCorrelation.getRequest());
+        requestCorrelation.getResponse().onError(new DiscardedRequestException(requestCorrelation.getRequest()));
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -132,7 +132,14 @@ class RequestStream<T> {
     }
 
     void start() {
-        requestQueue.requests().subscribe(new RequestSubscriber(rateLimitStrategy));
+        requestQueue.requests()
+                .doOnDiscard(RequestCorrelation.class, this::onDiscard)
+                .subscribe(new RequestSubscriber(rateLimitStrategy));
+    }
+
+    private void onDiscard(RequestCorrelation<?> requestCorrelation) {
+        requestCorrelation.getResponse().onComplete();
+        log.debug("Request completed early due to backpressure: {}", requestCorrelation.getRequest());
     }
 
     /**


### PR DESCRIPTION
## Description

Added doOnDiscard operator to properly terminate the requests when they are discarded due to backpressure. I had to slightly change the implementation of processor request queue factory to make this operator work (basically I wrapped the processor in a `Flux.create` that drains the processor and forwards onNext signals to a sink that has access to the onDiscard callback, unlike the processor's own sink). When a request is discarded I made it so the response completes empty, but I wouldn't mind changing it to make it error with an exception, I'm open to discussion regarding this. 

## Justification

Currently there's a bug that causes REST requests to never complete if the request gets discarded by the overflow strategy. Talked with @quanticc about it on Discord and we had a hard time finding a solution, but I finally found one pretty simple. 

## Testing

I tested this bugfix by using a command bursting a lot of REST requests and setting a custom `RequestQueueFactory` with a very small queue size and different overflow strategies. Requests are now discarded properly. 