### PR TITLE
Add support for channel following

### DIFF
--- a/core/src/main/java/discord4j/core/object/FollowedChannel.java
+++ b/core/src/main/java/discord4j/core/object/FollowedChannel.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.object;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.Webhook;
+import discord4j.core.object.entity.channel.NewsChannel;
+import discord4j.core.retriever.EntityRetrievalStrategy;
+import discord4j.discordjson.json.FollowedChannelData;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+/**
+ * A news channel that has been followed.
+ */
+public class FollowedChannel implements DiscordObject {
+
+    /**
+     * The gateway associated to this object.
+     */
+    private final GatewayDiscordClient gateway;
+
+    /**
+     * The raw data as represented by Discord.
+     */
+    private final FollowedChannelData data;
+
+    public FollowedChannel(final GatewayDiscordClient gateway, final FollowedChannelData data) {
+        this.gateway = Objects.requireNonNull(gateway);
+        this.data = Objects.requireNonNull(data);
+    }
+
+    @Override
+    public final GatewayDiscordClient getClient() {
+        return gateway;
+    }
+
+    /**
+     * Returns the ID of the news channel that has been followed.
+     *
+     * @return the news channel ID
+     */
+    public Snowflake getNewsChannelId() {
+        return Snowflake.of(data.channelId());
+    }
+
+    /**
+     * Requests to retrieve the news channel that has been followed.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link NewsChannel news channel} that has
+     * been followed. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<NewsChannel> getNewsChannel() {
+        return gateway.getChannelById(Snowflake.of(data.channelId()))
+                .cast(NewsChannel.class);
+    }
+
+    /**
+     * Requests to retrieve the news channel that has been followed, using the given retrieval strategy.
+     *
+     * @param retrievalStrategy the strategy to use to get the news channel
+     * @return A {@link Mono} where, upon successful completion, emits the {@link NewsChannel news channel} that has
+     * been followed. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<NewsChannel> getNewsChannel(EntityRetrievalStrategy retrievalStrategy) {
+        return gateway.withRetrievalStrategy(retrievalStrategy)
+                .getChannelById(Snowflake.of(data.channelId()))
+                .cast(NewsChannel.class);
+    }
+
+    /**
+     * Returns the ID of the webhook created as the result of following the news channel.
+     *
+     * @return the webhook ID
+     */
+    public Snowflake getWebhookId() {
+        return Snowflake.of(data.webhookId());
+    }
+
+    /**
+     * Requests to retrieve the webhook that has been created when following the news channel. Requires
+     * 'MANAGE_WEBHOOKS' permission.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Webhook webhook} that has been created
+     * when following the news channel. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Webhook> getWebhook() {
+        return gateway.getWebhookById(Snowflake.of(data.webhookId()));
+    }
+}

--- a/core/src/main/java/discord4j/core/object/FollowedChannel.java
+++ b/core/src/main/java/discord4j/core/object/FollowedChannel.java
@@ -97,6 +97,9 @@ public class FollowedChannel implements DiscordObject {
      * Requests to retrieve the webhook that has been created when following the news channel. Requires
      * 'MANAGE_WEBHOOKS' permission.
      *
+     * <p>
+     * Note that the returned webhook cannot be executed, but can be deleted.
+     *
      * @return A {@link Mono} where, upon successful completion, emits the {@link Webhook webhook} that has been created
      * when following the news channel. If an error is received, it is emitted through the {@code Mono}.
      */

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.object.entity.channel;
 
+import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.FollowedChannel;
@@ -66,6 +67,7 @@ public final class NewsChannel extends BaseGuildMessageChannel {
      * @param targetChannelId the ID of the channel where to create the follow webhook
      * @return
      */
+    @Experimental
     public Mono<FollowedChannel> follow(Snowflake targetChannelId) {
         return getClient().getRestClient().getChannelService()
                 .followNewsChannel(getId().asLong(), NewsChannelFollowRequest.builder()

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -16,10 +16,13 @@
  */
 package discord4j.core.object.entity.channel;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.FollowedChannel;
 import discord4j.core.spec.NewsChannelEditSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.discordjson.json.ChannelData;
+import discord4j.discordjson.json.NewsChannelFollowRequest;
 import reactor.core.publisher.Mono;
 
 import java.util.function.Consumer;
@@ -54,6 +57,21 @@ public final class NewsChannel extends BaseGuildMessageChannel {
                 })
                 .map(data -> EntityUtil.getChannel(getClient(), data))
                 .cast(NewsChannel.class);
+    }
+
+    /**
+     * Requests to follow this news channel. Following will create a webhook in the channel which ID is specified.
+     * Requires 'MANAGE_WEBHOOKS' permission.
+     *
+     * @param targetChannelId the ID of the channel where to create the follow webhook
+     * @return
+     */
+    public Mono<FollowedChannel> follow(Snowflake targetChannelId) {
+        return getClient().getRestClient().getChannelService()
+                .followNewsChannel(getId().asLong(), NewsChannelFollowRequest.builder()
+                        .webhookChannelId(targetChannelId.asString())
+                        .build())
+                .map(data -> new FollowedChannel(getClient(), data));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -65,7 +65,8 @@ public final class NewsChannel extends BaseGuildMessageChannel {
      * Requires 'MANAGE_WEBHOOKS' permission.
      *
      * @param targetChannelId the ID of the channel where to create the follow webhook
-     * @return
+     * @return a {@link FollowedChannel} object containing a reference to this news channel and allowing to retrieve the
+     * webhook created.
      */
     @Experimental
     public Mono<FollowedChannel> follow(Snowflake targetChannelId) {

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -396,6 +396,18 @@ public class RestChannel {
     }
 
     /**
+     * Requests to follow this channel. Only works if this channel represents a news channel. Following this channel
+     * will create a webhook in a chosen target channel where 'MANAGE_WEBHOOKS' permission is granted.
+     *
+     * @param request the request to follow this channel
+     * @return A {@link Mono} where, upon successful completion, emits the data indicating that the channel has been
+     * followed. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<FollowedChannelData> follow(NewsChannelFollowRequest request) {
+        return restClient.getChannelService().followNewsChannel(id, request);
+    }
+
+    /**
      * Request to trigger the typing indicator in this channel. A single invocation of this method will trigger the
      * indicator for 10 seconds or until the bot sends a message in this channel.
      *

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -296,6 +296,13 @@ public abstract class Routes {
     public static final Route CHANNEL_PERMISSION_DELETE = Route.delete("/channels/{channel.id}/permissions/{overwrite.id}");
 
     /**
+     * Follow a News Channel to send messages to a target channel. Requires the `MANAGE_WEBHOOKS` permission in the
+     * target channel. Returns a followed channel object.
+     */
+    @Experimental
+    public static final Route FOLLOW_NEWS_CHANNEL = Route.post("/channels/{channel.id}/followers");
+
+    /**
      * Post a typing indicator for the specified channel. Generally bots should not implement this route. However, if a
      * bot is responding to a command and expects the computation to take a few seconds, this endpoint may be called to
      * let the user know that the bot is processing their message. Returns a 204 empty response on success. Fires a

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -184,6 +184,13 @@ public class ChannelService extends RestService {
                 .bodyToMono(Void.class);
     }
 
+    public Mono<FollowedChannelData> followNewsChannel(long channelId, NewsChannelFollowRequest request) {
+        return Routes.FOLLOW_NEWS_CHANNEL.newRequest(channelId)
+                .body(request)
+                .exchange(getRouter())
+                .bodyToMono(FollowedChannelData.class);
+    }
+
     public Mono<Void> triggerTypingIndicator(long channelId) {
         return Routes.TYPING_INDICATOR_TRIGGER.newRequest(channelId)
                 .exchange(getRouter())

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -184,6 +184,7 @@ public class ChannelService extends RestService {
                 .bodyToMono(Void.class);
     }
 
+    @Experimental
     public Mono<FollowedChannelData> followNewsChannel(long channelId, NewsChannelFollowRequest request) {
         return Routes.FOLLOW_NEWS_CHANNEL.newRequest(channelId)
                 .body(request)


### PR DESCRIPTION
:warning: **Depends on https://github.com/Discord4J/discord-json/pull/27**

**Description:**
* Add `NewsChannel#follow(Snowflake)` - Follow the news channel, creating webhook to target channel given in argument
* Create `FollowedChannel` class which is the response returned when following a channel (allows to retrieve the news channel instance and the newly created webhook)
* Added corresponding routes and requests in the rest module

**Justification:** There is this PR on discord docs repo: https://github.com/discord/discord-api-docs/pull/1692/files
The /crosspost endpoint was already implemented via https://github.com/Discord4J/Discord4J/pull/665 but not the /followers one.