### PR TITLE
Make EntityRetrieverStrategy classes public

### DIFF
--- a/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-class RestEntityRetriever implements EntityRetriever {
+public class RestEntityRetriever implements EntityRetriever {
 
     private final GatewayDiscordClient gateway;
     private final RestClient rest;

--- a/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
@@ -27,7 +27,7 @@ import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-class StoreEntityRetriever implements EntityRetriever {
+public class StoreEntityRetriever implements EntityRetriever {
 
     private final GatewayDiscordClient gateway;
     private final StateView stateView;


### PR DESCRIPTION
**Description:** Changes `EntityRetrieverStrategy` classes' visibility from `protected` to `public`. This pull request follows https://github.com/Discord4J/Discord4J/pull/659

**Justification:** If https://github.com/Discord4J/Discord4J/pull/682 is implemented as it is, I would like to create a custom `StoreEntityRetriever` that requests the whole guild instead of just the single member and for this, I need to extend `StoreEntityRetriever` which is currently protected. I would also like to create some sort of `SpyRestEntityRetriever` that tracks when a REST request is made, it would also need to extend `RestEntityRetriever` which is also protected.