### PR TITLE
Deprecate embed fields

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -290,7 +290,7 @@ public final class Guild implements Entity {
      * Gets the ID of the embedded channel, if present.
      *
      * @return The ID of the embedded channel, if present.
-     * @deprecated Use {@code Guild#getWidgetChannel} instead.
+     * @deprecated Use {@code Guild#getWidgetChannelId} instead.
      */
     @Deprecated
     public Optional<Snowflake> getEmbedChannelId() {

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -290,9 +290,11 @@ public final class Guild implements Entity {
      * Gets the ID of the embedded channel, if present.
      *
      * @return The ID of the embedded channel, if present.
+     * @deprecated Use {@code Guild#getWidgetChannel} instead.
      */
+    @Deprecated
     public Optional<Snowflake> getEmbedChannelId() {
-        return Possible.flatOpt(data.embedChannelId()).map(Snowflake::of);
+        return this.getWidgetChannelId();
     }
 
     /**
@@ -741,9 +743,11 @@ public final class Guild implements Entity {
      * Gets whether this guild is embeddable (e.g. widget).
      *
      * @return Whether this guild is embeddable (e.g. widget).
+     * @deprecated Use {@code Guild#isWidgetEnabled} instead
      */
+    @Deprecated
     public boolean isEmbedEnabled() {
-        return data.embedEnabled().toOptional().orElse(false);
+        return this.isWidgetEnabled();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -294,7 +294,7 @@ public final class Guild implements Entity {
      */
     @Deprecated
     public Optional<Snowflake> getEmbedChannelId() {
-        return this.getWidgetChannelId();
+        return getWidgetChannelId();
     }
 
     /**
@@ -747,7 +747,7 @@ public final class Guild implements Entity {
      */
     @Deprecated
     public boolean isEmbedEnabled() {
-        return this.isWidgetEnabled();
+        return isWidgetEnabled();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -551,9 +551,9 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Gets the channel ID for the server widget, if present.
+     * Gets the channel ID that the widget will generate an invite to, if present.
      *
-     * @return The channel ID for the server widget, if present.
+     * @return The channel ID that the widget will generate an invite to, if present.
      */
     public Optional<Snowflake> getWidgetChannelId() {
         return Possible.flatOpt(data.widgetChannelId()).map(Snowflake::of);

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -209,12 +209,28 @@ public class RestGuild {
         return restClient.getGuildService().syncGuildIntegration(id, integrationId);
     }
 
+    /**
+     * @deprecated Use {RestGuild#getWidget} instead.
+     */
+    @Deprecated
     public Mono<GuildEmbedData> getEmbed() {
         return restClient.getGuildService().getGuildEmbed(id);
     }
 
+    /**
+     * @deprecated Use {RestGuild#modifyWidget} instead.
+     */
+    @Deprecated
     public Mono<GuildEmbedData> modifyEmbed(GuildEmbedModifyRequest request) {
         return restClient.getGuildService().modifyGuildEmbed(id, request);
+    }
+
+    public Mono<GuildWidgetData> getWidget() {
+        return restClient.getGuildService().getGuildWidget(id);
+    }
+
+    public Mono<GuildWidgetData> modifyWidget(GuildWidgetModifyRequest request) {
+        return restClient.getGuildService().modifyGuildWidget(id, request);
     }
 
     // TODO add Get Guild Vanity URL

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -700,7 +700,7 @@ public abstract class Routes {
     /**
      * Returns the guild widget object. Requires the 'MANAGE_GUILD' permission.
      *
-     * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-widget">
+     * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-widget">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-widget</a>
      */
     public static final Route GUILD_WIDGET_GET = Route.get("/guilds/{guild.id}/widget");
@@ -720,7 +720,7 @@ public abstract class Routes {
      * Modify a guild widget object for the guild. All attributes may be passed in with JSON and modified. Requires the
      * 'MANAGE_GUILD' permission. Returns the updated guild widget object.
      *
-     * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-widget">
+     * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-widget">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-widget</a>
      */
     public static final Route GUILD_WIDGET_MODIFY = Route.patch("/guilds/{guild.id}/widget");

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -711,8 +711,19 @@ public abstract class Routes {
      *
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-embed">
      *         https://discordapp.com/developers/docs/resources/guild#modify-guild-embed</a>
+     * @deprecated Use {@code Routes.GUILD_WIDGET_MODIFY} instead.
      */
+    @Deprecated
     public static final Route GUILD_EMBED_MODIFY = Route.patch("/guilds/{guild.id}/embed");
+
+    /**
+     * Modify a guild widget object for the guild. All attributes may be passed in with JSON and modified. Requires the
+     * 'MANAGE_GUILD' permission. Returns the updated guild widget object.
+     *
+     * @see <a href="https://discordapp.com/developers/docs/resources/guild#modify-guild-widget">
+     *         https://discordapp.com/developers/docs/resources/guild#modify-guild-widget</a>
+     */
+    public static final Route GUILD_WIDGET_MODIFY = Route.patch("/guilds/{guild.id}/widget");
 
     /////////////////////////////////////////////
     ////////////// Invite Resource //////////////

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -692,7 +692,7 @@ public abstract class Routes {
      *
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-embed">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-embed</a>
-     * @deprecated Use {@code Routes.GUILD_WIDGET_GET} instead
+     * @deprecated Use {@code Routes.GUILD_WIDGET_GET} instead.
      */
     @Deprecated
     public static final Route GUILD_EMBED_GET = Route.get("/guilds/{guild.id}/embed");

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -692,8 +692,18 @@ public abstract class Routes {
      *
      * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-embed">
      *         https://discordapp.com/developers/docs/resources/guild#get-guild-embed</a>
+     * @deprecated Use {@code Routes.GUILD_WIDGET_GET} instead
      */
+    @Deprecated
     public static final Route GUILD_EMBED_GET = Route.get("/guilds/{guild.id}/embed");
+
+    /**
+     * Returns the guild widget object. Requires the 'MANAGE_GUILD' permission.
+     *
+     * @see <a href="https://discordapp.com/developers/docs/resources/guild#get-guild-widget">
+     *         https://discordapp.com/developers/docs/resources/guild#get-guild-widget</a>
+     */
+    public static final Route GUILD_WIDGET_GET = Route.get("/guilds/{guild.id}/widget");
 
     /**
      * Modify a guild embed object for the guild. All attributes may be passed in with JSON and modified. Requires the

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -701,7 +701,7 @@ public abstract class Routes {
      * Returns the guild widget object. Requires the 'MANAGE_GUILD' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-widget">
-     *         https://discordapp.com/developers/docs/resources/guild#get-guild-widget</a>
+     *         https://discord.com/developers/docs/resources/guild#get-guild-widget</a>
      */
     public static final Route GUILD_WIDGET_GET = Route.get("/guilds/{guild.id}/widget");
 
@@ -721,7 +721,7 @@ public abstract class Routes {
      * 'MANAGE_GUILD' permission. Returns the updated guild widget object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-widget">
-     *         https://discordapp.com/developers/docs/resources/guild#modify-guild-widget</a>
+     *         https://discord.com/developers/docs/resources/guild#modify-guild-widget</a>
      */
     public static final Route GUILD_WIDGET_MODIFY = Route.patch("/guilds/{guild.id}/widget");
 

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -280,8 +280,19 @@ public class GuildService extends RestService {
                 .bodyToMono(GuildEmbedData.class);
     }
 
+    /**
+     * @deprecated Use {@code GuildService#modifyGuildEmbed} instead.
+     */
+    @Deprecated
     public Mono<GuildEmbedData> modifyGuildEmbed(long guildId, GuildEmbedModifyRequest request) {
         return Routes.GUILD_EMBED_MODIFY.newRequest(guildId)
+                .body(request)
+                .exchange(getRouter())
+                .bodyToMono(GuildEmbedData.class);
+    }
+
+    public Mono<GuildEmbedData> modifyGuildWidget(long guildId, GuildEmbedModifyRequest request) {
+        return Routes.GUILD_WIDGET_MODIFY.newRequest(guildId)
                 .body(request)
                 .exchange(getRouter())
                 .bodyToMono(GuildEmbedData.class);

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -266,8 +266,16 @@ public class GuildService extends RestService {
                 .bodyToMono(Void.class);
     }
 
+    /**
+     * @deprecated Use {@code GuildService#getGuildWidget} instead.
+     */
+    @Deprecated
     public Mono<GuildEmbedData> getGuildEmbed(long guildId) {
-        return Routes.GUILD_EMBED_GET.newRequest(guildId)
+        return getGuildWidget(guildId);
+    }
+
+    public Mono<GuildEmbedData> getGuildWidget(long guildId) {
+        return Routes.GUILD_WIDGET_GET.newRequest(guildId)
                 .exchange(getRouter())
                 .bodyToMono(GuildEmbedData.class);
     }

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -271,13 +271,15 @@ public class GuildService extends RestService {
      */
     @Deprecated
     public Mono<GuildEmbedData> getGuildEmbed(long guildId) {
-        return getGuildWidget(guildId);
-    }
-
-    public Mono<GuildEmbedData> getGuildWidget(long guildId) {
-        return Routes.GUILD_WIDGET_GET.newRequest(guildId)
+        return Routes.GUILD_EMBED_GET.newRequest(guildId)
                 .exchange(getRouter())
                 .bodyToMono(GuildEmbedData.class);
+    }
+
+    public Mono<GuildWidgetData> getGuildWidget(long guildId) {
+        return Routes.GUILD_WIDGET_GET.newRequest(guildId)
+                .exchange(getRouter())
+                .bodyToMono(GuildWidgetData.class);
     }
 
     /**
@@ -291,10 +293,10 @@ public class GuildService extends RestService {
                 .bodyToMono(GuildEmbedData.class);
     }
 
-    public Mono<GuildEmbedData> modifyGuildWidget(long guildId, GuildEmbedModifyRequest request) {
+    public Mono<GuildWidgetData> modifyGuildWidget(long guildId, GuildWidgetModifyRequest request) {
         return Routes.GUILD_WIDGET_MODIFY.newRequest(guildId)
                 .body(request)
                 .exchange(getRouter())
-                .bodyToMono(GuildEmbedData.class);
+                .bodyToMono(GuildWidgetData.class);
     }
 }

--- a/rest/src/test/java/discord4j/rest/service/GuildServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/GuildServiceTest.java
@@ -260,8 +260,8 @@ public class GuildServiceTest {
     }
 
     @Test
-    public void testGetGuildEmbed() {
-        getGuildService().getGuildEmbed(guild).block();
+    public void testGetGuildWidget() {
+        getGuildService().getGuildWidget(guild).block();
     }
 
     @Test


### PR DESCRIPTION
**Description:** Guild embed was renamed to widget 

**Justification:** 
https://github.com/discord/discord-api-docs/pull/1536
https://github.com/Discord4J/discord-json/pull/17