### PR TITLE
Update MemberChunkEvent fields

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -370,8 +370,8 @@ class GuildDispatchHandlers {
         GatewayDiscordClient gateway = context.getGateway();
         long guildId = Snowflake.asLong(context.getDispatch().guildId());
         List<MemberData> members = context.getDispatch().members();
-        int chunkIndex = context.getDispatch().getChunkIndex();
-        int chunkCount = context.getDispatch().getChunkCount();
+        int chunkIndex = context.getDispatch().chunkIndex();
+        int chunkCount = context.getDispatch().chunkCount();
         List<Snowflake> notFound = context.getDispatch().notFound()
                 .toOptional()
                 .orElse(Collections.emptyList())

--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -378,6 +378,7 @@ class GuildDispatchHandlers {
                 .stream()
                 .map(Snowflake::of)
                 .collect(Collectors.toList());
+        String nonce = context.getDispatch().nonce().toOptional().orElse(null);
 
         Flux<Tuple2<LongLongTuple2, MemberData>> memberPairs = Flux.fromIterable(members)
                 .map(data -> Tuples.of(LongLongTuple2.of(guildId, Snowflake.asLong(data.user().id())),
@@ -418,7 +419,7 @@ class GuildDispatchHandlers {
                         members.stream()
                                 .map(member -> new Member(gateway, member, guildId))
                                 .collect(Collectors.toSet()),
-                        chunkIndex, chunkCount, notFound));
+                        chunkIndex, chunkCount, notFound, nonce));
     }
 
     static Mono<MemberUpdateEvent> guildMemberUpdate(DispatchContext<GuildMemberUpdate> context) {

--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -370,6 +370,14 @@ class GuildDispatchHandlers {
         GatewayDiscordClient gateway = context.getGateway();
         long guildId = Snowflake.asLong(context.getDispatch().guildId());
         List<MemberData> members = context.getDispatch().members();
+        int chunkIndex = context.getDispatch().getChunkIndex();
+        int chunkCount = context.getDispatch().getChunkCount();
+        List<Snowflake> notFound = context.getDispatch().notFound()
+                .toOptional()
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(Snowflake::of)
+                .collect(Collectors.toList());
 
         Flux<Tuple2<LongLongTuple2, MemberData>> memberPairs = Flux.fromIterable(members)
                 .map(data -> Tuples.of(LongLongTuple2.of(guildId, Snowflake.asLong(data.user().id())),
@@ -409,7 +417,8 @@ class GuildDispatchHandlers {
                 .thenReturn(new MemberChunkEvent(gateway, context.getShardInfo(), guildId,
                         members.stream()
                                 .map(member -> new Member(gateway, member, guildId))
-                                .collect(Collectors.toSet())));
+                                .collect(Collectors.toSet()),
+                        chunkIndex, chunkCount, notFound));
     }
 
     static Mono<MemberUpdateEvent> guildMemberUpdate(DispatchContext<GuildMemberUpdate> context) {

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
@@ -23,6 +23,7 @@ import discord4j.rest.util.Snowflake;
 import discord4j.gateway.ShardInfo;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -38,11 +39,18 @@ public class MemberChunkEvent extends GuildEvent {
 
     private final long guildId;
     private final Set<Member> members;
+    private final int chunkIndex;
+    private final int chunkCount;
+    private final List<Snowflake> notFound;
 
-    public MemberChunkEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long guildId, Set<Member> members) {
+    public MemberChunkEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long guildId, Set<Member> members,
+                            int chunkIndex, int chunkCount, List<Snowflake> notFound) {
         super(gateway, shardInfo);
         this.guildId = guildId;
         this.members = members;
+        this.chunkIndex = chunkIndex;
+        this.chunkCount = chunkCount;
+        this.notFound = notFound;
     }
 
     /**
@@ -74,11 +82,41 @@ public class MemberChunkEvent extends GuildEvent {
         return members;
     }
 
+    /**
+     * Gets the chunk index in the expected chunks for this response (0 <= chunk_index < chunk_count).
+     *
+     * @return The chunk index in the expected chunks for this response (0 <= chunk_index < chunk_count).
+     */
+    public int getChunkIndex() {
+        return chunkIndex;
+    }
+
+    /**
+     * Gets the total number of expected chunks for this response.
+     *
+     * @return The total number of expected chunks for this response.
+     */
+    public int getChunkCount() {
+        return chunkCount;
+    }
+
+    /**
+     * Gets invalid id passed to `REQUEST_GUILD_MEMBERS`, if any.
+     *
+     * @return Gets invalid id passed to `REQUEST_GUILD_MEMBERS`, if any.
+     */
+    public List<Snowflake> getNotFound() {
+        return notFound;
+    }
+
     @Override
     public String toString() {
         return "MemberChunkEvent{" +
                 "guildId=" + guildId +
                 ", members=" + members +
+                ", chunkIndex=" + chunkIndex +
+                ", chunkCount=" + chunkCount +
+                ", notFound=" + notFound +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
@@ -22,8 +22,10 @@ import discord4j.core.object.entity.Member;
 import discord4j.rest.util.Snowflake;
 import discord4j.gateway.ShardInfo;
 import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -42,15 +44,18 @@ public class MemberChunkEvent extends GuildEvent {
     private final int chunkIndex;
     private final int chunkCount;
     private final List<Snowflake> notFound;
+    @Nullable
+    private final String nonce;
 
     public MemberChunkEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long guildId, Set<Member> members,
-                            int chunkIndex, int chunkCount, List<Snowflake> notFound) {
+                            int chunkIndex, int chunkCount, List<Snowflake> notFound, @Nullable String nonce) {
         super(gateway, shardInfo);
         this.guildId = guildId;
         this.members = members;
         this.chunkIndex = chunkIndex;
         this.chunkCount = chunkCount;
         this.notFound = notFound;
+        this.nonce = nonce;
     }
 
     /**
@@ -107,6 +112,15 @@ public class MemberChunkEvent extends GuildEvent {
      */
     public List<Snowflake> getNotFound() {
         return notFound;
+    }
+
+    /**
+     * Gets the nonce used in the Guild Members Request, if present.
+     *
+     * @return The nonce used in the Guild Members Request, if present.
+     */
+    public Optional<String> getNonce() {
+        return Optional.ofNullable(nonce);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberChunkEvent.java
@@ -131,6 +131,7 @@ public class MemberChunkEvent extends GuildEvent {
                 ", chunkIndex=" + chunkIndex +
                 ", chunkCount=" + chunkCount +
                 ", notFound=" + notFound +
+                ", nonce='" + nonce + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:** 
- Adds `chunk_index` field
- Adds `chunk_count` field
- Adds `not_found` field
- Adds `nonce` field

**Justification:** 
https://github.com/discord/discord-api-docs/pull/1545
https://github.com/discord/discord-api-docs/pull/1549