### PR TITLE
RestChannel#createMessage for content and embed only

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -192,7 +192,7 @@ public class RestChannel {
     }
 
     /**
-     * Wrapper for {@link RestChannel#createMessage(MessageCreateRequest)} taking only message content
+     * Wrapper for {@link RestChannel#createMessage(MessageCreateRequest)} taking only message content.
      *
      * @param content The content of the message
      * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -192,6 +192,28 @@ public class RestChannel {
     }
 
     /**
+     * Wrapper for {@link RestChannel#createMessage(MessageCreateRequest)} taking only message content
+     *
+     * @param content The content of the message
+     * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an
+     * error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<MessageData> createMessage(String content) {
+        return createMessage(MessageCreateRequest.builder().content(content).build());
+    }
+
+    /**
+     * Wrapper for {@link RestChannel#createMessage(MessageCreateRequest)} taking an embed only
+     *
+     * @param embed The embed of the message
+     * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an
+     * error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<MessageData> createMessage(EmbedData embed) {
+        return createMessage(MessageCreateRequest.builder().embed(embed).build());
+    }
+
+    /**
      * Request to bulk delete the supplied message IDs.
      *
      * @param messageIds a {@link Publisher} to supply the message IDs to bulk delete.

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -203,7 +203,7 @@ public class RestChannel {
     }
 
     /**
-     * Wrapper for {@link RestChannel#createMessage(MessageCreateRequest)} taking an embed only
+     * Wrapper for {@link RestChannel#createMessage(MessageCreateRequest)} taking an embed only.
      *
      * @param embed The embed of the message
      * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an


### PR DESCRIPTION
**Description:** Adds RestChannel#createMessage taking message content and an embed only

**Justification:** It's annoying having to use EmbedData#builder every time for simple messages like content only or embed only.