### PR TITLE
Support get guild preview

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -317,4 +317,8 @@ public class RestGuild {
     public Flux<WebhookData> getWebhooks() {
         return restClient.getWebhookService().getGuildWebhooks(id);
     }
+
+    public Mono<GuildPreviewData> getPreview() {
+        return restClient.getGuildService().getGuildPreview(id);
+    }
 }

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -737,6 +737,14 @@ public abstract class Routes {
      */
     public static final Route GUILD_WIDGET_MODIFY = Route.patch("/guilds/{guild.id}/widget");
 
+    /**
+     * Returns the guild preview object. If the user is not in the guild, then the guild must be Discoverable.
+     *
+     * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-preview">
+     *     https://discord.com/developers/docs/resources/guild#get-guild-preview</a>
+     */
+    public static final Route GUILD_PREVIEW_GET = Route.get("/guilds/{guild.id}/preview");
+
     /////////////////////////////////////////////
     ////////////// Invite Resource //////////////
     /////////////////////////////////////////////

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -326,4 +326,10 @@ public class GuildService extends RestService {
                 .exchange(getRouter())
                 .bodyToMono(GuildWidgetData.class);
     }
+
+    public Mono<GuildPreviewData> getGuildPreview(long guildId) {
+        return Routes.GUILD_PREVIEW_GET.newRequest(guildId)
+            .exchange(getRouter())
+            .bodyToMono(GuildPreviewData.class);
+    }
 }

--- a/rest/src/test/java/discord4j/rest/service/GuildServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/GuildServiceTest.java
@@ -253,4 +253,9 @@ public class GuildServiceTest {
     public void testModifyGuildEmbed() {
         // TODO
     }
+
+    @Test
+    public void testGetGuildPreview() {
+        // TODO
+    }
 }


### PR DESCRIPTION
**Description:** 
Adds support for get guild preview in RestGuild. 
@Doc94 Is it what you were expecting?

**Justification:**
Documentation: https://discord.com/developers/docs/resources/guild#get-guild-preview
Closes: https://github.com/Discord4J/Discord4J/issues/780
