### PR TITLE
Replace java.awt.color with custom Color class

### DIFF
--- a/core/src/main/java/discord4j/core/object/Embed.java
+++ b/core/src/main/java/discord4j/core/object/Embed.java
@@ -19,8 +19,8 @@ package discord4j.core.object;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.discordjson.json.*;
 import discord4j.discordjson.possible.Possible;
+import discord4j.rest.util.Color;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;

--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -21,6 +21,7 @@ import discord4j.core.object.VoiceState;
 import discord4j.core.object.presence.Presence;
 import discord4j.core.retriever.EntityRetrievalStrategy;
 import discord4j.discordjson.possible.Possible;
+import discord4j.rest.util.Color;
 import discord4j.rest.util.PermissionSet;
 import discord4j.rest.util.Snowflake;
 import discord4j.core.spec.BanQuerySpec;
@@ -36,7 +37,6 @@ import reactor.core.publisher.Mono;
 import reactor.math.MathFlux;
 import reactor.util.annotation.Nullable;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.List;

--- a/core/src/main/java/discord4j/core/object/entity/Role.java
+++ b/core/src/main/java/discord4j/core/object/entity/Role.java
@@ -23,13 +23,13 @@ import discord4j.core.util.EntityUtil;
 import discord4j.core.util.OrderUtil;
 import discord4j.discordjson.json.RoleData;
 import discord4j.rest.entity.RestRole;
+import discord4j.rest.util.Color;
 import discord4j.rest.util.PermissionSet;
 import discord4j.rest.util.Snowflake;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
-import java.awt.Color;
 import java.util.Objects;
 import java.util.function.Consumer;
 

--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
@@ -18,9 +18,9 @@ package discord4j.core.spec;
 
 import discord4j.discordjson.json.*;
 import discord4j.discordjson.possible.Possible;
+import discord4j.rest.util.Color;
 import reactor.util.annotation.Nullable;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;

--- a/core/src/main/java/discord4j/core/spec/RoleCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/RoleCreateSpec.java
@@ -19,10 +19,10 @@ package discord4j.core.spec;
 import discord4j.core.object.entity.Role;
 import discord4j.discordjson.json.RoleCreateRequest;
 import discord4j.discordjson.possible.Possible;
+import discord4j.rest.util.Color;
 import discord4j.rest.util.PermissionSet;
 import reactor.util.annotation.Nullable;
 
-import java.awt.Color;
 
 /**
  * Spec used to create a new guild {@link Role} entity.

--- a/core/src/main/java/discord4j/core/spec/RoleEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/RoleEditSpec.java
@@ -19,10 +19,10 @@ package discord4j.core.spec;
 import discord4j.core.object.entity.Role;
 import discord4j.discordjson.json.ImmutableRoleModifyRequest;
 import discord4j.discordjson.json.RoleModifyRequest;
+import discord4j.rest.util.Color;
 import discord4j.rest.util.PermissionSet;
 import reactor.util.annotation.Nullable;
 
-import java.awt.Color;
 
 /**
  * Spec used to modify a guild {@link Role}.

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -162,24 +162,4 @@ public class Color {
         return Objects.hash(value);
     }
 
-    /**
-     * Converts float values to integer value.
-     *
-     * @param red The red value.
-     * @param green The green value.
-     * @param blue The blue value.
-     * @param alpha The alpha value.
-     * @return The integer value made of 8-bit sections.
-     */
-    private static int convert(float red, float green, float blue, float alpha) {
-        if (red < 0 || red > 1 || green < 0 || green > 1 || blue < 0 || blue > 1
-                || alpha < 0 || alpha > 1) {
-            throw new IllegalArgumentException("Bad RGB values");
-        }
-        int redval = Math.round(255 * red);
-        int greenval = Math.round(255 * green);
-        int blueval = Math.round(255 * blue);
-        int alphaval = Math.round(255 * alpha);
-        return (alphaval << 24) | (redval << 16) | (greenval << 8) | blueval;
-    }
 }

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -1,0 +1,185 @@
+package discord4j.rest.util;
+
+import java.util.Objects;
+
+public class Color {
+
+    /** Internal mask for red. */
+    private static final int RED_MASK = 255 << 16;
+    /** Internal mask for green. */
+    private static final int GREEN_MASK = 255 << 8;
+    /** Internal mask for blue. */
+    private static final int BLUE_MASK = 255;
+    /** Internal mask for alpha. */
+    private static final int ALPHA_MASK = 255 << 24;
+
+    /** The color value, in sRGB. */
+    private final int value;
+    /** The alpha value. This is in the range 0.0f - 1.0f. */
+    private final float falpha;
+
+    /**
+     * Initializes a new instance of {@link Color} using the specified
+     * red, green, and blue values, which must be given as integers in the
+     * range of 0-255. Alpha will default to 255 (opaque).
+     *
+     * @param red The red component of the RGB value.
+     * @param green The green component of the RGB value.
+     * @param blue The blue component of the RGB value.
+     */
+    public Color(int red, int green, int blue) {
+        this(red, green, blue, 255);
+    }
+
+    /**
+     * Initializes a new instance of {@link Color} using the specified
+     * red, green, blue, and alpha values, which must be given as integers in
+     * the range of 0-255.
+     *
+     * @param red The red component of the RGB value.
+     * @param green The green component of the RGB value.
+     * @param blue The blue component of the RGB value.
+     * @param alpha The alpha value of the color.
+     */
+    public Color(int red, int green, int blue, int alpha) {
+        if ((red & 255) != red || (green & 255) != green || (blue & 255) != blue
+                || (alpha & 255) != alpha) {
+            throw new IllegalArgumentException("Bad RGB values"
+                    + " red=0x" + Integer.toHexString(red)
+                    + " green=0x" + Integer.toHexString(green)
+                    + " blue=0x" + Integer.toHexString(blue)
+                    + " alpha=0x" + Integer.toHexString(alpha));
+        }
+
+        value = (alpha << 24) | (red << 16) | (green << 8) | blue;
+        falpha = 1;
+    }
+
+    /**
+     * Initializes a new instance of {@link Color} using the specified
+     * RGB value. The blue value is in bits 0-7, green in bits 8-15, and
+     * red in bits 16-23. The other bits are ignored. The alpha value is set
+     * to 255 (opaque).
+     *
+     * @param value The RGB value.
+     */
+    public Color(int value) {
+        this(value, false);
+    }
+
+    /**
+     * Initializes a new instance of {@link Color} using the specified
+     * RGB value. The blue value is in bits 0-7, green in bits 8-15, and
+     * red in bits 16-23. The alpha value is in bits 24-31, unless hasalpha
+     * is false, in which case alpha is set to 255.
+     *
+     * @param value The RGB value.
+     * @param hasalpha Whether value includes the alpha.
+     */
+    public Color(int value, boolean hasalpha) {
+        // NoteSystemColor calls this constructor, setting falpha to 0; but
+        // code in getRGBComponents correctly reports falpha as 1.0 to the user
+        // for all instances of SystemColor since frgbvalue is left null here.
+        if (hasalpha) {
+            falpha = ((value & ALPHA_MASK) >> 24) / 255f;
+        } else {
+            value |= ALPHA_MASK;
+            falpha = 1;
+        }
+        this.value = value;
+    }
+
+    /**
+     * Returns the red value for this color, as an integer in the range 0-255.
+     *
+     * @return The red value for this color.
+     */
+    public int getRed() {
+        return (getRGB() & RED_MASK) >> 16;
+    }
+
+    /**
+     * Returns the green value for this color, as an integer in the range 0-255.
+     *
+     * @return The green value for this color.
+     */
+    public int getGreen() {
+        return (getRGB() & GREEN_MASK) >> 8;
+    }
+
+    /**
+     * Returns the blue value for this color, as an integer in the range 0-255.
+     *
+     * @return The blue value for this color.
+     */
+    public int getBlue() {
+        return getRGB() & BLUE_MASK;
+    }
+
+    /**
+     * Returns the alpha value for this color, as an integer in the range 0-255.
+     *
+     * @return The alpha value for this color.
+     */
+    public int getAlpha() {
+        return (getRGB() & ALPHA_MASK) >>> 24;
+    }
+
+    /**
+     * Returns the RGB value for this color, in the sRGB color space. The blue
+     * value will be in bits 0-7, green in 8-15, red in 16-23, and alpha value in
+     * 24-31.
+     *
+     * @return The RGB value for this color.
+     */
+    public int getRGB() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "Color{" +
+                "r=" + getRed() +
+                "g=" + getGreen() +
+                "b=" + getBlue() +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Color color = (Color) o;
+        return value == color.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    /**
+     * Converts float values to integer value.
+     *
+     * @param red The red value.
+     * @param green The green value.
+     * @param blue The blue value.
+     * @param alpha The alpha value.
+     * @return The integer value made of 8-bit sections.
+     */
+    private static int convert(float red, float green, float blue, float alpha) {
+        if (red < 0 || red > 1 || green < 0 || green > 1 || blue < 0 || blue > 1
+                || alpha < 0 || alpha > 1) {
+            throw new IllegalArgumentException("Bad RGB values");
+        }
+        int redval = Math.round(255 * red);
+        int greenval = Math.round(255 * green);
+        int blueval = Math.round(255 * blue);
+        int alphaval = Math.round(255 * alpha);
+        return (alphaval << 24) | (redval << 16) | (greenval << 8) | blueval;
+    }
+}

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
 package discord4j.rest.util;
 
 import java.util.Objects;

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -77,9 +77,6 @@ public class Color {
      * @param hasalpha Whether value includes the alpha.
      */
     public Color(int value, boolean hasalpha) {
-        // NoteSystemColor calls this constructor, setting falpha to 0; but
-        // code in getRGBComponents correctly reports falpha as 1.0 to the user
-        // for all instances of SystemColor since frgbvalue is left null here.
         if (hasalpha) {
             falpha = ((value & ALPHA_MASK) >> 24) / 255f;
         } else {

--- a/rest/src/test/java/discord4j/rest/util/ColorTest.java
+++ b/rest/src/test/java/discord4j/rest/util/ColorTest.java
@@ -1,0 +1,52 @@
+package discord4j.rest.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class ColorTest {
+
+    @Test
+    public void testRedGreenBlueConstructor() {
+        Color color = new Color(1, 2, 3);
+        assertEquals(1, color.getRed());
+        assertEquals(2, color.getGreen());
+        assertEquals(3, color.getBlue());
+        assertEquals(255, color.getAlpha());
+
+        assertThrows(IllegalArgumentException.class, () -> new Color(-1, -100, -200));
+        assertThrows(IllegalArgumentException.class, () -> new Color(300, 400, 500));
+    }
+
+    @Test
+    public void testRedGreenBlueAlphaConstructor() {
+        Color color = new Color(1, 2, 3, 4);
+        assertEquals(1, color.getRed());
+        assertEquals(2, color.getGreen());
+        assertEquals(3, color.getBlue());
+        assertEquals(4, color.getAlpha());
+
+        assertThrows(IllegalArgumentException.class, () -> new Color(1, 2, 3, -300));
+        assertThrows(IllegalArgumentException.class, () -> new Color(1, 2, 3, 300));
+    }
+
+    @Test
+    public void testValueConstructor() {
+        Color color = new Color(255);
+        assertEquals(0, color.getRed());
+        assertEquals(0, color.getGreen());
+        assertEquals(255, color.getBlue());
+        assertEquals(255, color.getAlpha());
+    }
+
+    @Test
+    public void testValueAlphaConstructor() {
+        Color color = new Color(255, true);
+        assertEquals(0, color.getRed());
+        assertEquals(0, color.getGreen());
+        assertEquals(255, color.getBlue());
+        assertEquals(0, color.getAlpha());
+    }
+
+}


### PR DESCRIPTION
**Description:** An attempt to replace `java.awt.Color` with custom Color class which provides basic functionalities. Let me know if this needs more functionality like taking into account float rgb values or `brighter` and ` darker` methods for example.

**Justification:** Fix https://github.com/Discord4J/Discord4J/issues/696