### PR TITLE
Fix: Bot's presence is not updated using Member#getPresence

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Member.java
+++ b/core/src/main/java/discord4j/core/object/entity/Member.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.object.entity;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.VoiceState;
 import discord4j.core.object.presence.Presence;
@@ -25,10 +26,11 @@ import discord4j.core.spec.GuildMemberEditSpec;
 import discord4j.core.util.OrderUtil;
 import discord4j.core.util.PermissionUtil;
 import discord4j.discordjson.json.MemberData;
+import discord4j.discordjson.json.gateway.ImmutableRequestGuildMembers;
+import discord4j.discordjson.json.gateway.RequestGuildMembers;
 import discord4j.discordjson.possible.Possible;
 import discord4j.rest.util.Color;
 import discord4j.rest.util.PermissionSet;
-import discord4j.common.util.Snowflake;
 import discord4j.store.api.util.LongLongTuple2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -240,11 +242,31 @@ public final class Member extends User {
 
     /**
      * Requests to retrieve the presence for this user for this guild.
+     * {@code Intent.GUILD_PRESENCES} is required to get the presence of the bot, otherwise the emitted {@code Mono}
+     * will always be empty.
      *
      * @return A {@link Mono} where, upon successful completion, emits a {@link Presence presence} for this user for
      * this guild. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Presence> getPresence() {
+        // Fix https://github.com/Discord4J/Discord4J/issues/475
+        if (getClient().getSelfId().equals(getId())) {
+            return Mono.defer(() -> {
+                final ImmutableRequestGuildMembers request = RequestGuildMembers.builder()
+                    .guildId(getGuildId().asString())
+                    .addUserId(getId().asString())
+                    .presences(true)
+                    .limit(1)
+                    .build();
+
+                return getClient().requestMembers(request)
+                    .singleOrEmpty()
+                    .flatMap(Member::getPresence)
+                    // IllegalArgumentException can be thrown during request validation if intents are not matching the request
+                    .onErrorResume(IllegalArgumentException.class, err -> Mono.empty());
+            });
+        }
+
         return getClient().getGatewayResources().getStateView().getPresenceStore()
                 .find(LongLongTuple2.of(getGuildId().asLong(), getId().asLong()))
                 .map(Presence::new);


### PR DESCRIPTION
**Description:** 
Try to get the latest bot's presence by requesting it, returns Mono.empty() otherwise.

**Justification:** 
Fix https://github.com/Discord4J/Discord4J/issues/475