### PR TITLE
Lazy-Loading of DispatchData unless it is actually needed

### DIFF
--- a/core/src/main/java/discord4j/core/GatewayDiscordClient.java
+++ b/core/src/main/java/discord4j/core/GatewayDiscordClient.java
@@ -41,6 +41,7 @@ import discord4j.discordjson.json.RoleData;
 import discord4j.discordjson.json.gateway.GuildMembersChunk;
 import discord4j.discordjson.json.gateway.RequestGuildMembers;
 import discord4j.discordjson.json.gateway.StatusUpdate;
+import discord4j.gateway.LazyDispatch;
 import discord4j.gateway.GatewayClient;
 import discord4j.gateway.GatewayClientGroup;
 import discord4j.gateway.json.GatewayPayload;
@@ -474,6 +475,7 @@ public class GatewayDiscordClient implements EntityRetriever {
         String nonce = String.valueOf(System.nanoTime());
         Supplier<Flux<Member>> incomingMembers = () -> gatewayClientGroup.find(shardId)
                 .map(gatewayClient -> gatewayClient.dispatch()
+                        .map(LazyDispatch::getData)
                         .ofType(GuildMembersChunk.class)
                         .takeUntilOther(closeProcessor)
                         .filter(chunk -> chunk.nonce().toOptional()

--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchContext.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchContext.java
@@ -19,6 +19,8 @@ package discord4j.core.event.dispatch;
 
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.state.StateHolder;
+import discord4j.discordjson.json.gateway.PayloadData;
+import discord4j.gateway.LazyDispatch;
 import discord4j.gateway.ShardInfo;
 
 /**
@@ -27,19 +29,24 @@ import discord4j.gateway.ShardInfo;
  *
  * @param <D> The type of the payload.
  */
-public class DispatchContext<D> {
+public class DispatchContext<D extends PayloadData> {
 
-    private final D dispatch;
+    private final LazyDispatch<D> dispatch;
     private final GatewayDiscordClient gateway;
     private final StateHolder stateHolder;
     private final ShardInfo shardInfo;
 
-    public static <D> DispatchContext<D> of(D dispatch, GatewayDiscordClient gateway,
-                                            StateHolder stateHolder, ShardInfo shardInfo) {
+    public static <D extends PayloadData> DispatchContext<D> of(LazyDispatch<D> dispatch, GatewayDiscordClient gateway,
+                                                                StateHolder stateHolder, ShardInfo shardInfo) {
         return new DispatchContext<>(dispatch, gateway, stateHolder, shardInfo);
     }
 
-    private DispatchContext(D dispatch, GatewayDiscordClient gateway, StateHolder stateHolder, ShardInfo shardInfo) {
+    public static <D extends PayloadData> DispatchContext<D> of(D dispatch, GatewayDiscordClient gateway,
+                                                                StateHolder stateHolder, ShardInfo shardInfo) {
+        return new DispatchContext<>(new LazyDispatch<>(null, dispatch), gateway, stateHolder, shardInfo);
+    }
+
+    private DispatchContext(LazyDispatch<D> dispatch, GatewayDiscordClient gateway, StateHolder stateHolder, ShardInfo shardInfo) {
         this.dispatch = dispatch;
         this.gateway = gateway;
         this.stateHolder = stateHolder;
@@ -47,7 +54,7 @@ public class DispatchContext<D> {
     }
 
     public D getDispatch() {
-        return dispatch;
+        return dispatch.getData();
     }
 
     public GatewayDiscordClient getGateway() {

--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchEventMapper.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchEventMapper.java
@@ -19,6 +19,7 @@ package discord4j.core.event.dispatch;
 
 import discord4j.common.annotations.Experimental;
 import discord4j.core.event.domain.Event;
+import discord4j.discordjson.json.gateway.PayloadData;
 import discord4j.store.api.Store;
 import reactor.core.publisher.Mono;
 
@@ -38,7 +39,7 @@ public interface DispatchEventMapper {
      * @return a {@link Mono} of {@link Event} mapped from the given {@link DispatchContext} object, or empty if no
      * Event is produced. If an error occurs during processing, it is emitted through the {@code Mono}.
      */
-    <D, E extends Event> Mono<E> handle(DispatchContext<D> context);
+    <D extends PayloadData, E extends Event> Mono<E> handle(DispatchContext<D> context);
 
     /**
      * Create a {@link DispatchEventMapper} that processes updates and records them into the right {@link Store},
@@ -60,7 +61,7 @@ public interface DispatchEventMapper {
         DispatchHandlers handlers = new DispatchHandlers();
         return new DispatchEventMapper() {
             @Override
-            public <D, E extends Event> Mono<E> handle(DispatchContext<D> context) {
+            public <D extends PayloadData, E extends Event> Mono<E> handle(DispatchContext<D> context) {
                 // TODO improve DispatchHandlers to avoid creating Event objects to then discard here
                 return handlers.handle(context).then(Mono.empty());
             }
@@ -75,7 +76,7 @@ public interface DispatchEventMapper {
     static DispatchEventMapper noOp() {
         return new DispatchEventMapper() {
             @Override
-            public <D, E extends Event> Mono<E> handle(DispatchContext<D> context) {
+            public <D extends PayloadData, E extends Event> Mono<E> handle(DispatchContext<D> context) {
                 return Mono.empty();
             }
         };

--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchHandler.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchHandler.java
@@ -18,6 +18,7 @@
 package discord4j.core.event.dispatch;
 
 import discord4j.core.event.domain.Event;
+import discord4j.discordjson.json.gateway.PayloadData;
 import reactor.core.publisher.Mono;
 
 /**
@@ -27,7 +28,7 @@ import reactor.core.publisher.Mono;
  * @param <E> the outbound Event type
  */
 @FunctionalInterface
-public interface DispatchHandler<D, E extends Event> {
+public interface DispatchHandler<D extends PayloadData, E extends Event> {
 
     /**
      * Operates and transforms a Dispatch event with its context, from gateway to user-friendly Events, so it may be

--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
@@ -94,7 +94,7 @@ public class DispatchHandlers implements DispatchEventMapper {
         addHandler(GatewayStateChange.class, LifecycleDispatchHandlers::gatewayStateChanged);
     }
 
-    private static <D, E extends Event> void addHandler(Class<D> dispatchType,
+    private static <D extends PayloadData, E extends Event> void addHandler(Class<D> dispatchType,
                                                         DispatchHandler<D, E> dispatchHandler) {
         handlerMap.put(dispatchType, dispatchHandler);
     }
@@ -110,7 +110,7 @@ public class DispatchHandlers implements DispatchEventMapper {
      * @return an Event mapped from the given Dispatch object, or null if no Event is produced.
      */
     @SuppressWarnings("unchecked")
-    public <D, E extends Event> Mono<E> handle(DispatchContext<D> context) {
+    public <D extends PayloadData, E extends Event> Mono<E> handle(DispatchContext<D> context) {
         DispatchHandler<D, E> handler = (DispatchHandler<D, E>) handlerMap.entrySet()
                 .stream()
                 .filter(entry -> entry.getKey().isAssignableFrom(context.getDispatch().getClass()))

--- a/core/src/main/java/discord4j/core/shard/GatewayBootstrap.java
+++ b/core/src/main/java/discord4j/core/shard/GatewayBootstrap.java
@@ -777,7 +777,7 @@ public class GatewayBootstrap<O extends GatewayOptions> {
                                 if (dispatch.isShardAware()) {
                                     ShardAwareDispatch shardDispatch = (ShardAwareDispatch) dispatch.getData();
                                     info = new ShardInfo(shardDispatch.getShardIndex(), shardDispatch.getShardCount());
-                                    actual = new LazyDispatch(null, shardDispatch.getDispatch());
+                                    actual = new LazyDispatch<>(null, shardDispatch.getDispatch());
                                 } else {
                                     info = shard;
                                     actual = dispatch;

--- a/core/src/main/java/discord4j/core/shard/SingleGatewayClientGroup.java
+++ b/core/src/main/java/discord4j/core/shard/SingleGatewayClientGroup.java
@@ -19,6 +19,7 @@ package discord4j.core.shard;
 
 import discord4j.discordjson.json.gateway.Dispatch;
 import discord4j.gateway.GatewayClient;
+import discord4j.gateway.LazyDispatch;
 import discord4j.gateway.json.GatewayPayload;
 import discord4j.gateway.json.ShardGatewayPayload;
 import io.netty.buffer.ByteBuf;
@@ -115,7 +116,7 @@ class SingleGatewayClientGroup implements GatewayClientGroupManager {
         }
 
         @Override
-        public Flux<Dispatch> dispatch() {
+        public Flux<LazyDispatch<Dispatch>> dispatch() {
             return client.dispatch();
         }
 

--- a/gateway/src/main/java/discord4j/gateway/GatewayClient.java
+++ b/gateway/src/main/java/discord4j/gateway/GatewayClient.java
@@ -73,7 +73,7 @@ public interface GatewayClient {
      *
      * @return a {@link Flux} of {@link Dispatch} values
      */
-    Flux<Dispatch> dispatch();
+    Flux<LazyDispatch<Dispatch>> dispatch();
 
     /**
      * Obtains the {@link Flux} of raw payloads inbound from the gateway connection made by this client.

--- a/gateway/src/main/java/discord4j/gateway/LazyDispatch.java
+++ b/gateway/src/main/java/discord4j/gateway/LazyDispatch.java
@@ -1,0 +1,47 @@
+package discord4j.gateway;
+
+import discord4j.discordjson.json.gateway.PayloadData;
+import discord4j.gateway.json.GatewayPayload;
+import reactor.util.annotation.Nullable;
+
+public class LazyDispatch<T extends PayloadData> {
+
+    @Nullable
+    private GatewayPayload<T> source;
+    @Nullable
+    private T data;
+
+    private boolean shardAware;
+
+    public LazyDispatch(@Nullable GatewayPayload<T> source, @Nullable T data, boolean shardAware) {
+        this.source = source;
+        this.data = data;
+        this.shardAware = shardAware;
+    }
+
+    public LazyDispatch(@Nullable GatewayPayload<T> source, @Nullable T data) {
+        this(source, data, false);
+    }
+
+    public boolean isShardAware() {
+        return shardAware;
+    }
+
+    public boolean isFromGateway() {
+        return source != null;
+    }
+
+    @Nullable
+    public T getData() {
+        if (isFromGateway()) {
+            return source.getData();
+        } else {
+            return data;
+        }
+    }
+
+    @Nullable
+    public GatewayPayload<T> getSource() {
+        return source;
+    }
+}

--- a/gateway/src/main/java/discord4j/gateway/LazyDispatch.java
+++ b/gateway/src/main/java/discord4j/gateway/LazyDispatch.java
@@ -31,11 +31,15 @@ public class LazyDispatch<T extends PayloadData> {
         return source != null;
     }
 
-    @Nullable
     public T getData() {
-        if (isFromGateway()) {
-            return source.getData();
+        if (source != null) {
+            final T data = source.getData();
+            if(data == null)
+                throw new IllegalStateException("LazyDispatch is from gateway, source.getData is null");
+            return data;
         } else {
+            if(data == null)
+                throw new IllegalStateException("LazyDispatch is from other source, data is null");
             return data;
         }
     }

--- a/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
+++ b/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
@@ -72,7 +72,7 @@ public abstract class PayloadHandlers {
             context.getClient().sessionId().set(newSessionId);
         }
         if (context.getData() != null) {
-            context.getClient().dispatchSink().next(context.getData());
+            context.getClient().dispatchSink().next(new LazyDispatch<>(context.getPayload(), null));
         }
     }
 

--- a/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
+++ b/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
@@ -72,7 +72,7 @@ public abstract class PayloadHandlers {
             String newSessionId = ((Ready) context.getData()).sessionId();
             context.getClient().sessionId().set(newSessionId);
         }
-        if (context.getPayload().isDataPresent()) {
+        if (context.getPayload().isDataPresent()) { // this should avoid "null" gateway payloads in lazy dispatches
             context.getClient().dispatchSink().next(new LazyDispatch<>(context.getPayload(), null));
         }
     }

--- a/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
+++ b/gateway/src/main/java/discord4j/gateway/PayloadHandlers.java
@@ -19,6 +19,7 @@ package discord4j.gateway;
 import discord4j.discordjson.json.gateway.*;
 import discord4j.discordjson.possible.Possible;
 import discord4j.gateway.json.GatewayPayload;
+import discord4j.gateway.json.dispatch.EventNames;
 import discord4j.gateway.retry.GatewayException;
 import discord4j.gateway.retry.ReconnectException;
 import reactor.util.Logger;
@@ -67,11 +68,11 @@ public abstract class PayloadHandlers {
     }
 
     private static void handleDispatch(PayloadContext<Dispatch> context) {
-        if (context.getData() instanceof Ready) {
+        if (context.getPayload().getType() != null && context.getPayload().getType().equals(EventNames.READY)) {
             String newSessionId = ((Ready) context.getData()).sessionId();
             context.getClient().sessionId().set(newSessionId);
         }
-        if (context.getData() != null) {
+        if (context.getPayload().isDataPresent()) {
             context.getClient().dispatchSink().next(new LazyDispatch<>(context.getPayload(), null));
         }
     }

--- a/gateway/src/main/java/discord4j/gateway/json/GatewayPayload.java
+++ b/gateway/src/main/java/discord4j/gateway/json/GatewayPayload.java
@@ -16,6 +16,7 @@
  */
 package discord4j.gateway.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import discord4j.discordjson.json.gateway.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -85,6 +86,7 @@ public class GatewayPayload<T extends PayloadData> {
         return data;
     }
 
+    @JsonIgnore
     public boolean isDataPresent() {
         return data != null;
     }

--- a/gateway/src/main/java/discord4j/gateway/json/GatewayPayload.java
+++ b/gateway/src/main/java/discord4j/gateway/json/GatewayPayload.java
@@ -85,6 +85,10 @@ public class GatewayPayload<T extends PayloadData> {
         return data;
     }
 
+    public boolean isDataPresent() {
+        return data != null;
+    }
+
     @Nullable
     public Integer getSequence() {
         return sequence;


### PR DESCRIPTION
**Description:** Avoiding the calls to the actual dispatch data unless we're inside of the event-mapper, so alternative implementations of PayloadReader can make the dispatch lazy-loading and avoid some unnecessary json parsing, which can improve performance in some use cases.