### PR TITLE
Update BanQuerySpec#setDeleteMessageDays

### DIFF
--- a/core/src/main/java/discord4j/core/spec/BanQuerySpec.java
+++ b/core/src/main/java/discord4j/core/spec/BanQuerySpec.java
@@ -33,7 +33,7 @@ public final class BanQuerySpec implements AuditSpec<Map<String, Object>> {
      * @return This spec.
      */
     public BanQuerySpec setDeleteMessageDays(final int days) {
-        request.put("delete-message-days", days);
+        request.put("delete_message_days", days);
         return this;
     }
 


### PR DESCRIPTION
**Description:** The `delete-message-days` has been renamed to `delete_message_days`.

**Justification:** https://github.com/discord/discord-api-docs/commit/b9edace323c9df64c79f104d85984690ae4e2977#diff-c4e1390fca89ecc96b01a093f988fa1cL650