### PR TITLE
Add MemberRequestFilter to control member loading

### DIFF
--- a/core/src/main/java/discord4j/core/GatewayResources.java
+++ b/core/src/main/java/discord4j/core/GatewayResources.java
@@ -20,6 +20,7 @@ package discord4j.core;
 import discord4j.common.retry.ReconnectOptions;
 import discord4j.core.event.EventDispatcher;
 import discord4j.core.event.domain.Event;
+import discord4j.core.shard.MemberRequestFilter;
 import discord4j.core.shard.ShardCoordinator;
 import discord4j.core.state.StateHolder;
 import discord4j.core.state.StateView;
@@ -36,7 +37,7 @@ public class GatewayResources {
     private final StateView stateView;
     private final EventDispatcher eventDispatcher;
     private final ShardCoordinator shardCoordinator;
-    private final boolean memberRequest;
+    private final MemberRequestFilter memberRequestFilter;
     private final GatewayReactorResources gatewayReactorResources;
     private final VoiceReactorResources voiceReactorResources;
     private final ReconnectOptions voiceReconnectOptions;
@@ -47,20 +48,20 @@ public class GatewayResources {
      * @param stateView a read-only facade for an entity cache based off {@link StateHolder}
      * @param eventDispatcher an event bus dedicated to distribute {@link Event} instances
      * @param shardCoordinator a middleware component to coordinate multiple shard-connecting efforts
-     * @param memberRequest whether to enable large guild member requests from the Gateway (chunking)
+     * @param memberRequestFilter a strategy to determine whether guild members should be requested
      * @param gatewayReactorResources a custom set of Reactor resources targeting Gateway operations
      * @param voiceReactorResources a set of Reactor resources targeting Voice Gateway operations
      * @param voiceReconnectOptions a reconnection policy for Voice Gateway connections
      */
     public GatewayResources(StateView stateView, EventDispatcher eventDispatcher,
-                            ShardCoordinator shardCoordinator, boolean memberRequest,
+                            ShardCoordinator shardCoordinator, MemberRequestFilter memberRequestFilter,
                             GatewayReactorResources gatewayReactorResources,
                             VoiceReactorResources voiceReactorResources,
                             ReconnectOptions voiceReconnectOptions) {
         this.stateView = stateView;
         this.eventDispatcher = eventDispatcher;
         this.shardCoordinator = shardCoordinator;
-        this.memberRequest = memberRequest;
+        this.memberRequestFilter = memberRequestFilter;
         this.gatewayReactorResources = gatewayReactorResources;
         this.voiceReactorResources = voiceReactorResources;
         this.voiceReconnectOptions = voiceReconnectOptions;
@@ -98,12 +99,24 @@ public class GatewayResources {
     }
 
     /**
+     * Return a {@link MemberRequestFilter} indicating whether this shard group should be requesting guild members.
+     *
+     * @return the {@link MemberRequestFilter} configured in this {@link GatewayResources}
+     */
+    public MemberRequestFilter getMemberRequestFilter() {
+        return memberRequestFilter;
+    }
+
+    /**
      * Return whether the Gateway should be instructed to request guild members for large guilds.
      *
-     * @return {@code true} if enabled, {@code false} otherwise
+     * @return {@code true} if using the default (enabled for large guilds), {@code false} otherwise
+     * @deprecated this method only returns {@code true} if using {@link MemberRequestFilter#DEFAULT}. Use
+     * {@link #getMemberRequestFilter()}
      */
+    @Deprecated
     public boolean isMemberRequest() {
-        return memberRequest;
+        return memberRequestFilter == MemberRequestFilter.DEFAULT;
     }
 
     /**

--- a/core/src/main/java/discord4j/core/shard/MemberRequestFilter.java
+++ b/core/src/main/java/discord4j/core/shard/MemberRequestFilter.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.shard;
+
+import discord4j.discordjson.json.GuildCreateData;
+import discord4j.rest.util.Snowflake;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+/**
+ * A filter to customize the guild member request strategy. Applied on each GUILD_CREATE returning a potentially
+ * delayed {@link Mono} that, if containing {@code true}, guild members should be requested.
+ */
+@FunctionalInterface
+public interface MemberRequestFilter {
+
+    /**
+     * Request members from all large guilds.
+     */
+    MemberRequestFilter DEFAULT = withLargeGuilds();
+
+    /**
+     * Request members from all guilds.
+     *
+     * @return a {@link MemberRequestFilter} requesting members from all guilds
+     */
+    static MemberRequestFilter all() {
+        return data -> Mono.just(true);
+    }
+
+    /**
+     * Do not request guild members.
+     *
+     * @return a {@link MemberRequestFilter} not requesting any member
+     */
+    static MemberRequestFilter none() {
+        return data -> Mono.just(false);
+    }
+
+    /**
+     * Request members from large guilds.
+     *
+     * @return a {@link MemberRequestFilter} requesting members from large guilds
+     */
+    static MemberRequestFilter withLargeGuilds() {
+        return data -> Mono.just(data.large());
+    }
+
+    /**
+     * Request guild members for the given guild {@link Snowflake} IDs.
+     *
+     * @return a {@link MemberRequestFilter} requesting members from the given guilds
+     */
+    static MemberRequestFilter withGuilds(Snowflake... guildIds) {
+        return data -> Flux.fromArray(guildIds).hasElement(Snowflake.of(data.id()));
+    }
+
+    /**
+     * Obtain a {@link Mono} of {@link Boolean} for the given {@link GuildCreateData}. If the resulting sequence
+     * contains {@code true}, then members will be requested through the Gateway for this guild.
+     *
+     * @param guildCreateData the guild triggering this filter
+     * @return a {@link Mono} indicating if a guild should have their members requested
+     */
+    Mono<Boolean> apply(GuildCreateData guildCreateData);
+
+    /**
+     * Transform this current {@link MemberRequestFilter} by applying the given {@link Function} to derive a new
+     * {@link Mono} of {@code boolean}.
+     *
+     * @param transformer the function to transform this {@link MemberRequestFilter}
+     * @return a transformed {@link MemberRequestFilter}
+     */
+    default MemberRequestFilter as(Function<Mono<Boolean>, Mono<Boolean>> transformer) {
+        return data -> apply(data).as(transformer);
+    }
+}


### PR DESCRIPTION
**Description:** Initial work to resolve issues described in #660. Provide API to customize the member request behavior.

Example usage:

```java
DiscordClient.create(System.getenv("token"))
        .gateway()
        .setMemberRequestFilter(MemberRequestFilter.all().as(m -> m.delayElement(Duration.ofSeconds(10))))
        .login().block();
```

The idea @danthonywalker had is to make this filter return `Mono` so users can inject a delay or perform any kind of async logic.

**Justification:** Looking for ways to mitigate members not being sent under some intent configurations. Covering said ticket entirely is not a goal of this PR.