### PR TITLE
Update Integration support

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Webhook.java
+++ b/core/src/main/java/discord4j/core/object/entity/Webhook.java
@@ -184,6 +184,15 @@ public final class Webhook implements Entity {
     }
 
     /**
+     * Gets the bot/OAuth2 application ID that created this webhook.
+     *
+     * @return The bot/OAuth2 application ID that created this webhook.
+     */
+    public Optional<Snowflake> getApplicationId() {
+        return data.applicationId().map(Snowflake::of);
+    }
+
+    /**
      * Requests to delete this webhook.
      *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the webhook has been deleted.

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -258,6 +258,10 @@ public class RestGuild {
         return restClient.getGuildService().getGuildIntegrations(id);
     }
 
+    public Flux<IntegrationData> getIntegrations(boolean includeApplications) {
+        return restClient.getGuildService().getGuildIntegrations(id, includeApplications);
+    }
+
     public Mono<Void> createIntegration(IntegrationCreateRequest request) {
         return restClient.getGuildService().createGuildIntegration(id, request);
     }

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -253,6 +253,14 @@ public class GuildService extends RestService {
 
     public Flux<IntegrationData> getGuildIntegrations(long guildId) {
         return Routes.GUILD_INTEGRATIONS_GET.newRequest(guildId)
+            .exchange(getRouter())
+            .bodyToMono(IntegrationData[].class)
+            .flatMapMany(Flux::fromArray);
+    }
+
+    public Flux<IntegrationData> getGuildIntegrations(long guildId, boolean includeApplications) {
+        return Routes.GUILD_INTEGRATIONS_GET.newRequest(guildId)
+                .query("include_applications", includeApplications)
                 .exchange(getRouter())
                 .bodyToMono(IntegrationData[].class)
                 .flatMapMany(Flux::fromArray);


### PR DESCRIPTION
**This PR depends on https://github.com/Discord4J/discord-json/pull/32**

**Description:**
- Adds `Webhook#getApplicationId()`
- Supports `include_applications` when requestions integrations


**Justification:** https://github.com/discord/discord-api-docs/pull/1886