### PR TITLE
Add VoiceStateUpdateEvent utility functions

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/VoiceStateUpdateEvent.java
@@ -64,6 +64,36 @@ public class VoiceStateUpdateEvent extends Event {
         return Optional.ofNullable(old);
     }
 
+    /**
+     * Gets whether this event is a voice channel join event.
+     *
+     * @return {@code true} if this is a voice channel join event, {@code false} otherwise.
+     */
+    public boolean isJoinEvent() {
+        return current.getChannelId().isPresent() && old == null;
+    }
+
+    /**
+     * Gets whether this event is a voice channel leave event.
+     *
+     * @return {@code true} if this is a voice channel leave event, {@code false} otherwise.
+     */
+    public boolean isLeaveEvent() {
+        return !current.getChannelId().isPresent() && old != null;
+    }
+
+    /**
+     * Gets whether this event is a voice channel move event.
+     *
+     * @return {code true} if this is a voice channel move event, {@code false} otherwise.
+     */
+    public boolean isMoveEvent() {
+        if(old == null) {
+            return false;
+        }
+        return !current.getChannelId().flatMap(current -> old.getChannelId().map(current::equals)).orElse(true);
+    }
+
     @Override
     public String toString() {
         return "VoiceStateUpdateEvent{" +


### PR DESCRIPTION
**Description:** This pull request is a draft because I'm not really satisfied with the javadoc and the method naming. Anyway, this PR is open to discuss the usefulness of these changes.

**Justification:** Discord API only provides one event to all voice state updates. It may be hard to determine if the event is related to a user joining, leaving or moving voice channel. This PR tries to improve that.