### PR TITLE
Call correct methods

### DIFF
--- a/core/src/main/java/discord4j/core/spec/MessageReferenceSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageReferenceSpec.java
@@ -20,7 +20,7 @@ public class MessageReferenceSpec implements Spec<MessageReferenceData> {
      * @return This spec.
      */
     public MessageReferenceSpec setMessageId(Snowflake messageId) {
-        requestBuilder.guildId(messageId.asString());
+        requestBuilder.messageId(messageId.asString());
         return this;
     }
 
@@ -31,7 +31,7 @@ public class MessageReferenceSpec implements Spec<MessageReferenceData> {
      * @return This spec.
      */
     public MessageReferenceSpec setChannelId(Snowflake channelId) {
-        requestBuilder.guildId(channelId.asString());
+        requestBuilder.channelId(channelId.asString());
         return this;
     }
 


### PR DESCRIPTION
**Description:** Fixed issue in MessageReferenceSpec calling wrong methods for MessageReferenceData

**Justification:** Calling```spec.setMessageId(messageId)```  or ```spec.setChannelId(channelId)``` would set MessageReferenceData.guildId which resulted in an error from the DiscordApi.