### PR TITLE
NoOp DispatchEventMapper

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchEventMapper.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchEventMapper.java
@@ -66,4 +66,18 @@ public interface DispatchEventMapper {
             }
         };
     }
+
+    /**
+     * Create a {@link DispatchEventMapper} that doesn't process any dispatches
+     *
+     * @return a {@link DispatchEventMapper} that does nothing
+     */
+    static DispatchEventMapper noOp() {
+        return new DispatchEventMapper() {
+            @Override
+            public <D, E extends Event> Mono<E> handle(DispatchContext<D> context) {
+                return Mono.empty();
+            }
+        };
+    }
 }


### PR DESCRIPTION
**Description:** Added a NoOp DispatchEventMapper as default implementation, this EventMapper doesn't do any JSON serialization and saves tons of performance on gateway-level when **NO** event processing is required.

**Justification:** Performance issues on gateway level