### PR TITLE
Fix some problematic uses of Possible::get

### DIFF
--- a/core/src/main/java/discord4j/core/object/Embed.java
+++ b/core/src/main/java/discord4j/core/object/Embed.java
@@ -20,6 +20,7 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.discordjson.json.*;
 import discord4j.discordjson.possible.Possible;
 import discord4j.rest.util.Color;
+import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -84,9 +85,11 @@ public final class Embed implements DiscordObject {
      *
      * @return The type of embed, if present.
      */
+    @Nullable
     public Type getType() {
-        // TODO FIXME is this actually Possible?
-        return Type.of(data.type().get());
+        return data.type().toOptional()
+                .map(Type::of)
+                .orElse(null);
     }
 
     /**
@@ -289,9 +292,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The URL of the footer icon (only supports http(s) and attachments).
          */
+        @Nullable
         public String getIconUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.iconUrl().get();
+            return data.iconUrl().toOptional().orElse(null);
         }
 
         /**
@@ -299,9 +302,9 @@ public final class Embed implements DiscordObject {
          *
          * @return A proxied URL of the footer icon.
          */
+        @Nullable
         public String getProxyIconUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.proxyIconUrl().get();
+            return data.proxyIconUrl().toOptional().orElse(null);
         }
     }
 
@@ -334,9 +337,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The source URL of the image (only supports http(s) and attachments).
          */
+        @Nullable
         public String getUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.url().get();
+            return data.url().toOptional().orElse(null);
         }
 
         /**
@@ -344,9 +347,9 @@ public final class Embed implements DiscordObject {
          *
          * @return A proxied URL of the image.
          */
+        @Nullable
         public String getProxyUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.proxyUrl().get();
+            return data.proxyUrl().toOptional().orElse(null);
         }
 
         /**
@@ -355,8 +358,8 @@ public final class Embed implements DiscordObject {
          * @return The height of the image.
          */
         public int getHeight() {
-            // TODO FIXME: is this actually Possible?
-            return data.height().get();
+            return data.height().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
 
         /**
@@ -365,8 +368,8 @@ public final class Embed implements DiscordObject {
          * @return The width of the image.
          */
         public int getWidth() {
-            // TODO FIXME: is this actually Possible?
-            return data.width().get();
+            return data.width().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
     }
 
@@ -399,9 +402,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The source URL of the thumbnail (only supports http(s) and attachments).
          */
+        @Nullable
         public String getUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.url().get();
+            return data.url().toOptional().orElse(null);
         }
 
         /**
@@ -409,9 +412,9 @@ public final class Embed implements DiscordObject {
          *
          * @return A proxied URL of the thumbnail.
          */
+        @Nullable
         public String getProxyUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.proxyUrl().get();
+            return data.proxyUrl().toOptional().orElse(null);
         }
 
         /**
@@ -420,8 +423,8 @@ public final class Embed implements DiscordObject {
          * @return The height of the thumbnail.
          */
         public int getHeight() {
-            // TODO FIXME: is this actually Possible?
-            return data.height().get();
+            return data.height().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
 
         /**
@@ -430,8 +433,8 @@ public final class Embed implements DiscordObject {
          * @return The width of the thumbnail.
          */
         public int getWidth() {
-            // TODO FIXME: is this actually Possible?
-            return data.width().get();
+            return data.width().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
     }
 
@@ -464,9 +467,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The source URL of the video.
          */
+        @Nullable
         public String getUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.url().get();
+            return data.url().toOptional().orElse(null);
         }
 
         /**
@@ -475,8 +478,8 @@ public final class Embed implements DiscordObject {
          * @return The height of the video.
          */
         public int getHeight() {
-            // TODO FIXME: is this actually Possible?
-            return data.height().get();
+            return data.height().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
 
         /**
@@ -485,8 +488,8 @@ public final class Embed implements DiscordObject {
          * @return The width of the video.
          */
         public int getWidth() {
-            // TODO FIXME: is this actually Possible?
-            return data.width().get();
+            return data.width().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
     }
 
@@ -519,9 +522,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The name of the provider.
          */
+        @Nullable
         public String getName() {
-            // TODO FIXME: is this actually Possible?
-            return data.name().get();
+            return data.name().toOptional().orElse(null);
         }
 
         /**
@@ -530,7 +533,6 @@ public final class Embed implements DiscordObject {
          * @return The URL of the provider.
          */
         public Optional<String> getUrl() {
-            // TODO FIXME: is this actually Possible?
             return Possible.flatOpt(data.url());
         }
     }
@@ -567,9 +569,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The name of the author.
          */
+        @Nullable
         public String getName() {
-            // TODO FIXME: is this actually Possible?
-            return data.name().get();
+            return data.name().toOptional().orElse(null);
         }
 
         /**
@@ -577,9 +579,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The URL of the author.
          */
+        @Nullable
         public String getUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.url().get();
+            return data.url().toOptional().orElse(null);
         }
 
         /**
@@ -587,9 +589,9 @@ public final class Embed implements DiscordObject {
          *
          * @return The URL of the author icon (only supports http(s) and attachments).
          */
+        @Nullable
         public String getIconUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.iconUrl().get();
+            return data.iconUrl().toOptional().orElse(null);
         }
 
         /**
@@ -597,9 +599,9 @@ public final class Embed implements DiscordObject {
          *
          * @return A proxied URL of the author icon.
          */
+        @Nullable
         public String getProxyIconUrl() {
-            // TODO FIXME: is this actually Possible?
-            return data.proxyIconUrl().get();
+            return data.proxyIconUrl().toOptional().orElse(null);
         }
     }
 
@@ -657,8 +659,8 @@ public final class Embed implements DiscordObject {
          * @return {@code true} if this field should display inline, {@code false} otherwise.
          */
         public boolean isInline() {
-            // TODO FIXME: is this actually Possible?
-            return data.inline().get();
+            return data.inline().toOptional()
+                    .orElseThrow(IllegalStateException::new);
         }
     }
 

--- a/core/src/main/java/discord4j/core/object/MessageReference.java
+++ b/core/src/main/java/discord4j/core/object/MessageReference.java
@@ -35,8 +35,7 @@ public class MessageReference implements DiscordObject {
     }
 
     public Snowflake getChannelId() {
-        // TODO FIXME: is this actually Possible?
-        return Snowflake.of(data.channelId().get());
+        return Snowflake.of(data.channelId().toOptional().orElseThrow(IllegalStateException::new));
     }
 
     public Optional<Snowflake> getGuildId() {

--- a/core/src/main/java/discord4j/core/object/VoiceState.java
+++ b/core/src/main/java/discord4j/core/object/VoiceState.java
@@ -64,8 +64,10 @@ public final class VoiceState implements DiscordObject {
      * @return The guild ID this voice state is for.
      */
     public Snowflake getGuildId() {
-        // TODO FIXME: why is this Possible?
-        return Snowflake.of(data.guildId().get());
+        // Even though Discord's raw Voice State structure does not include the guild_id key when sent in the
+        // voice_states for a guild_create, we manually populate the field in GuildDispatchHandlers.guildCreate, so
+        // it should always be present, making this safe.
+        return Snowflake.of(data.guildId().toOptional().orElseThrow(IllegalStateException::new));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
@@ -18,6 +18,7 @@ package discord4j.core.object.entity;
 
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.retriever.EntityRetrievalStrategy;
+import discord4j.discordjson.json.UserData;
 import discord4j.rest.util.Image;
 import discord4j.common.util.Snowflake;
 import discord4j.core.spec.GuildEmojiEditSpec;
@@ -42,7 +43,6 @@ import static discord4j.rest.util.Image.Format.PNG;
  * <p>
  * <a href="https://discord.com/developers/docs/resources/emoji#emoji-resource">Emoji Resource</a>
  */
-// TODO FIXME so many gets
 public final class GuildEmoji implements Entity {
 
     /** The path for {@code GuildEmoji} image URLs. */
@@ -77,7 +77,9 @@ public final class GuildEmoji implements Entity {
 
     @Override
     public Snowflake getId() {
-        return Snowflake.of(data.id().get()); // this is safe for guild emojis
+        return data.id()
+                .map(Snowflake::of)
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**
@@ -86,7 +88,8 @@ public final class GuildEmoji implements Entity {
      * @return The emoji name.
      */
     public String getName() {
-        return data.name().get();
+        return data.name()
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**
@@ -95,9 +98,11 @@ public final class GuildEmoji implements Entity {
      * @return The IDs of the roles this emoji is whitelisted to.
      */
     public Set<Snowflake> getRoleIds() {
-        return data.roles().get().stream()
-                .map(Snowflake::of)
-                .collect(Collectors.toSet());
+        return data.roles().toOptional()
+                .map(roles -> roles.stream()
+                        .map(Snowflake::of)
+                        .collect(Collectors.toSet()))
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**
@@ -135,9 +140,12 @@ public final class GuildEmoji implements Entity {
      * an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<User> getUser() {
+        UserData user = data.user().toOptional()
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
+
         return gateway.getRestClient().getEmojiService()
                 .getGuildEmoji(getGuildId().asLong(), getId().asLong())
-                .map(data -> new User(gateway, data.user().get()));
+                .map(data -> new User(gateway, user));
     }
 
     /**
@@ -146,7 +154,8 @@ public final class GuildEmoji implements Entity {
      * @return {@code true} if this emoji must be wrapped in colons, {@code false} otherwise.
      */
     public boolean requiresColons() {
-        return data.requireColons().get();
+        return data.requireColons().toOptional()
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**
@@ -155,7 +164,8 @@ public final class GuildEmoji implements Entity {
      * @return {@code true} if this emoji is managed, {@code false} otherwise.
      */
     public boolean isManaged() {
-        return data.managed().get();
+        return data.managed().toOptional()
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**
@@ -164,7 +174,8 @@ public final class GuildEmoji implements Entity {
      * @return {@code true} if this emoji is animated, {@code false} otherwise.
      */
     public boolean isAnimated() {
-        return data.animated().get();
+        return data.animated().toOptional()
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**
@@ -173,7 +184,8 @@ public final class GuildEmoji implements Entity {
      * @return {@code true} if this emoji is available, {@code false} otherwise (due to loss of Server Boosts for example).
      */
     public boolean isAvailable() {
-        return data.available().get();
+        return data.available().toOptional()
+                .orElseThrow(IllegalStateException::new); // this should be safe for guild emojis
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -47,7 +47,8 @@ public final class TextChannel extends BaseGuildMessageChannel {
      * @return The amount of seconds an user has to wait before sending another message (0-120).
      */
     public int getRateLimitPerUser() {
-        return getData().rateLimitPerUser().get();
+        return getData().rateLimitPerUser().toOptional()
+                .orElseThrow(IllegalStateException::new); // this should be safe for all TextChannels
     }
 
     /**


### PR DESCRIPTION
**Description:**
Replace many uses of Possible::get with explicit `orElseThrow`. These were mostly in places in `core` entities where it wasn't clear previously if the fields actually had the potential to be absent. I have included comments to explain where the equivalent `get()` would have been safe. 

In the case of `Embed`, many of the uses of `get()` were not safe and resulted in errors. For now, they have been updated to return `null` instead. A following PR targeted to 3.2 will make them `Optional`. 

**Justification:**
Fixes #747
