### PR TITLE
Validate intents for GatewayDiscordClient::requestMembers

### DIFF
--- a/core/src/main/java/discord4j/core/GatewayDiscordClient.java
+++ b/core/src/main/java/discord4j/core/GatewayDiscordClient.java
@@ -34,6 +34,7 @@ import discord4j.core.retriever.EntityRetriever;
 import discord4j.core.shard.GatewayBootstrap;
 import discord4j.core.spec.GuildCreateSpec;
 import discord4j.core.spec.UserEditSpec;
+import discord4j.core.util.ValidationUtil;
 import discord4j.discordjson.json.EmojiData;
 import discord4j.discordjson.json.GuildData;
 import discord4j.discordjson.json.GuildUpdateData;
@@ -485,6 +486,11 @@ public class GatewayDiscordClient implements EntityRetriever {
      * the {@link Flux}.
      */
     public Flux<Member> requestMembers(RequestGuildMembers request) {
+        try {
+            ValidationUtil.validateRequestGuildMembers(request, gatewayResources.getIntents());
+        } catch (Throwable t) {
+            return Flux.error(t);
+        }
         Snowflake guildId = Snowflake.of(request.guildId());
         int shardId = gatewayClientGroup.computeShardIndex(guildId);
         String nonce = String.valueOf(System.nanoTime());

--- a/core/src/main/java/discord4j/core/util/ValidationUtil.java
+++ b/core/src/main/java/discord4j/core/util/ValidationUtil.java
@@ -1,0 +1,35 @@
+package discord4j.core.util;
+
+import discord4j.discordjson.json.gateway.RequestGuildMembers;
+import discord4j.discordjson.possible.Possible;
+import discord4j.gateway.intent.Intent;
+import discord4j.gateway.intent.IntentSet;
+
+public class ValidationUtil {
+    /**
+     * Throws if the request is not invalid given the current intents.
+     *
+     * @param request The request to validate
+     * @param possibleIntents The current intents
+     * @see <a href="https://discord.com/developers/docs/topics/gateway#request-guild-members">https://discord.com/developers/docs/topics/gateway#request-guild-members</a>
+     */
+    public static void validateRequestGuildMembers(RequestGuildMembers request, Possible<IntentSet> possibleIntents) {
+        if (request.query().isAbsent() == request.userIds().isAbsent()) {
+            throw new IllegalArgumentException("One of query or user ids is required.");
+        }
+
+        // Further Validation is only required if we are using intents.
+        if (possibleIntents.isAbsent()) return;
+        IntentSet intents = possibleIntents.get();
+
+        boolean requestingPresences = request.presences().toOptional().orElse(false);
+        if (requestingPresences && !intents.contains(Intent.GUILD_PRESENCES)) {
+            throw new IllegalArgumentException("GUILD_PRESENCES intent is required to set presences = true.");
+        }
+
+        boolean requestingEntireList = request.query().toOptional().map(String::isEmpty).orElse(false) && request.limit() == 0;
+        if (requestingEntireList && !intents.contains(Intent.GUILD_MEMBERS)) {
+            throw new IllegalArgumentException("GUILD_MEMBERS intent is required to request the entire member list");
+        }
+    }
+}

--- a/core/src/main/java/discord4j/core/util/ValidationUtil.java
+++ b/core/src/main/java/discord4j/core/util/ValidationUtil.java
@@ -7,7 +7,7 @@ import discord4j.gateway.intent.IntentSet;
 
 public class ValidationUtil {
     /**
-     * Throws if the request is not invalid given the current intents.
+     * Throws if the request is invalid given the current intents.
      *
      * @param request The request to validate
      * @param possibleIntents The current intents

--- a/core/src/main/java/discord4j/core/util/ValidationUtil.java
+++ b/core/src/main/java/discord4j/core/util/ValidationUtil.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.core.util;
 
 import discord4j.discordjson.json.gateway.RequestGuildMembers;
@@ -19,7 +36,9 @@ public class ValidationUtil {
         }
 
         // Further Validation is only required if we are using intents.
-        if (possibleIntents.isAbsent()) return;
+        if (possibleIntents.isAbsent()) {
+            return;
+        }
         IntentSet intents = possibleIntents.get();
 
         boolean requestingPresences = request.presences().toOptional().orElse(false);
@@ -27,7 +46,8 @@ public class ValidationUtil {
             throw new IllegalArgumentException("GUILD_PRESENCES intent is required to set presences = true.");
         }
 
-        boolean requestingEntireList = request.query().toOptional().map(String::isEmpty).orElse(false) && request.limit() == 0;
+        boolean requestingEntireList = request.query().toOptional().map(String::isEmpty).orElse(false)
+            && request.limit() == 0;
         if (requestingEntireList && !intents.contains(Intent.GUILD_MEMBERS)) {
             throw new IllegalArgumentException("GUILD_MEMBERS intent is required to request the entire member list");
         }

--- a/core/src/test/java/discord4j/core/ExampleIntents.java
+++ b/core/src/test/java/discord4j/core/ExampleIntents.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.core;
 
 import discord4j.common.util.Snowflake;

--- a/core/src/test/java/discord4j/core/ExampleIntents.java
+++ b/core/src/test/java/discord4j/core/ExampleIntents.java
@@ -1,9 +1,9 @@
 package discord4j.core;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.object.entity.Member;
 import discord4j.gateway.intent.Intent;
 import discord4j.gateway.intent.IntentSet;
-import discord4j.rest.util.Snowflake;
 
 import java.util.List;
 

--- a/core/src/test/java/discord4j/core/ExampleIntents.java
+++ b/core/src/test/java/discord4j/core/ExampleIntents.java
@@ -1,0 +1,22 @@
+package discord4j.core;
+
+import discord4j.core.object.entity.Member;
+import discord4j.gateway.intent.Intent;
+import discord4j.gateway.intent.IntentSet;
+import discord4j.rest.util.Snowflake;
+
+import java.util.List;
+
+public class ExampleIntents {
+    public static void main(String[] args) {
+        List<Member> members = DiscordClient.create(System.getenv("token"))
+            .gateway()
+            .setEnabledIntents(IntentSet.of(Intent.GUILD_MEMBERS))
+            .login()
+            .flatMapMany(gateway ->
+                gateway.requestMembers(Snowflake.of(System.getenv("guild")))
+            )
+            .collectList()
+            .block();
+    }
+}

--- a/core/src/test/java/discord4j/core/util/ValidationUtilTest.java
+++ b/core/src/test/java/discord4j/core/util/ValidationUtilTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.core.util;
 
 import discord4j.discordjson.json.gateway.RequestGuildMembers;

--- a/core/src/test/java/discord4j/core/util/ValidationUtilTest.java
+++ b/core/src/test/java/discord4j/core/util/ValidationUtilTest.java
@@ -1,0 +1,62 @@
+package discord4j.core.util;
+
+import discord4j.discordjson.json.gateway.RequestGuildMembers;
+import discord4j.discordjson.possible.Possible;
+import discord4j.gateway.intent.IntentSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ValidationUtilTest {
+
+    @Test
+    public void shouldLetAQueryForAllMembersHappenIfIntentsAreAbsent() {
+        ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("").limit(0).build(),
+            Possible.absent()
+        );
+    }
+
+    @Test
+    public void shouldMakeSureExactlyOneOfQueryOrUserIds() {
+        ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("prefix").limit(0).build(),
+            Possible.absent()
+        );
+
+        ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").addUserId("9876").limit(1).build(),
+            Possible.absent()
+        );
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("prefix").addUserId("5678").limit(0).build(),
+            Possible.absent()
+        ));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").limit(0).build(),
+            Possible.absent()
+        ));
+    }
+
+    @Test
+    public void shouldRequireGuildPresencesIntentsIfRequestingEntireMemberListAndUsingIntents() {
+        ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("").limit(0).build(),
+            Possible.absent()
+        );
+        ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("prefix").limit(0).build(),
+            Possible.of(IntentSet.none())
+        );
+        ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("").limit(100).build(),
+            Possible.of(IntentSet.none())
+        );
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> ValidationUtil.validateRequestGuildMembers(
+            RequestGuildMembers.builder().guildId("1234").query("").limit(0).build(),
+            Possible.of(IntentSet.none())
+        ));
+    }
+}


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** Adds validation for the `requestMembers()` function.

**Justification:** For https://github.com/Discord4J/Discord4J/issues/684