### PR TITLE
Rename currentRoles to currentRoleIds

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/GuildDispatchHandlers.java
@@ -188,10 +188,10 @@ class GuildDispatchHandlers {
         long guildId = Snowflake.asLong(context.getDispatch().guildId());
         long memberId = Snowflake.asLong(context.getDispatch().user().id());
 
-        List<Long> currentRoles = context.getDispatch().roles()
+        Set<Long> currentRoleIds = context.getDispatch().roles()
                 .stream()
                 .map(Snowflake::asLong)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
         String currentNick = Possible.flatOpt(context.getDispatch().nick()).orElse(null);
         String currentJoinedAt = context.getDispatch().joinedAt();
         String currentPremiumSince = Possible.flatOpt(context.getDispatch().premiumSince()).orElse(null);
@@ -200,7 +200,7 @@ class GuildDispatchHandlers {
                 .orElse(null);
 
         return Mono.just(new MemberUpdateEvent(gateway, context.getShardInfo(), guildId, memberId, oldMember,
-                currentRoles, currentNick, currentJoinedAt, currentPremiumSince));
+                currentRoleIds, currentNick, currentJoinedAt, currentPremiumSince));
     }
 
     static Mono<RoleCreateEvent> guildRoleCreate(DispatchContext<GuildRoleCreate, Void> context) {

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -128,9 +128,9 @@ public class MemberUpdateEvent extends GuildEvent {
     }
 
     /**
-     * Requests to receive the list of {@link Role roles} that the {@link Member} is currently assigned.
+     * Requests to receive the list of {@link Role} roles that the {@link Member} is currently assigned.
      *
-     * @return A {@link Flux} emitting the roles that the {@link Member} is assigned.
+     * @return A {@link Flux} emitting the {@link Role} roles that the {@link Member} is assigned.
      */
     public Flux<Role> getCurrentRoles() {
         return getClient().getGuildRoles(getGuildId())

--- a/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/guild/MemberUpdateEvent.java
@@ -20,13 +20,14 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.Member;
 import discord4j.common.util.Snowflake;
+import discord4j.core.object.entity.Role;
 import discord4j.gateway.ShardInfo;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,7 +47,7 @@ public class MemberUpdateEvent extends GuildEvent {
     @Nullable
     private final Member old;
 
-    private final List<Long> currentRoles;
+    private final Set<Long> currentRoleIds;
     @Nullable
     private final String currentNickname;
     private final String currentJoinedAt;
@@ -54,14 +55,14 @@ public class MemberUpdateEvent extends GuildEvent {
     private final String currentPremiumSince;
 
     public MemberUpdateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long guildId, long memberId,
-                             @Nullable Member old, List<Long> currentRoles, @Nullable String currentNickname,
+                             @Nullable Member old, Set<Long> currentRoleIds, @Nullable String currentNickname,
                              String currentJoinedAt, @Nullable String currentPremiumSince) {
         super(gateway, shardInfo);
 
         this.guildId = guildId;
         this.memberId = memberId;
         this.old = old;
-        this.currentRoles = currentRoles;
+        this.currentRoleIds = currentRoleIds;
         this.currentNickname = currentNickname;
         this.currentJoinedAt = currentJoinedAt;
         this.currentPremiumSince = currentPremiumSince;
@@ -120,10 +121,20 @@ public class MemberUpdateEvent extends GuildEvent {
      *
      * @return The IDs of the roles the {@link Member} is assigned.
      */
-    public Set<Snowflake> getCurrentRoles() {
-        return currentRoles.stream()
+    public Set<Snowflake> getCurrentRoleIds() {
+        return currentRoleIds.stream()
                 .map(Snowflake::of)
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * Requests to receive the list of {@link Role roles} that the {@link Member} is currently assigned.
+     *
+     * @return A {@link Flux} emitting the roles that the {@link Member} is assigned.
+     */
+    public Flux<Role> getCurrentRoles() {
+        return getClient().getGuildRoles(getGuildId())
+                .filter(role -> currentRoleIds.contains(role.getId().asLong()));
     }
 
     /**
@@ -160,7 +171,7 @@ public class MemberUpdateEvent extends GuildEvent {
                 "guildId=" + guildId +
                 ", memberId=" + memberId +
                 ", old=" + old +
-                ", currentRoles=" + currentRoles +
+                ", currentRoleIds=" + currentRoleIds +
                 ", currentNickname='" + currentNickname + '\'' +
                 ", currentJoinedAt='" + currentJoinedAt + '\'' +
                 ", currentPremiumSince='" + currentPremiumSince + '\'' +


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
- Rename the element `currentRoles` to `currentRoleIds` in `MemberUpdateEvent`, along with all other references to this collection, including the event's constructor, the getter, the `toString()` implementation, and the guild dispatch handler.
- Update the collection from `List` to `Set` to match the getter.
- Add a new method, `getCurrentRoles()`, to return a `Flux` of the roles referenced by the `currentRoleIds`. **The way this works is that it fetches all roles for the guild and filters for only the ones that are owned by the member. If there is a way to only request the roles by their IDs directly, I assume we would prefer to do it that way instead. I don't immediately see a way to do that, however, without requesting each role individually.**

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
To bring this object more in line with the library's conventions.