### PR TITLE
Changes in Crosspost and Follow methods

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -573,10 +573,10 @@ public final class Message implements Entity {
 
     /**
      * Requests to publish (crosspost) this message if the {@code channel} is of type 'news'.
+     * Requires 'SEND_MESSAGES' permission if the current user sent the message, or additionally the 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
      *
      * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds. If an error is
      * received, it is emitted through the {@code Mono}.
-     *
      */
     public Mono<Message> publish() {
         return gateway.getRestClient().getChannelService()

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -574,13 +574,14 @@ public final class Message implements Entity {
     /**
      * Requests to publish (crosspost) this message if the {@code channel} is of type 'news'.
      *
-     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the message was published
-     * (crossposted) in the guilds. If an error is received, it is emitted through the {@code Mono}.
+     * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds. If an error is
+     * received, it is emitted through the {@code Mono}.
+     *
      */
-    @Experimental
-    public Mono<Void> publish() {
+    public Mono<Message> publish() {
         return gateway.getRestClient().getChannelService()
-                .publishMessage(getChannelId().asLong(), getId().asLong());
+            .publishMessage(getChannelId().asLong(), getId().asLong())
+            .map(data -> new Message(gateway, data));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -68,7 +68,6 @@ public final class NewsChannel extends BaseGuildMessageChannel {
      * @return a {@link FollowedChannel} object containing a reference to this news channel and allowing to retrieve the
      * webhook created.
      */
-    @Experimental
     public Mono<FollowedChannel> follow(Snowflake targetChannelId) {
         return getClient().getRestClient().getChannelService()
                 .followNewsChannel(getId().asLong(), NewsChannelFollowRequest.builder()

--- a/rest/src/main/java/discord4j/rest/entity/RestMessage.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMessage.java
@@ -151,11 +151,10 @@ public class RestMessage {
     /**
      * Requests to publish (crosspost) this message if the {@code channel} is of type 'news'.
      *
-     * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the message was published
+     * @return A {@link Mono} where, upon successful completion, emits the published {@link MessageData}
      * (crossposted) in the guilds. If an error is received, it is emitted through the {@code Mono}.
      */
-    @Experimental
-    public Mono<Void> publish() {
+    public Mono<MessageData> publish() {
         return restClient.getChannelService().publishMessage(channelId, id);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestMessage.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMessage.java
@@ -150,9 +150,11 @@ public class RestMessage {
 
     /**
      * Requests to publish (crosspost) this message if the {@code channel} is of type 'news'.
+     * Requires 'SEND_MESSAGES' permission if the current user sent the message, or additionally the 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
      *
      * @return A {@link Mono} where, upon successful completion, emits the published {@link MessageData}
      * (crossposted) in the guilds. If an error is received, it is emitted through the {@code Mono}.
+     * @see <a href="https://discord.com/developers/docs/resources/channel#crosspost-message">Crosspost Message</a>
      */
     public Mono<MessageData> publish() {
         return restClient.getChannelService().publishMessage(channelId, id);

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -249,9 +249,13 @@ public abstract class Routes {
 
     /**
      * Crosspost a Message into all guilds what follow the news channel indicated. This endpoint requires the
-     * 'DISCOVERY' feature to be present for the guild.
+     * 'DISCOVERY' feature to be present for the guild and requires the 'SEND_MESSAGES' permission, if the current user
+     * sent the message, or additionally the 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
      * <p>
      * Returns a 204 empty response on success.
+     *
+     * @see <a href="https://discord.com/developers/docs/resources/channel#crosspost-message">
+     *         https://discord.com/developers/docs/resources/channel#crosspost-message</a>
      */
     public static final Route CROSSPOST_MESSAGE = Route.post("/channels/{channel.id}/messages/{message.id}/crosspost");
 
@@ -297,8 +301,10 @@ public abstract class Routes {
     /**
      * Follow a News Channel to send messages to a target channel. Requires the `MANAGE_WEBHOOKS` permission in the
      * target channel. Returns a followed channel object.
+     *
+     * @see <a href="https://discord.com/developers/docs/resources/channel#follow-news-channel">
+     *         https://discord.com/developers/docs/resources/channel#follow-news-channel</a>
      */
-    @Experimental
     public static final Route FOLLOW_NEWS_CHANNEL = Route.post("/channels/{channel.id}/followers");
 
     /**

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -253,7 +253,6 @@ public abstract class Routes {
      * <p>
      * Returns a 204 empty response on success.
      */
-    @Experimental
     public static final Route CROSSPOST_MESSAGE = Route.post("/channels/{channel.id}/messages/{message.id}/crosspost");
 
     /**

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -146,11 +146,10 @@ public class ChannelService extends RestService {
                 .bodyToMono(Void.class);
     }
 
-    @Experimental
-    public Mono<Void> publishMessage(long channelId, long messageId) {
+    public Mono<MessageData> publishMessage(long channelId, long messageId) {
         return Routes.CROSSPOST_MESSAGE.newRequest(channelId, messageId)
                 .exchange(getRouter())
-                .bodyToMono(Void.class);
+                .bodyToMono(MessageData.class);
     }
 
     public Mono<Void> editChannelPermissions(long channelId, long overwriteId, PermissionsEditRequest request,

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -183,7 +183,6 @@ public class ChannelService extends RestService {
                 .bodyToMono(Void.class);
     }
 
-    @Experimental
     public Mono<FollowedChannelData> followNewsChannel(long channelId, NewsChannelFollowRequest request) {
         return Routes.FOLLOW_NEWS_CHANNEL.newRequest(channelId)
                 .body(request)


### PR DESCRIPTION
**Description:** Discord release in docs the crosspost and follow endpoints, in the case of crosspost now confirm the endpoint return the Message published (when make the PR only return a empty). Then i change the returns and remove the experimental annotation.

**Justification:** https://github.com/discord/discord-api-docs/commit/960a8eaf13a55453e9a5aeafb1086645906d25ec