### PR TITLE
Forward-compatibility of Spec::asRequest by using Builder

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -473,7 +473,8 @@ public final class Message implements Entity {
     @Experimental
     public Mono<Void> suppressEmbeds(final boolean suppress) {
         return gateway.getRestClient().getChannelService()
-                .suppressEmbeds(getChannelId().asLong(), getId().asLong(), ImmutableSuppressEmbedsRequest.of(suppress));
+                .suppressEmbeds(getChannelId().asLong(), getId().asLong(),
+                        ImmutableSuppressEmbedsRequest.builder().suppress(suppress).build());
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/User.java
+++ b/core/src/main/java/discord4j/core/object/entity/User.java
@@ -213,7 +213,7 @@ public class User implements Entity {
      */
     public final Mono<PrivateChannel> getPrivateChannel() {
         return gateway.getRestClient().getUserService()
-                .createDM(ImmutableDMCreateRequest.of(Snowflake.asString(getId().asLong())))
+                .createDM(ImmutableDMCreateRequest.builder().recipientId(Snowflake.asString(getId().asLong())).build())
                 .map(data -> EntityUtil.getChannel(gateway, data))
                 .cast(PrivateChannel.class);
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildChannel.java
@@ -136,7 +136,12 @@ class BaseGuildChannel extends BaseChannel implements GuildChannel {
     public Mono<Void> addMemberOverwrite(Snowflake memberId, PermissionOverwrite overwrite, @Nullable String reason) {
         PermissionSet allow = overwrite.getAllowed();
         PermissionSet deny = overwrite.getDenied();
-        PermissionsEditRequest request = ImmutablePermissionsEditRequest.of(allow.getRawValue(), deny.getRawValue(), "member");
+        PermissionsEditRequest request = ImmutablePermissionsEditRequest
+                .builder()
+                .allow(allow.getRawValue())
+                .deny(deny.getRawValue())
+                .type("member")
+                .build();
 
         return getClient().getRestClient().getChannelService()
                 .editChannelPermissions(getId().asLong(), memberId.asLong(), request, reason);
@@ -146,7 +151,12 @@ class BaseGuildChannel extends BaseChannel implements GuildChannel {
     public Mono<Void> addRoleOverwrite(Snowflake roleId, PermissionOverwrite overwrite, @Nullable String reason) {
         PermissionSet allow = overwrite.getAllowed();
         PermissionSet deny = overwrite.getDenied();
-        PermissionsEditRequest request = ImmutablePermissionsEditRequest.of(allow.getRawValue(), deny.getRawValue(), "role");
+        PermissionsEditRequest request = ImmutablePermissionsEditRequest
+                .builder()
+                .allow(allow.getRawValue())
+                .deny(deny.getRawValue())
+                .type("role")
+                .build();
 
         return getClient().getRestClient().getChannelService()
                 .editChannelPermissions(getId().asLong(), roleId.asLong(), request, reason);

--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildMessageChannel.java
@@ -260,7 +260,7 @@ class BaseGuildMessageChannel extends BaseChannel implements GuildMessageChannel
                 .buffer(100) // REST accepts 100 IDs
                 .filterWhen(filterMessageIdChunk)
                 .flatMap(messageIdChunk -> getClient().getRestClient().getChannelService()
-                        .bulkDeleteMessages(getId().asLong(), ImmutableBulkDeleteRequest.of(messageIdChunk)))
+                        .bulkDeleteMessages(getId().asLong(), ImmutableBulkDeleteRequest.builder().messages(messageIdChunk).build()))
                 .thenMany(Flux.fromIterable(ignoredMessageIds));
     }
 

--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -34,19 +34,36 @@ import java.util.stream.Collectors;
 public class Activity {
 
     public static ActivityUpdateRequest playing(String name) {
-        return ImmutableActivityUpdateRequest.of(name, Type.PLAYING.getValue(), Optional.empty());
+        return ImmutableActivityUpdateRequest
+                .builder()
+                .name(name)
+                .type(Type.PLAYING.getValue())
+                .build();
     }
 
     public static ActivityUpdateRequest streaming(String name, String url) {
-        return ImmutableActivityUpdateRequest.of(name, Type.STREAMING.getValue(), Optional.of(url));
+        return ImmutableActivityUpdateRequest
+                .builder()
+                .name(name)
+                .type(Type.STREAMING.getValue())
+                .url(url)
+                .build();
     }
 
     public static ActivityUpdateRequest listening(String name) {
-        return ImmutableActivityUpdateRequest.of(name, Type.LISTENING.getValue(), Optional.empty());
+        return ImmutableActivityUpdateRequest
+                .builder()
+                .name(name)
+                .type(Type.LISTENING.getValue())
+                .build();
     }
 
     public static ActivityUpdateRequest watching(String name) {
-        return ImmutableActivityUpdateRequest.of(name, Type.WATCHING.getValue(), Optional.empty());
+        return ImmutableActivityUpdateRequest
+                .builder()
+                .name(name)
+                .type(Type.WATCHING.getValue())
+                .build();
     }
 
     private final ActivityData data;

--- a/core/src/main/java/discord4j/core/spec/CategoryEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/CategoryEditSpec.java
@@ -66,8 +66,12 @@ public class CategoryEditSpec implements AuditSpec<ChannelModifyRequest> {
      */
     public CategoryEditSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-            .map(o -> ImmutableOverwriteData.of(o.getTargetId().asString(), o.getType().getValue(),
-                o.getAllowed().getRawValue(), o.getDenied().getRawValue()))
+            .map(o -> ImmutableOverwriteData.builder()
+                    .id(o.getTargetId().asString())
+                    .type(o.getType().getValue())
+                    .allow(o.getAllowed().getRawValue())
+                    .deny(o.getDenied().getRawValue())
+                    .build())
             .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(Possible.of(raw));

--- a/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
@@ -153,12 +153,26 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
      * @return This spec.
      */
     public GuildCreateSpec addChannel(String name, Channel.Type type) {
-        channels.add(ImmutablePartialChannelCreateRequest.of(name, type.getValue()));
+        channels.add(ImmutablePartialChannelCreateRequest
+                .builder()
+                .name(name)
+                .type(type.getValue())
+                .build());
         return this;
     }
 
     @Override
     public GuildCreateRequest asRequest() {
-        return ImmutableGuildCreateRequest.of(name, region, icon, verificationLevel, defaultMessageNotificationLevel, explicitContentFilter, roles, channels);
+        return ImmutableGuildCreateRequest
+                .builder()
+                .name(name)
+                .region(region)
+                .icon(icon)
+                .verificationLevel(verificationLevel)
+                .defaultMessageNotifications(defaultMessageNotificationLevel)
+                .explicitContentFilter(explicitContentFilter)
+                .roles(roles)
+                .channels(channels)
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/GuildEmojiCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEmojiCreateSpec.java
@@ -86,6 +86,11 @@ public class GuildEmojiCreateSpec implements AuditSpec<GuildEmojiCreateRequest> 
 
     @Override
     public GuildEmojiCreateRequest asRequest() {
-        return ImmutableGuildEmojiCreateRequest.of(name, image, roles.stream().map(Snowflake::asString).collect(Collectors.toList()));
+        return ImmutableGuildEmojiCreateRequest
+                .builder()
+                .name(name)
+                .image(image)
+                .roles(roles.stream().map(Snowflake::asString).collect(Collectors.toList()))
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/GuildEmojiEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEmojiEditSpec.java
@@ -74,6 +74,10 @@ public class GuildEmojiEditSpec implements AuditSpec<GuildEmojiModifyRequest> {
 
     @Override
     public GuildEmojiModifyRequest asRequest() {
-        return ImmutableGuildEmojiModifyRequest.of(name, roles);
+        return ImmutableGuildEmojiModifyRequest
+                .builder()
+                .name(name)
+                .roles(roles)
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/InviteCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/InviteCreateSpec.java
@@ -97,6 +97,12 @@ public class InviteCreateSpec implements AuditSpec<InviteCreateRequest> {
 
     @Override
     public InviteCreateRequest asRequest() {
-        return ImmutableInviteCreateRequest.of(maxAge, maxUses, temporary, unique);
+        return ImmutableInviteCreateRequest
+                .builder()
+                .maxAge(maxAge)
+                .maxUses(maxUses)
+                .temporary(temporary)
+                .unique(unique)
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpec.java
@@ -82,6 +82,10 @@ public class MessageEditSpec implements Spec<MessageEditRequest> {
 
     @Override
     public MessageEditRequest asRequest() {
-        return ImmutableMessageEditRequest.of(content, embed, flags);
+        return ImmutableMessageEditRequest.builder()
+                .content(content)
+                .embed(embed)
+                .flags(flags)
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/UserEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/UserEditSpec.java
@@ -56,6 +56,9 @@ public class UserEditSpec implements Spec<UserModifyRequest> {
 
     @Override
     public UserModifyRequest asRequest() {
-        return ImmutableUserModifyRequest.of(username, avatar);
+        return ImmutableUserModifyRequest.builder()
+                .username(username)
+                .avatar(avatar)
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/WebhookCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookCreateSpec.java
@@ -71,6 +71,10 @@ public class WebhookCreateSpec implements AuditSpec<WebhookCreateRequest> {
 
     @Override
     public WebhookCreateRequest asRequest() {
-        return ImmutableWebhookCreateRequest.of(name, Optional.of(avatar));
+        return ImmutableWebhookCreateRequest
+                .builder()
+                .name(name)
+                .avatar(avatar)
+                .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/WebhookEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookEditSpec.java
@@ -83,6 +83,11 @@ public class WebhookEditSpec implements AuditSpec<WebhookModifyRequest> {
 
     @Override
     public WebhookModifyRequest asRequest() {
-        return ImmutableWebhookModifyRequest.of(name, avatar, channelId);
+        return ImmutableWebhookModifyRequest
+                .builder()
+                .name(name)
+                .avatar(avatar)
+                .channelId(channelId)
+                .build();
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -231,7 +231,7 @@ public class RestChannel {
                 .buffer(100) // REST accepts 100 IDs
                 .filterWhen(filterMessageIdChunk)
                 .flatMap(messageIdChunk -> restClient.getChannelService()
-                        .bulkDeleteMessages(id, ImmutableBulkDeleteRequest.of(messageIdChunk)))
+                        .bulkDeleteMessages(id, ImmutableBulkDeleteRequest.builder().messages(messageIdChunk).build()))
                 .thenMany(Flux.fromIterable(ignoredMessageIds));
     }
 

--- a/rest/src/main/java/discord4j/rest/entity/RestRole.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestRole.java
@@ -90,7 +90,10 @@ public class RestRole {
      * guild. If an error is received, it is emitted through the {@code Flux}.
      */
     public Flux<RoleData> changePosition(final int position) {
-        final PositionModifyRequest[] requests = {ImmutablePositionModifyRequest.of(Snowflake.asString(id), position)};
+        final PositionModifyRequest[] requests = {ImmutablePositionModifyRequest.builder()
+                .id(Snowflake.asString(id))
+                .position(position)
+                .build()};
         return restClient.getGuildService().modifyGuildRolePositions(guildId, requests);
     }
 

--- a/rest/src/main/java/discord4j/rest/entity/RestUser.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestUser.java
@@ -53,6 +53,6 @@ public class RestUser {
      * this user. If an error is received, it is emitted through the {@code Mono}.
      */
     public final Mono<ChannelData> getPrivateChannel() {
-        return restClient.getUserService().createDM(ImmutableDMCreateRequest.of(Snowflake.asString(id)));
+        return restClient.getUserService().createDM(ImmutableDMCreateRequest.builder().recipientId(Snowflake.asString(id)).build());
     }
 }

--- a/rest/src/test/java/discord4j/rest/service/ChannelServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/ChannelServiceTest.java
@@ -209,7 +209,12 @@ public class ChannelServiceTest {
 
     @Test
     public void testEditChannelPermissions() {
-        PermissionsEditRequest req = ImmutablePermissionsEditRequest.of(0, 0, "member");
+        PermissionsEditRequest req = ImmutablePermissionsEditRequest
+                .builder()
+                .allow(0)
+                .deny(0)
+                .type("member")
+                .build();
         getChannelService().editChannelPermissions(modifyChannel, permanentOverwrite, req, null).block();
     }
 
@@ -220,7 +225,13 @@ public class ChannelServiceTest {
 
     @Test
     public void testCreateChannelInvite() {
-        InviteCreateRequest req = ImmutableInviteCreateRequest.of(1, 0, true, true);
+        InviteCreateRequest req = ImmutableInviteCreateRequest
+                .builder()
+                .maxAge(1)
+                .maxUses(0)
+                .temporary(true)
+                .unique(true)
+                .build();
         getChannelService().createChannelInvite(modifyChannel, req, null).block();
     }
 

--- a/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
@@ -93,7 +93,7 @@ public class UserServiceTest {
 
     @Test
     public void testCreateDM() {
-        DMCreateRequest req = ImmutableDMCreateRequest.of(Long.toUnsignedString(user));
+        DMCreateRequest req = ImmutableDMCreateRequest.builder().recipientId(Long.toUnsignedString(user)).build();
         getUserService().createDM(req).block();
     }
 


### PR DESCRIPTION
**Description:** Use Builder inside Spec::asRequest for forward-compatibility.

**Justification:** Fix https://github.com/Discord4J/Discord4J/issues/652