### PR TITLE
Remove include_applications when getting guild integrations

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -258,10 +258,6 @@ public class RestGuild {
         return restClient.getGuildService().getGuildIntegrations(id);
     }
 
-    public Flux<IntegrationData> getIntegrations(boolean includeApplications) {
-        return restClient.getGuildService().getGuildIntegrations(id, includeApplications);
-    }
-
     public Mono<Void> createIntegration(IntegrationCreateRequest request) {
         return restClient.getGuildService().createGuildIntegration(id, request);
     }

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -258,14 +258,6 @@ public class GuildService extends RestService {
             .flatMapMany(Flux::fromArray);
     }
 
-    public Flux<IntegrationData> getGuildIntegrations(long guildId, boolean includeApplications) {
-        return Routes.GUILD_INTEGRATIONS_GET.newRequest(guildId)
-                .query("include_applications", includeApplications)
-                .exchange(getRouter())
-                .bodyToMono(IntegrationData[].class)
-                .flatMapMany(Flux::fromArray);
-    }
-
     public Mono<Void> createGuildIntegration(long guildId, IntegrationCreateRequest request) {
         return Routes.GUILD_INTEGRATION_CREATE.newRequest(guildId)
                 .body(request)


### PR DESCRIPTION
**Description:**
- Remove `include_applications` field when getting guild integrations because it is no longer taken into account in V8.

**Justification:** https://github.com/discord/discord-api-docs/pull/2175