### PR TITLE
Make FallbackEntityRetriever public

### DIFF
--- a/core/src/main/java/discord4j/core/retriever/FallbackEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/FallbackEntityRetriever.java
@@ -28,12 +28,12 @@ import discord4j.rest.util.Snowflake;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-class FallbackEntityRetriever implements EntityRetriever {
+public class FallbackEntityRetriever implements EntityRetriever {
 
     private final EntityRetriever first;
     private final EntityRetriever fallback;
 
-    FallbackEntityRetriever(EntityRetriever first, EntityRetriever fallback) {
+    public FallbackEntityRetriever(EntityRetriever first, EntityRetriever fallback) {
         this.first = first;
         this.fallback = fallback;
     }


### PR DESCRIPTION
**Description:** Make FallbackEntityRetriever class and constructor public.

**Justification:** This is useful if we want to create a custom entity retriever strategy using the already-defined FallbackEntityRetriever.