### PR TITLE
Add default AllowedMentions option

### DIFF
--- a/core/src/main/java/discord4j/core/CoreResources.java
+++ b/core/src/main/java/discord4j/core/CoreResources.java
@@ -19,14 +19,22 @@ package discord4j.core;
 
 import discord4j.common.JacksonResources;
 import discord4j.common.ReactorResources;
+import discord4j.core.object.entity.channel.AllowedMentions;
+import discord4j.discordjson.json.AllowedMentionsData;
 import discord4j.rest.RestResources;
 import discord4j.rest.request.Router;
+import reactor.util.annotation.Nullable;
+
+import java.util.Optional;
 
 /**
  * A set of resources required to build {@link DiscordClient} instances and are used for core Discord4J operations
  * like entity manipulation and API communication.
  */
 public class CoreResources extends RestResources {
+
+    @Nullable
+    private final AllowedMentionsData allowedMentionsData;
 
     /**
      * Create a {@link CoreResources} instance with the given resources.
@@ -35,9 +43,20 @@ public class CoreResources extends RestResources {
      * @param reactorResources Reactor resources to establish connections and schedule tasks
      * @param jacksonResources Jackson data-binding resources to map objects
      * @param router a connector to perform requests against Discord API
+     * @param allowedMentionsData the default {@link AllowedMentionsData} value to use when creating messages
      */
     public CoreResources(String token, ReactorResources reactorResources, JacksonResources jacksonResources,
-                         Router router) {
+                         Router router, @Nullable AllowedMentionsData allowedMentionsData) {
         super(token, reactorResources, jacksonResources, router);
+        this.allowedMentionsData = allowedMentionsData;
+    }
+
+    /**
+     * Get the default AllowedMentions value used when creating messages
+     *
+     * @return Returns the default {@link AllowedMentions} value
+     */
+    public Optional<AllowedMentionsData> getAllowedMentionsData() {
+        return Optional.ofNullable(allowedMentionsData);
     }
 }

--- a/core/src/main/java/discord4j/core/DiscordClientBuilder.java
+++ b/core/src/main/java/discord4j/core/DiscordClientBuilder.java
@@ -17,12 +17,14 @@
 package discord4j.core;
 
 import discord4j.common.GitProperties;
+import discord4j.core.object.entity.channel.AllowedMentions;
 import discord4j.rest.RestClientBuilder;
 import discord4j.rest.request.DefaultRouter;
 import discord4j.rest.request.Router;
 import discord4j.rest.request.RouterOptions;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
 
 import java.util.Properties;
 import java.util.function.Function;
@@ -42,7 +44,7 @@ public final class DiscordClientBuilder<C, O extends RouterOptions> extends Rest
     public static DiscordClientBuilder<DiscordClient, RouterOptions> create(String token) {
         Function<Config, DiscordClient> clientFactory = config -> {
             CoreResources coreResources = new CoreResources(config.getToken(), config.getReactorResources(),
-                    config.getJacksonResources(), config.getRouter());
+                    config.getJacksonResources(), config.getRouter(), config.getAllowedMentions().orElse(null));
             Properties properties = GitProperties.getProperties();
             String url = properties.getProperty(GitProperties.APPLICATION_URL, "https://discord4j.com");
             String name = properties.getProperty(GitProperties.APPLICATION_NAME, "Discord4J");

--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseMessageChannel.java
@@ -77,7 +77,9 @@ class BaseMessageChannel extends BaseChannel implements MessageChannel {
     public final Mono<Message> createMessage(final Consumer<? super MessageCreateSpec> spec) {
         return Mono.defer(
                 () -> {
-                    MessageCreateSpec mutatedSpec = new MessageCreateSpec();
+                    MessageCreateSpec mutatedSpec = new MessageCreateSpec(
+                        this.getClient().getCoreResources().getAllowedMentionsData().orElse(null)
+                    );
                     spec.accept(mutatedSpec);
                     return getRestChannel().createMessage(mutatedSpec.asRequest());
                 })

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -52,7 +52,12 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
     private boolean tts;
     private EmbedData embed;
     private List<Tuple2<String, InputStream>> files;
+    @Nullable
     private AllowedMentionsData allowedMentionsData;
+
+    public MessageCreateSpec(@Nullable AllowedMentionsData allowedMentionsData) {
+        this.allowedMentionsData = allowedMentionsData;
+    }
 
     /**
      * Sets the created {@link Message} contents, up to 2000 characters.


### PR DESCRIPTION
**Description:** Added a default AllowedMentions field to the builder.

**Justification:** This way users won't have to manually set an AllowedMentions in every createMessage call when for example they want to disable all pings on every message.