### PR TITLE
Add joined_at field to GuildMemberUpdate

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -446,6 +446,7 @@ class GuildDispatchHandlers {
                 .map(Snowflake::asLong)
                 .collect(Collectors.toList());
         String currentNick = Possible.flatOpt(context.getDispatch().nick()).orElse(null);
+        String currentJoinedAt = context.getDispatch().joinedAt();
         String currentPremiumSince = Possible.flatOpt(context.getDispatch().premiumSince()).orElse(null);
 
         LongLongTuple2 key = LongLongTuple2.of(guildId, memberId);
@@ -465,11 +466,11 @@ class GuildDispatchHandlers {
                     return context.getStateHolder().getMemberStore()
                             .save(key, newMember)
                             .thenReturn(new MemberUpdateEvent(gateway, context.getShardInfo(), guildId, memberId, old,
-                                    currentRoles, currentNick, currentPremiumSince));
+                                    currentRoles, currentNick, currentJoinedAt, currentPremiumSince));
                 });
 
         return update.defaultIfEmpty(new MemberUpdateEvent(gateway, context.getShardInfo(), guildId, memberId, null,
-                currentRoles, currentNick, currentPremiumSince));
+                currentRoles, currentNick, currentJoinedAt, currentPremiumSince));
     }
 
     static Mono<RoleCreateEvent> guildRoleCreate(DispatchContext<GuildRoleCreate> context) {

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -49,12 +49,13 @@ public class MemberUpdateEvent extends GuildEvent {
     private final List<Long> currentRoles;
     @Nullable
     private final String currentNickname;
+    private final String currentJoinedAt;
     @Nullable
     private final String currentPremiumSince;
 
     public MemberUpdateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long guildId, long memberId,
                              @Nullable Member old, List<Long> currentRoles, @Nullable String currentNickname,
-                             @Nullable String currentPremiumSince) {
+                             String currentJoinedAt, @Nullable String currentPremiumSince) {
         super(gateway, shardInfo);
 
         this.guildId = guildId;
@@ -62,6 +63,7 @@ public class MemberUpdateEvent extends GuildEvent {
         this.old = old;
         this.currentRoles = currentRoles;
         this.currentNickname = currentNickname;
+        this.currentJoinedAt = currentJoinedAt;
         this.currentPremiumSince = currentPremiumSince;
     }
 
@@ -134,6 +136,15 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
+     * Gets the current join time of the {@link Member} involved in this event.
+     *
+     * @return The current join time of the {@link Member} involved in this event.
+     */
+    public Instant getJoinTime() {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(currentJoinedAt, Instant::from);
+    }
+
+    /**
      * Gets when the user started boosting the guild, if present.
      *
      * @return When the user started boosting the guild, if present.
@@ -151,6 +162,7 @@ public class MemberUpdateEvent extends GuildEvent {
                 ", old=" + old +
                 ", currentRoles=" + currentRoles +
                 ", currentNickname='" + currentNickname + '\'' +
+                ", currentJoinedAt='" + currentJoinedAt + '\'' +
                 ", currentPremiumSince='" + currentPremiumSince + '\'' +
                 '}';
     }


### PR DESCRIPTION
**Description:** Add `joined_at` field to `GuildMemberUpdate` event.

**Justification:** https://github.com/Discord4J/discord-json/pull/28