### PR TITLE
Add getGuildId and getGuild to classes missing them

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
@@ -230,11 +230,16 @@ class ChannelDispatchHandlers {
 
     static Mono<PinsUpdateEvent> channelPinsUpdate(DispatchContext<ChannelPinsUpdate> context) {
         long channelId = Snowflake.asLong(context.getDispatch().channelId());
+        Long guildId = context.getDispatch().guildId()
+            .toOptional()
+            .map(Snowflake::asLong)
+            .orElse(null);
+
         Instant timestamp = Possible.flatOpt(context.getDispatch().lastPinTimestamp())
                 .map(text -> DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(text, Instant::from))
                 .orElse(null);
 
-        return Mono.just(new PinsUpdateEvent(context.getGateway(), context.getShardInfo(), channelId, timestamp));
+        return Mono.just(new PinsUpdateEvent(context.getGateway(), context.getShardInfo(), channelId, guildId, timestamp));
     }
 
     static Mono<? extends Event> channelUpdate(DispatchContext<ChannelUpdate> context) {

--- a/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
@@ -85,15 +85,19 @@ class MessageDispatchHandlers {
         GatewayDiscordClient gateway = context.getGateway();
         long messageId = Snowflake.asLong(context.getDispatch().id());
         long channelId = Snowflake.asLong(context.getDispatch().channelId());
+        Long guildId = context.getDispatch().guildId()
+            .toOptional()
+            .map(Snowflake::asLong)
+            .orElse(null);
 
         Mono<Void> deleteMessage = context.getStateHolder().getMessageStore().delete(messageId);
 
         return context.getStateHolder().getMessageStore()
                 .find(messageId)
                 .flatMap(deleteMessage::thenReturn)
-                .map(messageBean -> new MessageDeleteEvent(gateway, context.getShardInfo(), messageId, channelId,
+                .map(messageBean -> new MessageDeleteEvent(gateway, context.getShardInfo(), messageId, channelId, guildId,
                         new Message(gateway, messageBean)))
-                .defaultIfEmpty(new MessageDeleteEvent(gateway, context.getShardInfo(), messageId, channelId, null));
+                .defaultIfEmpty(new MessageDeleteEvent(gateway, context.getShardInfo(), messageId, channelId, guildId, null));
     }
 
     static Mono<MessageBulkDeleteEvent> messageDeleteBulk(DispatchContext<MessageDeleteBulk> context) {

--- a/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/channel/PinsUpdateEvent.java
@@ -17,6 +17,8 @@
 package discord4j.core.event.domain.channel;
 
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.Guild;
+import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.channel.MessageChannel;
 import discord4j.common.util.Snowflake;
 import discord4j.gateway.ShardInfo;
@@ -37,11 +39,14 @@ public class PinsUpdateEvent extends ChannelEvent {
 
     private final long channelId;
     @Nullable
+    private final Long guildId;
+    @Nullable
     private final Instant lastPinTimestamp;
 
-    public PinsUpdateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, @Nullable Instant lastPinTimestamp) {
+    public PinsUpdateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, @Nullable Long guildId, @Nullable Instant lastPinTimestamp) {
         super(gateway, shardInfo);
         this.channelId = channelId;
+        this.guildId = guildId;
         this.lastPinTimestamp = lastPinTimestamp;
     }
 
@@ -64,6 +69,29 @@ public class PinsUpdateEvent extends ChannelEvent {
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Guild} the pinned/unpinned
+     * {@link discord4j.core.object.entity.Message} is in, if this happened in a guild.
+     * This may not be available if the {@code Message} is in a private channel.
+     *
+     * @return The ID of the {@link Guild} involved, if present.
+     */
+    public Optional<Snowflake> getGuildId() {
+        return Optional.ofNullable(guildId).map(Snowflake::of);
+    }
+
+    /**
+     * Requests to retrieve the {@link Guild} the pinned/unpinned
+     * {@link discord4j.core.object.entity.Message} is in, if this happened in a guild.
+     * This may not be available if the {@code Message} is in a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the
+     * {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Guild> getGuild() {
+        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/MessageDeleteEvent.java
@@ -17,6 +17,7 @@
 package discord4j.core.event.domain.message;
 
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.channel.MessageChannel;
 import discord4j.common.util.Snowflake;
@@ -40,12 +41,15 @@ public class MessageDeleteEvent extends MessageEvent {
     private final long messageId;
     private final long channelId;
     @Nullable
+    private final Long guildId;
+    @Nullable
     private final Message message;
 
-    public MessageDeleteEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long messageId, long channelId, @Nullable Message message) {
+    public MessageDeleteEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long messageId, long channelId, @Nullable Long guildId, @Nullable Message message) {
         super(gateway, shardInfo);
         this.messageId = messageId;
         this.channelId = channelId;
+        this.guildId = guildId;
         this.message = message;
     }
 
@@ -85,6 +89,29 @@ public class MessageDeleteEvent extends MessageEvent {
      */
     public Mono<MessageChannel> getChannel() {
         return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Guild} the
+     * {@link discord4j.core.object.entity.Message} was deleted from, if present.
+     * This may not be available if the deleted {@code Message} was from a private channel.
+     *
+     * @return The ID of the {@link Guild} involved, if present.
+     */
+    public Optional<Snowflake> getGuildId() {
+        return Optional.ofNullable(guildId).map(Snowflake::of);
+    }
+
+    /**
+     * Requests to retrieve the {@link Guild} the
+     * {@link discord4j.core.object.entity.Message} was deleted from, if present.
+     * This may not be available if the deleted {@code Message} was from a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} that contained the
+     * {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Guild> getGuild() {
+        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -394,6 +394,15 @@ public final class Message implements Entity {
     }
 
     /**
+     * Gets the ID of the guild this message is associated to, if present.
+     *
+     * @return The ID of the guild this message is associated to, if present.
+     */
+    public Optional<Snowflake> getGuildId() {
+        return data.guildId().toOptional().map(Snowflake::of);
+    }
+
+    /**
      * Requests to retrieve the guild this message is associated to, if present.
      *
      * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} this message is associated to,


### PR DESCRIPTION
**Description:** Adds `getGuildId` and `getGuild` methods to PinsUpdateEvent and MessageDeleteEvent, and a `getGuildId` method to the Message entity.

**Justification:** Discord sends the `guildId` on PinsUpdateEvent and MessageDeleteEvent,
so expose them too. The `getGuildId` method was absent in the Message entity despite the presence of a `getGuild` method.