### PR TITLE
Cleanup Color and Add Constants

### DIFF
--- a/core/src/main/java/discord4j/core/object/Embed.java
+++ b/core/src/main/java/discord4j/core/object/Embed.java
@@ -123,7 +123,7 @@ public final class Embed implements DiscordObject {
      * @return The color of the embed, if present.
      */
     public Optional<Color> getColor() {
-        return data.color().toOptional().map(color -> new Color(color, true));
+        return data.color().toOptional().map(Color::of);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/Role.java
+++ b/core/src/main/java/discord4j/core/object/entity/Role.java
@@ -41,7 +41,7 @@ import java.util.function.Consumer;
 public final class Role implements Entity {
 
     /** The default {@link Color} of a {@code Role}. */
-    public static final Color DEFAULT_COLOR = new Color(0, true);
+    public static final Color DEFAULT_COLOR = Color.of(0);
 
     /** The gateway associated to this object. */
     private final GatewayDiscordClient gateway;
@@ -168,7 +168,7 @@ public final class Role implements Entity {
      * @return The color assigned to this role.
      */
     public Color getColor() {
-        return new Color(data.color(), true);
+        return Color.of(data.color());
     }
 
     /**

--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
@@ -87,17 +87,7 @@ public class EmbedCreateSpec implements Spec<EmbedData> {
      * @return This spec.
      */
     public EmbedCreateSpec setColor(final Color color) {
-        return setColor(color.getRGB());
-    }
-
-    /**
-     * Sets the color of the embed.
-     *
-     * @param color An RGB color to display on the embed.
-     * @return This spec.
-     */
-    public EmbedCreateSpec setColor(int color) {
-        requestBuilder.color(color & 0xFFFFFF);
+        requestBuilder.color(color.getRGB());
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/RoleCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/RoleCreateSpec.java
@@ -67,7 +67,7 @@ public class RoleCreateSpec implements AuditSpec<RoleCreateRequest> {
      * @return This spec.
      */
     public RoleCreateSpec setColor(Color color) {
-        this.color = color.getRGB() & 0xFFFFFF;
+        this.color = color.getRGB();
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/RoleEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/RoleEditSpec.java
@@ -64,7 +64,7 @@ public class RoleEditSpec implements AuditSpec<RoleModifyRequest> {
      * @return This spec.
      */
     public RoleEditSpec setColor(Color color) {
-        requestBuilder.color(color.getRGB() & 0xFFFFFF);
+        requestBuilder.color(color.getRGB());
         return this;
     }
 

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -57,6 +57,66 @@ public final class Color {
     /** The color blue. */
     public static final Color BLUE = of(0, 0, 255);
 
+    /** The color light sea green. This is a Discord color present. */
+    public static final Color LIGHT_SEA_GREEN = of(0x1ABC9C);
+
+    /** The color medium sea green. This is a Discord color present. */
+    public static final Color MEDIUM_SEA_GREEN = of(0x2ECC71);
+
+    /** The color summer sky. This is a Discord color present. */
+    public static final Color SUMMER_SKY = of(0x3498DB);
+
+    /** The color deep lilac. This is a Discord color present. */
+    public static final Color DEEP_LILAC = of(0x9B59B6);
+
+    /** The color ruby. This is a Discord color present. */
+    public static final Color RUBY = of(0xE91E63);
+
+    /** The color moon yellow. This is a Discord color present. */
+    public static final Color MOON_YELLOW = of(0xF1C40F);
+
+    /** The color tahiti gold. This is a Discord color present. */
+    public static final Color TAHITI_GOLD = of(0xE67E22);
+
+    /** The color cinnabar. This is a Discord color present. */
+    public static final Color CINNABAR = of(0xE74C3C);
+
+    /** The color submarine. This is a Discord color present. */
+    public static final Color SUBMARINE = of(0x95A5A6);
+
+    /** The color hoki. This is a Discord color present. */
+    public static final Color HOKI = of(0x607D8B);
+
+    /** The color deep sea. This is a Discord color present. */
+    public static final Color DEEP_SEA = of(0x11806A);
+
+    /** The color sea green. This is a Discord color present. */
+    public static final Color SEA_GREEN = of(0x1F8B4C);
+
+    /** The color endeavour. This is a Discord color present. */
+    public static final Color ENDEAVOUR = of(0x206694);
+
+    /** The color vivid violet. This is a Discord color present. */
+    public static final Color VIVID_VIOLET = of(0x71368A);
+
+    /** The color jazzberry jam. This is a Discord color present. */
+    public static final Color JAZZBERRY_JAM = of(0xAD1457);
+
+    /** The color dark goldenrod. This is a Discord color present. */
+    public static final Color DARK_GOLDENROD = of(0xC27C0E);
+
+    /** The color rust. This is a Discord color present. */
+    public static final Color RUST = of(0xA84300);
+
+    /** The color brown. This is a Discord color present. */
+    public static final Color BROWN = of(0x992D22);
+
+    /** The color gray chateau. This is a Discord color present. */
+    public static final Color GRAY_CHATEAU = of(0x979C9F);
+
+    /** The color bismark. This is a Discord color present. */
+    public static final Color BISMARK = of(0x546E7A);
+
     /**
      * Initializes a new instance of {@link Color} using the specified red, green, and blue values, which must be given
      * as floats in the range of 0.0F-255.0F.

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -16,90 +16,114 @@
  */
 package discord4j.rest.util;
 
-import java.util.Objects;
+public final class Color {
 
-public class Color {
+    /** The color white. */
+    public static final Color WHITE = of(255, 255, 255);
 
-    /** Internal mask for red. */
-    private static final int RED_MASK = 255 << 16;
-    /** Internal mask for green. */
-    private static final int GREEN_MASK = 255 << 8;
-    /** Internal mask for blue. */
-    private static final int BLUE_MASK = 255;
-    /** Internal mask for alpha. */
-    private static final int ALPHA_MASK = 255 << 24;
+    /** The color light gray. */
+    public static final Color LIGHT_GRAY = of(192, 192, 192);
 
-    /** The color value, in sRGB. */
-    private final int value;
-    /** The alpha value. This is in the range 0.0f - 1.0f. */
-    private final float falpha;
+    /** The color gray. */
+    public static final Color GRAY = of(128, 128, 128);
+
+    /** The color dark gray. */
+    public static final Color DARK_GRAY = of(64, 64, 64);
+
+    /** The color black. */
+    public static final Color BLACK = of(0, 0, 0);
+
+    /** The color red. */
+    public static final Color RED = of(255, 0, 0);
+
+    /** The color pink. */
+    public static final Color PINK = of(255, 175, 175);
+
+    /** The color orange. */
+    public static final Color ORANGE = of(255, 200, 0);
+
+    /** The color yellow. */
+    public static final Color YELLOW = of(255, 255, 0);
+
+    /** The color green. */
+    public static final Color GREEN = of(0, 255, 0);
+
+    /** The color magenta. */
+    public static final Color MAGENTA = of(255, 0, 255);
+
+    /** The color cyan. */
+    public static final Color CYAN = of(0, 255, 255);
+
+    /** The color blue. */
+    public static final Color BLUE = of(0, 0, 255);
 
     /**
-     * Initializes a new instance of {@link Color} using the specified
-     * red, green, and blue values, which must be given as integers in the
-     * range of 0-255. Alpha will default to 255 (opaque).
+     * Initializes a new instance of {@link Color} using the specified red, green, and blue values, which must be given
+     * as floats in the range of 0.0F-255.0F.
      *
      * @param red The red component of the RGB value.
      * @param green The green component of the RGB value.
      * @param blue The blue component of the RGB value.
      */
-    public Color(int red, int green, int blue) {
-        this(red, green, blue, 255);
+    public static Color of(final float red, final float green, final float blue) {
+        return of((int) (red * 255.0F + 0.5F), (int) (green * 255.0F + 0.5F), (int) (blue * 255.0F + 0.5F));
     }
 
     /**
-     * Initializes a new instance of {@link Color} using the specified
-     * red, green, blue, and alpha values, which must be given as integers in
-     * the range of 0-255.
+     * Initializes a new instance of {@link Color} using the specified red, green, and blue values, which must be given
+     * as integers in the range of 0-255.
      *
      * @param red The red component of the RGB value.
      * @param green The green component of the RGB value.
      * @param blue The blue component of the RGB value.
-     * @param alpha The alpha value of the color.
      */
-    public Color(int red, int green, int blue, int alpha) {
-        if ((red & 255) != red || (green & 255) != green || (blue & 255) != blue
-                || (alpha & 255) != alpha) {
-            throw new IllegalArgumentException("Bad RGB values"
-                    + " red=0x" + Integer.toHexString(red)
-                    + " green=0x" + Integer.toHexString(green)
-                    + " blue=0x" + Integer.toHexString(blue)
-                    + " alpha=0x" + Integer.toHexString(alpha));
+    public static Color of(final int red, final int green, final int blue) {
+        if ((red & 0xFF) != red || (green & 0xFF) != green || (blue & 0xFF) != blue) {
+            throw new IllegalArgumentException("Illegal RGB arguments" +
+                " red=0x" + Integer.toHexString(red) +
+                " green=0x" + Integer.toHexString(green) +
+                " blue=0x" + Integer.toHexString(blue));
         }
 
-        value = (alpha << 24) | (red << 16) | (green << 8) | blue;
-        falpha = 1;
+        return of((red << 16) | (green << 8) | blue);
+    }
+
+    private static void checkComponent(final int component, final String type) {
+        if ((component & 0xFF) != component) {
+            throw new IllegalArgumentException("Bad " + type + " Value: 0x" + Integer.toHexString(component));
+        }
     }
 
     /**
-     * Initializes a new instance of {@link Color} using the specified
-     * RGB value. The blue value is in bits 0-7, green in bits 8-15, and
-     * red in bits 16-23. The other bits are ignored. The alpha value is set
-     * to 255 (opaque).
+     * Initializes a new instance of {@link Color} using the specified RGB value. The blue value is in bits 0-7, green
+     * in bits 8-15, and red in bits 16-23.
      *
-     * @param value The RGB value.
+     * @param rgb The RGB value.
      */
-    public Color(int value) {
-        this(value, false);
+    public static Color of(final int rgb) {
+        return new Color(rgb & 0xFFFFFF);
+    }
+
+    /** The color value, in RGB. */
+    private final int rgb;
+
+    /**
+     * Initializes a new instance of {@link Color} using the specified RGB value. The blue value is in bits 0-7, green
+     * in bits 8-15, and red in bits 16-23.
+     *
+     * @param rgb The RGB value.
+     */
+    private Color(final int rgb) {
+        this.rgb = rgb;
     }
 
     /**
-     * Initializes a new instance of {@link Color} using the specified
-     * RGB value. The blue value is in bits 0-7, green in bits 8-15, and
-     * red in bits 16-23. The alpha value is in bits 24-31, unless hasalpha
-     * is false, in which case alpha is set to 255.
+     * Returns the RGB value for this color. The blue value will be in bits 0-7, green in 8-15, and red in 16-23.
      *
-     * @param value The RGB value.
-     * @param hasalpha Whether value includes the alpha.
+     * @return The RGB value for this color.
      */
-    public Color(int value, boolean hasalpha) {
-        if (hasalpha) {
-            falpha = ((value & ALPHA_MASK) >> 24) / 255f;
-        } else {
-            value |= ALPHA_MASK;
-            falpha = 1;
-        }
-        this.value = value;
+    public int getRGB() {
+        return rgb;
     }
 
     /**
@@ -108,7 +132,7 @@ public class Color {
      * @return The red value for this color.
      */
     public int getRed() {
-        return (getRGB() & RED_MASK) >> 16;
+        return (rgb >> 16) & 0xFF;
     }
 
     /**
@@ -117,7 +141,7 @@ public class Color {
      * @return The green value for this color.
      */
     public int getGreen() {
-        return (getRGB() & GREEN_MASK) >> 8;
+        return (rgb >> 8) & 0xFF;
     }
 
     /**
@@ -126,53 +150,23 @@ public class Color {
      * @return The blue value for this color.
      */
     public int getBlue() {
-        return getRGB() & BLUE_MASK;
-    }
-
-    /**
-     * Returns the alpha value for this color, as an integer in the range 0-255.
-     *
-     * @return The alpha value for this color.
-     */
-    public int getAlpha() {
-        return (getRGB() & ALPHA_MASK) >>> 24;
-    }
-
-    /**
-     * Returns the RGB value for this color, in the sRGB color space. The blue
-     * value will be in bits 0-7, green in 8-15, red in 16-23, and alpha value in
-     * 24-31.
-     *
-     * @return The RGB value for this color.
-     */
-    public int getRGB() {
-        return value;
+        return rgb & 0xFF;
     }
 
     @Override
     public String toString() {
         return "Color{" +
-                "r=" + getRed() +
-                "g=" + getGreen() +
-                "b=" + getBlue() +
-                '}';
+            "red=" + getRed() +
+            ", green=" + getGreen() +
+            ", blue=" + getBlue() +
+            '}';
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Color color = (Color) o;
-        return value == color.value;
+    public boolean equals(final Object obj) {
+        return obj instanceof Color && ((Color) obj).getRGB() == getRGB();
     }
 
-    @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return getRGB();
     }
-
 }

--- a/rest/src/main/java/discord4j/rest/util/Color.java
+++ b/rest/src/main/java/discord4j/rest/util/Color.java
@@ -88,12 +88,6 @@ public final class Color {
         return of((red << 16) | (green << 8) | blue);
     }
 
-    private static void checkComponent(final int component, final String type) {
-        if ((component & 0xFF) != component) {
-            throw new IllegalArgumentException("Bad " + type + " Value: 0x" + Integer.toHexString(component));
-        }
-    }
-
     /**
      * Initializes a new instance of {@link Color} using the specified RGB value. The blue value is in bits 0-7, green
      * in bits 8-15, and red in bits 16-23.

--- a/rest/src/test/java/discord4j/rest/util/ColorTest.java
+++ b/rest/src/test/java/discord4j/rest/util/ColorTest.java
@@ -9,44 +9,20 @@ public class ColorTest {
 
     @Test
     public void testRedGreenBlueConstructor() {
-        Color color = new Color(1, 2, 3);
+        Color color = Color.of(1, 2, 3);
         assertEquals(1, color.getRed());
         assertEquals(2, color.getGreen());
         assertEquals(3, color.getBlue());
-        assertEquals(255, color.getAlpha());
 
-        assertThrows(IllegalArgumentException.class, () -> new Color(-1, -100, -200));
-        assertThrows(IllegalArgumentException.class, () -> new Color(300, 400, 500));
-    }
-
-    @Test
-    public void testRedGreenBlueAlphaConstructor() {
-        Color color = new Color(1, 2, 3, 4);
-        assertEquals(1, color.getRed());
-        assertEquals(2, color.getGreen());
-        assertEquals(3, color.getBlue());
-        assertEquals(4, color.getAlpha());
-
-        assertThrows(IllegalArgumentException.class, () -> new Color(1, 2, 3, -300));
-        assertThrows(IllegalArgumentException.class, () -> new Color(1, 2, 3, 300));
+        assertThrows(IllegalArgumentException.class, () -> Color.of(-1, -100, -200));
+        assertThrows(IllegalArgumentException.class, () -> Color.of(300, 400, 500));
     }
 
     @Test
     public void testValueConstructor() {
-        Color color = new Color(255);
+        Color color = Color.of(255);
         assertEquals(0, color.getRed());
         assertEquals(0, color.getGreen());
         assertEquals(255, color.getBlue());
-        assertEquals(255, color.getAlpha());
     }
-
-    @Test
-    public void testValueAlphaConstructor() {
-        Color color = new Color(255, true);
-        assertEquals(0, color.getRed());
-        assertEquals(0, color.getGreen());
-        assertEquals(255, color.getBlue());
-        assertEquals(0, color.getAlpha());
-    }
-
 }


### PR DESCRIPTION
Cleanup the implementation of Color to be simpler. A part of this was removing alpha as Discord does not use it (in fact including it breaks things!).

Removed constructors to fit the rest of how D4J plays out regarding constructors and static factory methods. Additionally added static constants you'd see on `java.awt.Color`