### PR TITLE
Request member from the gateway if missing from the cache

### DIFF
--- a/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
@@ -27,6 +27,8 @@ import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Set;
+
 class StoreEntityRetriever implements EntityRetriever {
 
     private final GatewayDiscordClient gateway;
@@ -63,7 +65,7 @@ class StoreEntityRetriever implements EntityRetriever {
         return stateView.getMemberStore()
                 .find(LongLongTuple2.of(guildId.asLong(), userId.asLong()))
                 .map(data -> new Member(gateway, data, guildId.asLong()))
-                .switchIfEmpty(gateway.requestMembers(guildId)
+                .switchIfEmpty(gateway.requestMembers(guildId, Set.of(userId))
                         .filter(member -> member.getId().equals(userId))
                         .next());
     }

--- a/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
@@ -27,6 +27,7 @@ import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Collections;
 import java.util.Set;
 
 class StoreEntityRetriever implements EntityRetriever {
@@ -65,7 +66,7 @@ class StoreEntityRetriever implements EntityRetriever {
         return stateView.getMemberStore()
                 .find(LongLongTuple2.of(guildId.asLong(), userId.asLong()))
                 .map(data -> new Member(gateway, data, guildId.asLong()))
-                .switchIfEmpty(gateway.requestMembers(guildId, Set.of(userId))
+                .switchIfEmpty(gateway.requestMembers(guildId, Collections.singleton(userId))
                         .filter(member -> member.getId().equals(userId))
                         .next());
     }

--- a/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
@@ -62,7 +62,10 @@ class StoreEntityRetriever implements EntityRetriever {
     public Mono<Member> getMemberById(Snowflake guildId, Snowflake userId) {
         return stateView.getMemberStore()
                 .find(LongLongTuple2.of(guildId.asLong(), userId.asLong()))
-                .map(data -> new Member(gateway, data, guildId.asLong()));
+                .map(data -> new Member(gateway, data, guildId.asLong()))
+                .switchIfEmpty(gateway.requestMembers(guildId)
+                        .filter(member -> member.getId().equals(userId))
+                        .next());
     }
 
     @Override


### PR DESCRIPTION
**Description:** In this commit <https://github.com/Discord4J/Discord4J/commit/9c93af766395e55e6a3acb8ffb3b1920035cbed6>, members are requested when not present in the cache using `StoreEntityRetriever#getGuildMembers`. This pull request does the same for `getMemberById`

**Justification:** https://github.com/Discord4J/Discord4J/issues/660