### PR TITLE
Adds configurable timeout to VoiceChannelJoinSpec

### DIFF
--- a/core/src/main/java/discord4j/core/spec/VoiceChannelJoinSpec.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelJoinSpec.java
@@ -133,7 +133,8 @@ public class VoiceChannelJoinSpec implements Spec<Mono<VoiceConnection>> {
 
     /**
      * Sets the maximum amount of time to wait before the connection to the voice channel timeouts.
-     * For example, the connection may get stuck when the bot does not have {@link discord4j.rest.util.Permission.VIEW_CHANNEL}.
+     * For example, the connection may get stuck when the bot does not have {@link discord4j.rest.util.Permission.VIEW_CHANNEL} or
+     * when the voice channel is full.
      * The default value is {@value #DEFAULT_TIMEOUT} seconds.
      *
      * @param timeout The maximum amount of time to wait before the connection to the voice channel timeouts.


### PR DESCRIPTION
**Description:** Adds a configurable timeout to the join voice channel request. It is needed to ensure that the request does not get stuck indefinitively when the bot tries to join a voice channel without the `Permission.VIEW_CHANNEL` permission.
It could be interesting to add a note in the `VoiceChannel#join` method to mention that the method can throw a `TimeoutException`.

These changes can be tested using the following code:
```java
final GatewayDiscordClient client = DiscordClient.builder("token")
        .build()
        .login()
        .block();

client.getEventDispatcher()
        .on(MessageCreateEvent.class)
        .filter(event -> event.getMessage().getContent().startsWith("!join"))
        .flatMap(event -> client.getChannelById(Snowflake.of("voice-channel-id"))
                .cast(VoiceChannel.class)
                .flatMap(channel -> channel.join(spec -> spec
                        .setTimeoutDuration(Duration.ofSeconds(Integer.parseInt(event.getMessage().getContent().split(" ")[1]))))))
        .subscribe(null, Throwable::printStackTrace);

client.onDisconnect().block();
```

Sending `!join X` will join the specific voice channel with a X seconds timeout.

Edit: 
Quoting the documentation `Bot users respect the voice channel's user limit, if set. When the voice channel is full, you will not receive the Voice State Update or Voice Server Update events in response to your own Voice State Update. Having MANAGE_CHANNELS permission bypasses this limit and allows you to join regardless of the channel being full or not.` 
So, this timeout will also be useful to avoid getting stuck when the voice channel user limit has been reached.

**Justification:** Fixes https://github.com/Discord4J/Discord4J/issues/638