### PR TITLE
Change default voice timeout value

### DIFF
--- a/core/src/main/java/discord4j/core/spec/VoiceChannelJoinSpec.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelJoinSpec.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeoutException;
 public class VoiceChannelJoinSpec implements Spec<Mono<VoiceConnection>> {
 
     /** The default maximum amount of time in seconds to wait before the connection to the voice channel timeouts. */
-    private static final int DEFAULT_TIMEOUT = 5;
+    private static final int DEFAULT_TIMEOUT = 10;
 
     private Duration timeout = Duration.ofSeconds(DEFAULT_TIMEOUT);
     private AudioProvider provider = AudioProvider.NO_OP;


### PR DESCRIPTION
**Description:** Double the default voice timeout value.

**Justification:** 5 seconds was a bit short, it could lead to case like this where the timeout was occurring during the session description leading to a false concurrent voice handshakes detection afterwhile.
```
2020-05-06 17:46:49.875 INFO [Thread-9/shadbot.music]: {Guild ID: 597111231035473941} Joining voice channel...
2020-05-06 17:46:50.062 INFO [d4j-events-1/shadbot.music]: {Guild ID: 597111231035473941} Voice channel joined
2020-05-06 17:46:54.512 INFO [reactor-http-epoll-3/discord4j.voice.DefaultVoiceGatewayClient]: [G:d37fb4e, S:5, guildId:597111231035473941] Identifying
2020-05-06 17:46:54.812 INFO [reactor-http-epoll-3/discord4j.voice.DefaultVoiceGatewayClient]: [G:d37fb4e, S:5, guildId:597111231035473941] Waiting for session description
2020-05-06 17:46:54.880 INFO [parallel-3/shadbot.music]: {Guild ID: 597111231035473941} Voice channel connection timed out
2020-05-06 17:46:55.006 INFO [d4j-events-1/shadbot.music]: {Guild ID: 597111231035473941} Voice channel left
2020-05-06 17:48:58.711 INFO [Thread-34/shadbot.music]: {Guild ID: 597111231035473941} Joining voice channel...
2020-05-06 17:48:58.845 INFO [d4j-events-2/shadbot.music]: {Guild ID: 597111231035473941} Voice channel joined
2020-05-06 17:48:59.034 WARN [d4j-events-2/shadbot.music]: Concurrent voice handshakes are not allowed for guild 597111231035473941
```
I've been running my bot for more than 14 hours in production by using a default timeout value of 15 seconds and everything works perfectly fine (first time in several years \o/).
It's maybe too long, so my pull request only set it to 10 seconds.
I'll make another adjustment if 10 seconds is still too short. 