### PR TITLE
[NOT FOR MERGE] [#782] Prototype for new Stores API and usage in Core module

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchContext.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchContext.java
@@ -18,7 +18,7 @@
 package discord4j.core.event.dispatch;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.state.StateHolder;
+import discord4j.core.newstoresapi.Store;
 import discord4j.gateway.ShardInfo;
 
 /**
@@ -31,18 +31,18 @@ public class DispatchContext<D> {
 
     private final D dispatch;
     private final GatewayDiscordClient gateway;
-    private final StateHolder stateHolder;
+    private final Store store;
     private final ShardInfo shardInfo;
 
     public static <D> DispatchContext<D> of(D dispatch, GatewayDiscordClient gateway,
-                                            StateHolder stateHolder, ShardInfo shardInfo) {
-        return new DispatchContext<>(dispatch, gateway, stateHolder, shardInfo);
+                                            Store store, ShardInfo shardInfo) {
+        return new DispatchContext<>(dispatch, gateway, store, shardInfo);
     }
 
-    private DispatchContext(D dispatch, GatewayDiscordClient gateway, StateHolder stateHolder, ShardInfo shardInfo) {
+    private DispatchContext(D dispatch, GatewayDiscordClient gateway, Store store, ShardInfo shardInfo) {
         this.dispatch = dispatch;
         this.gateway = gateway;
-        this.stateHolder = stateHolder;
+        this.store = store;
         this.shardInfo = shardInfo;
     }
 
@@ -54,11 +54,15 @@ public class DispatchContext<D> {
         return gateway;
     }
 
-    public StateHolder getStateHolder() {
-        return stateHolder;
+    public Store getStore() {
+        return store;
     }
 
     public ShardInfo getShardInfo() {
         return shardInfo;
+    }
+
+    public String getShardTag() {
+        return "shard/" + shardInfo.getIndex();
     }
 }

--- a/core/src/main/java/discord4j/core/newstoresapi/DataIdentifier.java
+++ b/core/src/main/java/discord4j/core/newstoresapi/DataIdentifier.java
@@ -1,0 +1,36 @@
+package discord4j.core.newstoresapi;
+
+import discord4j.common.util.Snowflake;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class DataIdentifier {
+
+    private final DataIdentifier parent;
+    private final EntityType type;
+    private final Snowflake snowflake;
+
+    private DataIdentifier(DataIdentifier parent, EntityType type, Snowflake snowflake) {
+        this.parent = parent;
+        this.type = type;
+        this.snowflake = snowflake;
+    }
+
+    public static DataIdentifier id(EntityType type, Snowflake snowflake) {
+        return new DataIdentifier(null, type, snowflake);
+    }
+
+    public static DataIdentifier idWithParent(DataIdentifier parent, EntityType type, Snowflake snowflake) {
+        Objects.requireNonNull(parent);
+        return new DataIdentifier(parent, type, snowflake);
+    }
+
+    public Snowflake getSnowflake() {
+        return snowflake;
+    }
+
+    public Optional<DataIdentifier> getParent() {
+        return Optional.ofNullable(parent);
+    }
+}

--- a/core/src/main/java/discord4j/core/newstoresapi/EntityMetadata.java
+++ b/core/src/main/java/discord4j/core/newstoresapi/EntityMetadata.java
@@ -1,0 +1,65 @@
+package discord4j.core.newstoresapi;
+
+import discord4j.common.util.Snowflake;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static discord4j.core.newstoresapi.DataIdentifier.id;
+import static discord4j.core.newstoresapi.DataIdentifier.idWithParent;
+import static discord4j.core.newstoresapi.EntityType.*;
+
+public class EntityMetadata {
+
+    private final DataIdentifier identifier;
+    private final List<String> tags;
+
+    private EntityMetadata(DataIdentifier identifier, String[] tags) {
+        this.identifier = identifier;
+        this.tags = Arrays.asList(tags);
+    }
+
+    public DataIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public static EntityMetadata channel(Snowflake channelId, String... tags) {
+        return new EntityMetadata(id(CHANNEL, channelId), tags);
+    }
+
+    public static EntityMetadata guild(Snowflake guildId, String... tags) {
+        return new EntityMetadata(id(GUILD, guildId), tags);
+    }
+
+    public static EntityMetadata emoji(Snowflake emojiId, String... tags) {
+        return new EntityMetadata(id(EMOJI, emojiId), tags);
+    }
+
+    public static EntityMetadata member(Snowflake guildId, Snowflake memberId, String... tags) {
+        return new EntityMetadata(idWithParent(id(GUILD, guildId), MEMBER, memberId), tags);
+    }
+
+    public static EntityMetadata message(Snowflake channelId, Snowflake messageId, String... tags) {
+        return new EntityMetadata(idWithParent(id(CHANNEL, channelId), MESSAGE, messageId), tags);
+    }
+
+    public static EntityMetadata presence(Snowflake guildId, Snowflake userId, String... tags) {
+        return new EntityMetadata(idWithParent(id(GUILD, guildId), PRESENCE, userId), tags);
+    }
+
+    public static EntityMetadata role(Snowflake roleId, String... tags) {
+        return new EntityMetadata(id(ROLE, roleId), tags);
+    }
+
+    public static EntityMetadata user(Snowflake userId, String... tags) {
+        return new EntityMetadata(id(USER, userId), tags);
+    }
+
+    public static EntityMetadata voiceState(Snowflake channelId, Snowflake userId, String... tags) {
+        return new EntityMetadata(idWithParent(id(CHANNEL, channelId), VOICE_STATE, userId), tags);
+    }
+}

--- a/core/src/main/java/discord4j/core/newstoresapi/EntityPatcher.java
+++ b/core/src/main/java/discord4j/core/newstoresapi/EntityPatcher.java
@@ -1,0 +1,52 @@
+package discord4j.core.newstoresapi;
+
+import discord4j.discordjson.json.*;
+import discord4j.discordjson.json.gateway.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface EntityPatcher {
+
+    // If a method returns something else than Mono<Void> : it OPTIONALLY returns OLD state (implementation may choose
+    // to always return empty to save performance)
+
+    Mono<Void> addChannelIdToGuild(ChannelCreate create);
+
+    Mono<Void> removeChannelIdFromGuild(ChannelDelete delete);
+
+    Mono<ChannelData> updateChannel(ChannelUpdate update);
+
+    Mono<Void> updateEmojiIdsOnGuild(GuildEmojisUpdate update);
+
+    Mono<Void> addMemberIdToGuild(GuildMemberAdd add);
+
+    Mono<Void> addMemberIdsToGuild(GuildMembersChunk chunk);
+
+    Mono<Void> removeMemberIdFromGuild(GuildMemberRemove remove);
+
+    Mono<MemberData> updateMember(GuildMemberUpdate update);
+
+    Mono<Void> addRoleIdToGuild(GuildRoleCreate create);
+
+    Mono<Void> removeRoleIdFromGuildAndMembers(GuildRoleDelete delete);
+
+    Mono<RoleData> updateRole(GuildRoleUpdate update);
+
+    Mono<GuildData> updateGuild(GuildUpdate update);
+
+    Mono<Void> editLastMessageId(MessageCreate create);
+
+    Mono<MessageData> deleteMessage(MessageDelete delete); // Not using Store#delete to offer the ability to return old state
+
+    Flux<MessageData> deleteMessageBulk(MessageDeleteBulk deleteBulk);
+
+    Mono<Void> addReactionToMessage(MessageReactionAdd reactionAdd);
+
+    Mono<Void> removeReactionFromMessage(MessageReactionRemove reactionRemove);
+
+    Mono<Void> removeEmojiReactionFromMessage(MessageReactionRemoveEmoji reactionRemoveEmoji);
+
+    Mono<Void> removeAllReactionsFromMessage(MessageReactionRemoveAll reactionRemoveAll);
+
+    Mono<MessageData> updateMessage(MessageUpdate update);
+}

--- a/core/src/main/java/discord4j/core/newstoresapi/EntityType.java
+++ b/core/src/main/java/discord4j/core/newstoresapi/EntityType.java
@@ -1,0 +1,13 @@
+package discord4j.core.newstoresapi;
+
+public enum EntityType {
+    CHANNEL,
+    GUILD,
+    EMOJI,
+    MEMBER,
+    MESSAGE,
+    PRESENCE,
+    ROLE,
+    USER,
+    VOICE_STATE;
+}

--- a/core/src/main/java/discord4j/core/newstoresapi/Store.java
+++ b/core/src/main/java/discord4j/core/newstoresapi/Store.java
@@ -1,0 +1,16 @@
+package discord4j.core.newstoresapi;
+
+import reactor.core.publisher.Mono;
+
+public interface Store {
+
+    Mono<Void> save(EntityMetadata meta, Object toSave);
+
+    Mono<Object> find(EntityMetadata meta);
+
+    Mono<Void> delete(EntityMetadata meta);
+
+    Mono<Long> count(EntityMetadata meta);
+
+    EntityPatcher getEntityPatcher();
+}


### PR DESCRIPTION
:warning: The purpose of this PR is only to showcase some code to illustrate my previous issue #782, taking into account all the feedbacks from the Discord server so that it complies better with the team's expectations. This is not for merging, anyway it doesn't even compile lol.

So, here is an explanation of what I tried to design:
* In the original issue I've talked about paths to use as key for data. The initial idea was to have something that can unify single-ID and double-ID entities, and something that encourages a tree data structure. In the end, I think the latter point does not make sense, because whether it's organized in a tree or not is an implementation detail, the API shouldn't be suggesting that. So instead of paths, I finally went for a more simple object which only contains an ID as well as an optional parent ID, that's what I called `DataIdentifier`.
* Data identifiers and tags are contained in an `EntityMetadata` object, that is passed to the Store methods and conveniently constructed via static factories, there's one factory per entity type.
* I added a new method: `Store#getEntityPatcher()`. `EntityPatcher` is an interface that will allow to perform patching operations on existing entities in the store. I think that's more or less what @quanticc suggested with his `EntityAccessor` concept, except it is only focused on patching operations (inserting or deleting full payloads is done via the generic `Store#save` and `Store#delete` methods).

In this draft PR I also updated `DispatchContext` and `ChannelDispatchHandlers` so you can have an overview of how this new API would be used in the Core module.