### PR TITLE
Fix rate limiter deadlock on high parallel load

### DIFF
--- a/common/src/main/java/discord4j/common/operator/RateLimitOperator.java
+++ b/common/src/main/java/discord4j/common/operator/RateLimitOperator.java
@@ -18,15 +18,20 @@
 package discord4j.common.operator;
 
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.logging.Level;
 
 /**
  * A rate limiting operator based off the token bucket algorithm. From
@@ -36,55 +41,61 @@ import java.util.function.Function;
  */
 public class RateLimitOperator<T> implements Function<Publisher<T>, Publisher<T>> {
 
+    private static final AtomicInteger ID_GENERATOR = new AtomicInteger();
+
+    private final int id;
+    private final Logger log;
     private final AtomicInteger tokens;
     private final Duration refillPeriod;
     private final Scheduler delayScheduler;
-    private final EmitterProcessor<Integer> tokenChanged;
+    private final ReplayProcessor<Integer> tokenChanged;
+    private final FluxSink<Integer> tokenChangedSink;
+    private final Scheduler tokenPublishScheduler;
 
     public RateLimitOperator(int capacity, Duration refillPeriod) {
         this(capacity, refillPeriod, Schedulers.parallel());
     }
 
     public RateLimitOperator(int capacity, Duration refillPeriod, Scheduler delayScheduler) {
+        this.id = ID_GENERATOR.incrementAndGet();
+        this.log = Loggers.getLogger("discord4j.limiter." + id);
         this.tokens = new AtomicInteger(capacity);
         this.refillPeriod = refillPeriod;
         this.delayScheduler = delayScheduler;
-        this.tokenChanged = EmitterProcessor.create(false);
-        tokenChanged.onNext(tokens.get());
+        this.tokenChanged = ReplayProcessor.cacheLastOrDefault(capacity);
+        this.tokenChangedSink = tokenChanged.sink(FluxSink.OverflowStrategy.LATEST);
+        this.tokenPublishScheduler = Schedulers.newSingle("d4j-limiter-" + id);
     }
 
     @Override
     public Publisher<T> apply(Publisher<T> source) {
-        if (source instanceof Mono) {
-            return Mono.from(source).flatMapMany(value -> availableTokens()
-                    .take(1)
-                    .map(token -> {
-                        acquire();
-                        Mono.delay(refillPeriod, delayScheduler).subscribe(__ -> release());
-                        return value;
-                    }));
-        } else if (source instanceof Flux) {
-            return Flux.from(source).flatMap(value -> availableTokens()
-                    .take(1)
-                    .map(token -> {
-                        acquire();
-                        Mono.delay(refillPeriod, delayScheduler).subscribe(__ -> release());
-                        return value;
-                    }));
-        } else {
-            throw new IllegalArgumentException("Unsupported publisher: " + source.getClass());
-        }
+        return Flux.from(source).flatMap(value -> availableTokens()
+                .take(1)
+                .log(log, Level.FINEST, false, SignalType.ON_SUBSCRIBE, SignalType.ON_NEXT)
+                .map(token -> {
+                    acquire();
+                    Mono.delay(refillPeriod, delayScheduler).subscribe(__ -> release());
+                    return value;
+                }));
     }
 
     private void acquire() {
-        tokenChanged.onNext(tokens.decrementAndGet());
+        int token = tokens.decrementAndGet();
+        if (log.isTraceEnabled()) {
+            log.trace("Acquired a token, {} tokens remaining", token);
+        }
+        tokenChangedSink.next(token);
     }
 
     private void release() {
-        tokenChanged.onNext(tokens.incrementAndGet());
+        int token = tokens.incrementAndGet();
+        if (log.isTraceEnabled()) {
+            log.trace("Released a token, {} tokens remaining", token);
+        }
+        tokenChangedSink.next(token);
     }
 
     private Flux<Integer> availableTokens() {
-        return tokenChanged.filter(__ -> tokens.get() > 0);
+        return tokenChanged.publishOn(tokenPublishScheduler).filter(__ -> tokens.get() > 0);
     }
 }

--- a/rest/src/main/java/discord4j/rest/request/BucketGlobalRateLimiter.java
+++ b/rest/src/main/java/discord4j/rest/request/BucketGlobalRateLimiter.java
@@ -35,7 +35,7 @@ public class BucketGlobalRateLimiter implements GlobalRateLimiter {
 
     private static final Logger log = Loggers.getLogger(BucketGlobalRateLimiter.class);
 
-    private final RateLimitOperator<?> operator;
+    private final RateLimitOperator<Integer> operator;
 
     private volatile long limitedUntil = 0;
 
@@ -77,18 +77,14 @@ public class BucketGlobalRateLimiter implements GlobalRateLimiter {
 
     @Override
     public <T> Flux<T> withLimiter(Publisher<T> stage) {
-        return Mono.fromCallable(this::getRemaining)
-                .transform(getRateLimitOperator())
+        return Mono.just(0)
+                .transform(operator)
+                .then(Mono.fromCallable(this::getRemaining))
                 .filter(delay -> delay.getSeconds() > 0)
                 .flatMapMany(delay -> {
                     log.trace("[{}] Delaying for {}", Integer.toHexString(hashCode()), delay);
                     return Mono.delay(delay).flatMapMany(tick -> Flux.from(stage));
                 })
                 .switchIfEmpty(stage);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> RateLimitOperator<T> getRateLimitOperator() {
-        return (RateLimitOperator<T>) operator;
     }
 }

--- a/rest/src/test/java/discord4j/rest/request/GlobalRateLimiterTest.java
+++ b/rest/src/test/java/discord4j/rest/request/GlobalRateLimiterTest.java
@@ -52,4 +52,12 @@ public class GlobalRateLimiterTest {
                 })))
                 .blockLast();
     }
+
+    @Test
+    public void testRateLimitOperator() {
+        GlobalRateLimiter grl = BucketGlobalRateLimiter.create();
+        Flux.range(0, 2000) // Test with 2000 concurrent requests
+                .flatMap(i -> grl.withLimiter(Mono.just(i)), 2000)
+                .blockLast();
+    }
 }

--- a/rest/src/test/resources/logback.xml
+++ b/rest/src/test/resources/logback.xml
@@ -7,6 +7,7 @@
     <!-- For tracing request stream tests -->
     <!--<logger name="discord4j.rest.request" level="TRACE"/>-->
     <!--<logger name="discord4j.rest.response" level="TRACE"/>-->
+    <logger name="discord4j.limiter" level="TRACE"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
## Description

Fixes a bug in the current implementation of `RateLimitOperator` that causes it to get stuck when acquiring/releasing a permit. It was caused by the processor not using a FluxSink, and was most likely triggered by the parallel scheduler being on high load (testing revealed that tokens were all published on the parallel scheduler).

This fix changes the processor implementation to `ReplayProcessor#cacheLastOrDefault` with LATEST overflow strategy, and publishes tokens on a dedicated single scheduler to relieve parallel scheduler while still properly handling concurrent requests.

`BucketGlobalRateLimiter` also had a minor fix by avoiding delaying the Duration object via this operator. It instead applies the operator on a placeholder value first, then it handles the `getRemaining()`, to be sure to process the latest Duration possible.

## Justification

The bug is quite serious and needs to be fixed. It required a lot of brainstorming and testing to come up with a stable and safe solution, and this is the best compromise I and @quanticc agreed on on Discord.