### PR TITLE
Update BanQuerySpec#setDeleteMessageDays

### DIFF
--- a/core/src/main/java/discord4j/core/spec/BanQuerySpec.java
+++ b/core/src/main/java/discord4j/core/spec/BanQuerySpec.java
@@ -33,7 +33,7 @@ public final class BanQuerySpec implements AuditSpec<Map<String, Object>> {
      * @return This spec.
      */
     public BanQuerySpec setDeleteMessageDays(final int days) {
-        request.put("delete-message-days", days);
+        request.put("delete_message_days", days);
         return this;
     }
 

--- a/rest/src/test/java/discord4j/rest/util/RouteUtilsTest.java
+++ b/rest/src/test/java/discord4j/rest/util/RouteUtilsTest.java
@@ -76,10 +76,10 @@ public class RouteUtilsTest {
     @Test
     public void testUriWithQueryParameterRequiringEscape() {
         String template = "/guilds/{guild.id}/bans/{user.id}";
-        String expected = "/guilds/123456789/bans/987654321?reason=you're%20a%20bad%20boi:%20gtfo%20;%3E&delete-message-days=7";
+        String expected = "/guilds/123456789/bans/987654321?reason=you're%20a%20bad%20boi:%20gtfo%20;%3E&delete_message_days=7";
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("reason", "you're a bad boi: gtfo ;>");
-        map.put("delete-message-days", 7);
+        map.put("delete_message_days", 7);
         assertEquals(expected, RouteUtils.expandQuery(RouteUtils.expand(template, 123456789, 987654321), map));
     }
 }


### PR DESCRIPTION
**Description:** The `delete-message-days` has been renamed to `delete_message_days`.

**Justification:** https://github.com/discord/discord-api-docs/commit/b9edace323c9df64c79f104d85984690ae4e2977#diff-c4e1390fca89ecc96b01a093f988fa1cL650