### PR TITLE
Rename delete-message-days to delete_message_days

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -202,7 +202,7 @@ public class RestGuild {
 
     public Mono<Void> createBan(Snowflake userId, @Nullable Integer deleteMessageDays, @Nullable String reason) {
         Map<String, Object> queryParams = new HashMap<>();
-        Optional.ofNullable(deleteMessageDays).ifPresent(value -> queryParams.put("delete-message-days", value));
+        Optional.ofNullable(deleteMessageDays).ifPresent(value -> queryParams.put("delete_message_days", value));
         Optional.ofNullable(reason).ifPresent(value -> queryParams.put("reason", value));
         return restClient.getGuildService().createGuildBan(id, userId.asLong(), queryParams, reason);
     }

--- a/rest/src/test/java/discord4j/rest/util/RouteUtilsTest.java
+++ b/rest/src/test/java/discord4j/rest/util/RouteUtilsTest.java
@@ -73,7 +73,7 @@ public class RouteUtilsTest {
     @Test
     public void testUriWithQueryParameterRequiringEscape() {
         String template = "/guilds/{guild.id}/bans/{user.id}";
-        String expected = "/guilds/123456789/bans/987654321?reason=you%27re%20a%20bad%20boi%3A%20gtfo%20%3B%3E&delete-message-days=7";
+        String expected = "/guilds/123456789/bans/987654321?reason=you%27re%20a%20bad%20boi%3A%20gtfo%20%3B%3E&delete_message_days=7";
         Multimap<String, Object> map = new Multimap<>();
         map.add("reason", "you're a bad boi: gtfo ;>");
         map.add("delete_message_days", 7);


### PR DESCRIPTION
**Description:** Rename `delete-message-days` to `delete_message_days`.

**Justification:** Some fields have not been updated during https://github.com/Discord4J/Discord4J/pull/730 merge.