### PR TITLE
Support for the COMPETING Activity type

### DIFF
--- a/core/src/main/java/discord4j/core/GatewayDiscordClient.java
+++ b/core/src/main/java/discord4j/core/GatewayDiscordClient.java
@@ -310,6 +310,7 @@ public class GatewayDiscordClient implements EntityRetriever {
      *     <li>{@link Activity#playing(String)}</li>
      *     <li>{@link Activity#streaming(String, String)}</li>
      *     <li>{@link Activity#watching(String)}</li>
+     *     <li>{@link Activity#competing(String)}</li>
      * </ul>
      *
      * @param statusUpdate The updated client status.
@@ -337,6 +338,7 @@ public class GatewayDiscordClient implements EntityRetriever {
      *     <li>{@link Activity#playing(String)}</li>
      *     <li>{@link Activity#streaming(String, String)}</li>
      *     <li>{@link Activity#watching(String)}</li>
+     *     <li>{@link Activity#competing(String)}</li>
      * </ul>
      *
      * @param statusUpdate The updated client presence.

--- a/core/src/main/java/discord4j/core/object/presence/Activity.java
+++ b/core/src/main/java/discord4j/core/object/presence/Activity.java
@@ -61,6 +61,13 @@ public class Activity {
                 .build();
     }
 
+    public static ActivityUpdateRequest competing(String name) {
+        return ActivityUpdateRequest.builder()
+            .name(name)
+            .type(Type.COMPETING.getValue())
+            .build();
+    }
+
     private final ActivityData data;
 
     Activity(final ActivityData data) {
@@ -311,7 +318,10 @@ public class Activity {
         WATCHING(3),
 
         /** {emoji} {name} */
-        CUSTOM(4);
+        CUSTOM(4),
+
+        /** "Competing in {name}" */
+        COMPETING(5);
 
         /** The underlying value as represented by Discord. */
         private final int value;
@@ -348,6 +358,7 @@ public class Activity {
                 case 2: return LISTENING;
                 case 3: return WATCHING;
                 case 4: return CUSTOM;
+                case 5: return COMPETING;
                 default: return UNKNOWN;
             }
         }

--- a/core/src/main/java/discord4j/core/object/presence/Presence.java
+++ b/core/src/main/java/discord4j/core/object/presence/Presence.java
@@ -64,6 +64,7 @@ public final class Presence {
      *     <li>{@link Activity#playing(String)}</li>
      *     <li>{@link Activity#streaming(String, String)}</li>
      *     <li>{@link Activity#watching(String)}</li>
+     *     <li>{@link Activity#competing(String)}</li>
      * </ul>
      *
      * @return a {@link StatusUpdate} for the ONLINE status
@@ -100,6 +101,7 @@ public final class Presence {
      *     <li>{@link Activity#playing(String)}</li>
      *     <li>{@link Activity#streaming(String, String)}</li>
      *     <li>{@link Activity#watching(String)}</li>
+     *     <li>{@link Activity#competing(String)}</li>
      * </ul>
      *
      * @return a {@link StatusUpdate} for the DO_NOT_DISTURB status
@@ -136,6 +138,7 @@ public final class Presence {
      *     <li>{@link Activity#playing(String)}</li>
      *     <li>{@link Activity#streaming(String, String)}</li>
      *     <li>{@link Activity#watching(String)}</li>
+     *     <li>{@link Activity#competing(String)}</li>
      * </ul>
      *
      * @return a {@link StatusUpdate} for the IDLE status


### PR DESCRIPTION
**Description:** Support for the new Activity type for presence the "Competing", this can be used by bots.
![image](https://user-images.githubusercontent.com/3602279/93154618-74235f00-f6da-11ea-8943-9ab170954db8.png)

**Justification:** https://github.com/discord/discord-api-docs/commit/cd6c72a9a297c32ef59f3243eaddd9167fb4e1c3