### PR TITLE
Fix support for VoiceState.getGuildId; closes #658

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -166,17 +166,8 @@ class GuildDispatchHandlers {
     
     private static VoiceStateData wrapVoiceState(VoiceStateData voiceState, String guildId) {
     	return ImmutableVoiceStateData.builder()
+    			.from(voiceState)
     			.guildId(Possible.of(guildId))
-    			.channelId(voiceState.channelId())
-    			.userId(voiceState.userId())
-    			.member(voiceState.member())
-    			.sessionId(voiceState.sessionId())
-    			.deaf(voiceState.deaf())
-    			.mute(voiceState.mute())
-    			.selfDeaf(voiceState.selfDeaf())
-    			.selfMute(voiceState.selfMute())
-    			.selfStream(voiceState.selfStream())
-    			.suppress(voiceState.suppress())
     			.build();
     }
 

--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -119,7 +119,7 @@ class GuildDispatchHandlers {
         Mono<Void> saveVoiceStates = context.getStateHolder().getVoiceStateStore()
                 .save(Flux.fromIterable(createData.voiceStates())
                         .map(voiceState -> Tuples.of(LongLongTuple2.of(guildId,
-                                Snowflake.asLong(voiceState.userId())), voiceState)));
+                                Snowflake.asLong(voiceState.userId())), wrapVoiceState(voiceState, guild.id()))));
 
         Mono<Void> savePresences = context.getStateHolder().getPresenceStore()
                 .save(Flux.fromIterable(createData.presences())
@@ -162,6 +162,22 @@ class GuildDispatchHandlers {
                 .and(saveOfflinePresences)
                 .and(startMemberChunk)
                 .thenReturn(new GuildCreateEvent(gateway, context.getShardInfo(), new Guild(gateway, guild)));
+    }
+    
+    private static VoiceStateData wrapVoiceState(VoiceStateData voiceState, String guildId) {
+    	return ImmutableVoiceStateData.builder()
+    			.guildId(Possible.of(guildId))
+    			.channelId(voiceState.channelId())
+    			.userId(voiceState.userId())
+    			.member(voiceState.member())
+    			.sessionId(voiceState.sessionId())
+    			.deaf(voiceState.deaf())
+    			.mute(voiceState.mute())
+    			.selfDeaf(voiceState.selfDeaf())
+    			.selfMute(voiceState.selfMute())
+    			.selfStream(voiceState.selfStream())
+    			.suppress(voiceState.suppress())
+    			.build();
     }
 
     private static PresenceData createPresence(MemberData member) {

--- a/core/src/test/java/discord4j/core/support/VoiceSupport.java
+++ b/core/src/test/java/discord4j/core/support/VoiceSupport.java
@@ -15,6 +15,8 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.message.MessageCreateEvent;
 import discord4j.core.object.VoiceState;
 import discord4j.core.object.entity.Member;
+import discord4j.discordjson.json.ImmutableMessageCreateRequest;
+import discord4j.discordjson.possible.Possible;
 import discord4j.voice.AudioProvider;
 import reactor.core.publisher.Mono;
 import reactor.util.Logger;
@@ -77,8 +79,18 @@ public class VoiceSupport {
                 .filter(e -> e.getMessage().getContent().equals("!stop"))
                 .doOnNext(e -> player.stopTrack())
                 .then();
+        
+        Mono<Void> cguild = client.getEventDispatcher().on(MessageCreateEvent.class)
+                .filter(e -> e.getMessage().getContent().equals("!vcguild"))
+                .flatMap(e -> Mono.justOrEmpty(e.getMember())
+                        .flatMap(Member::getVoiceState)
+                        .flatMap(vs->e.getMessage().getRestChannel().createMessage(
+                        		ImmutableMessageCreateRequest.builder()
+                                		.content(Possible.of(vs.getGuildId().asString()))
+                                		.build())))
+                .then();
 
-        return Mono.zip(join, play, stop).then();
+        return Mono.zip(join, play, stop, cguild).then();
     }
 
     private static class LavaplayerAudioProvider extends AudioProvider {


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** This PR wraps generated VoiceStateData objects created on a guild create event in such a way that said objects will contain the guild id from the primary event.

**Justification:** Getting the Guild ID from a pre-existing voice state no longer throws an exception. This pull request fixes #658 