### PR TITLE
Add methods for obtaining an existing, registered VoiceConnection to associated entities

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -1372,10 +1372,9 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Requests to retrieve the voice connection that the client is propagating in this guild.
+     * Returns the current voice connection registered for this guild.
      *
-     * @return A {@link Mono} that emits the voice connection that the client is propagating in this guild, if present,
-     * or an empty {@link Mono} otherwise.
+     * @return A {@link Mono} of {@link VoiceConnection} for this guild if present, or empty otherwise.
      */
     public Mono<VoiceConnection> getVoiceConnection() {
         return gateway.getVoiceConnectionRegistry().getVoiceConnection(getId());

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -38,6 +38,7 @@ import discord4j.discordjson.possible.Possible;
 import discord4j.rest.util.Image;
 import discord4j.rest.util.PaginationUtil;
 import discord4j.store.api.util.LongLongTuple2;
+import discord4j.voice.VoiceConnection;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
@@ -1368,6 +1369,16 @@ public final class Guild implements Entity {
                         sink.complete();
                     }
                 });
+    }
+
+    /**
+     * Requests to retrieve the voice connection that the client is propagating in this guild.
+     *
+     * @return A {@link Mono} that emits the voice connection that the client is propagating in this guild, if present,
+     * or an empty {@link Mono} otherwise.
+     */
+    public Mono<VoiceConnection> getVoiceConnection() {
+        return gateway.getVoiceConnectionRegistry().getVoiceConnection(getId());
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -175,10 +175,11 @@ public final class VoiceChannel extends BaseCategorizableChannel {
     }
 
     /**
-     * Requests to retrieve the voice connection that the client is propagating in this voice channel.
+     * Returns the current voice connection registered for this voice channel's guild.
      *
-     * @return A {@link Mono} that emits the voice connection associated with this voice channel, if present and if
-     * available from caching sources, or an empty {@link Mono} otherwise.
+     * @return A {@link Mono} of {@link VoiceConnection} for this voice channel's guild if present, or empty otherwise.
+     * The resulting {@code Mono} will also complete empty if the registered voice connection is not associated with
+     * this voice channel.
      */
     public Mono<VoiceConnection> getVoiceConnection() {
         return getGuild()

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -19,6 +19,7 @@ package discord4j.core.object.entity.channel;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.VoiceState;
+import discord4j.core.object.entity.Guild;
 import discord4j.core.spec.VoiceChannelEditSpec;
 import discord4j.core.spec.VoiceChannelJoinSpec;
 import discord4j.core.util.EntityUtil;
@@ -101,7 +102,9 @@ public final class VoiceChannel extends BaseCategorizableChannel {
     /**
      * Request to join this voice channel upon subscription. The resulting {@link VoiceConnection} will be available
      * to you from the {@code Mono} but also through a {@link VoiceConnectionRegistry} and can be obtained through
-     * {@link GatewayDiscordClient#getVoiceConnectionRegistry()}.
+     * {@link GatewayDiscordClient#getVoiceConnectionRegistry()}. Additionally, the resulting {@code VoiceConnection}
+     * can be retrieved from the associated guild through {@link Guild#getVoiceConnection()} and through
+     * {@link #getVoiceConnection()}.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link VoiceChannelJoinSpec} to be operated on.
      * @return A {@link Mono} where, upon successful completion, emits a {@link VoiceConnection}, indicating a
@@ -169,6 +172,18 @@ public final class VoiceChannel extends BaseCategorizableChannel {
         return getVoiceStates()
                 .map(VoiceState::getUserId)
                 .any(memberId::equals);
+    }
+
+    /**
+     * Requests to retrieve the voice connection that the client is propagating in this voice channel.
+     *
+     * @return A {@link Mono} that emits the voice connection associated with this voice channel, if present and if
+     * available from caching sources, or an empty {@link Mono} otherwise.
+     */
+    public Mono<VoiceConnection> getVoiceConnection() {
+        return getGuild()
+            .flatMap(Guild::getVoiceConnection)
+            .filterWhen(voiceConnection -> voiceConnection.getChannelId().map(channelId -> channelId.equals(getId())));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -182,8 +182,8 @@ public final class VoiceChannel extends BaseCategorizableChannel {
      */
     public Mono<VoiceConnection> getVoiceConnection() {
         return getGuild()
-            .flatMap(Guild::getVoiceConnection)
-            .filterWhen(voiceConnection -> voiceConnection.getChannelId().map(channelId -> channelId.equals(getId())));
+                .flatMap(Guild::getVoiceConnection)
+                .filterWhen(voiceConnection -> voiceConnection.getChannelId().map(channelId -> channelId.equals(getId())));
     }
 
     @Override


### PR DESCRIPTION
**Description:** Adds method to obtain a VoiceConnection registered to a guild snowflake through VoiceConnectionRegistry directly to Guild. Also adds a method to obtain a registered VoiceConnection from a VoiceChannel.

**Justification:** https://discordapp.com/channels/208023865127862272/451125724766535710/758786914496151562