### PR TITLE
Add `getSelfMember()` to Guild and RestGuild classes

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -721,6 +721,16 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Requests to retrieve the member as represented by the bot user's ID.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Member} as represented by the bot
+     * user's ID. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Member> getSelfMember() {
+        return gateway.getSelfId().flatMap(this::getMemberById);
+    }
+
+    /**
      * Requests to retrieve the guild's channels.
      * <p>
      * The order of items emitted by the returned {@code Flux} is unspecified. Use

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -83,16 +83,23 @@ public class RestGuild {
 
     public Flux<RoleData> modifyChannelPositions(List<PositionModifyRequest> requests) {
         return restClient.getGuildService()
-                .modifyGuildChannelPositions(id, requests.toArray(new PositionModifyRequest[0]));
+            .modifyGuildChannelPositions(id, requests.toArray(new PositionModifyRequest[0]));
     }
 
     public Mono<MemberData> getMember(long userId) {
         return restClient.getGuildService().getGuildMember(id, userId);
     }
 
+    public Mono<MemberData> getSelfMember() {
+        return restClient.getSelf()
+            .map(UserData::id)
+            .map(Long::parseLong)
+            .flatMap(this::getMember);
+    }
+
     public Flux<MemberData> getMembers() {
         Function<Map<String, Object>, Flux<MemberData>> doRequest =
-                params -> restClient.getGuildService().getGuildMembers(id, params);
+            params -> restClient.getGuildService().getGuildMembers(id, params);
         return PaginationUtil.paginateAfter(doRequest, data -> Snowflake.asLong(data.user().id()), 0, 100);
     }
 


### PR DESCRIPTION
Add `getSelfMember()` to Guild and RestGuild classes. 

This provides an easier and clearer way of getting the bot user's Member  and MemberData from a guild or RestGuild entity respectively. 