### PR TITLE
Add slash commands to discord4j-rest and discord4j-gateway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        mavenLocal()
 
         if (!isRelease || isJitpack) {
             maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ allprojects {
 
     repositories {
         mavenCentral()
+        mavenLocal()
+
         if (!isRelease || isJitpack) {
             maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
             maven { url 'https://oss.sonatype.org/content/repositories/staging' }

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
@@ -54,6 +54,10 @@ public abstract class EventNames {
     public static final String WEBHOOKS_UPDATE = "WEBHOOKS_UPDATE";
     public static final String INVITE_CREATE = "INVITE_CREATE";
     public static final String INVITE_DELETE = "INVITE_DELETE";
+    public static final String APPLICATION_COMMAND_CREATE = "APPLICATION_COMMAND_CREATE";
+    public static final String APPLICATION_COMMAND_UPDATE = "APPLICATION_COMMAND_UPDATE";
+    public static final String APPLICATION_COMMAND_DELETE = "APPLICATION_COMMAND_DELETE";
+    public static final String INTERACTION_CREATE = "INTERACTION_CREATE";
 
     // Ignored
     public static final String PRESENCES_REPLACE = "PRESENCES_REPLACE";

--- a/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
+++ b/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
@@ -16,6 +16,7 @@
  */
 package discord4j.gateway.json.jackson;
 
+import discord4j.discordjson.json.InteractionData;
 import discord4j.discordjson.json.gateway.*;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -75,6 +76,10 @@ public class PayloadDeserializer extends StdDeserializer<GatewayPayload<?>> {
         dispatchTypes.put(EventNames.WEBHOOKS_UPDATE, WebhooksUpdate.class);
         dispatchTypes.put(EventNames.INVITE_CREATE, InviteCreate.class);
         dispatchTypes.put(EventNames.INVITE_DELETE, InviteDelete.class);
+        dispatchTypes.put(EventNames.APPLICATION_COMMAND_CREATE, ApplicationCommandCreate.class);
+        dispatchTypes.put(EventNames.APPLICATION_COMMAND_UPDATE, ApplicationCommandUpdate.class);
+        dispatchTypes.put(EventNames.APPLICATION_COMMAND_DELETE, ApplicationCommandDelete.class);
+        dispatchTypes.put(EventNames.INTERACTION_CREATE, InteractionData.class);
 
         // Ignored
         dispatchTypes.put(EventNames.PRESENCES_REPLACE, null);

--- a/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
+++ b/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
@@ -79,7 +79,7 @@ public class PayloadDeserializer extends StdDeserializer<GatewayPayload<?>> {
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_CREATE, ApplicationCommandCreate.class);
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_UPDATE, ApplicationCommandUpdate.class);
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_DELETE, ApplicationCommandDelete.class);
-        dispatchTypes.put(EventNames.INTERACTION_CREATE, InteractionData.class);
+        dispatchTypes.put(EventNames.INTERACTION_CREATE, InteractionCreate.class);
 
         // Ignored
         dispatchTypes.put(EventNames.PRESENCES_REPLACE, null);

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.1.4-SNAPSHOT
 storesVersion=3.1.5
-discordJsonVersion=1.5.6
+discordJsonVersion=1.5.7
 storesArtifact=com.discord4j:stores-jdk

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.1.4-SNAPSHOT
 storesVersion=3.1.5
-discordJsonVersion=1.5.7
+discordJsonVersion=1.5.7-SNAPSHOT
 storesArtifact=com.discord4j:stores-jdk

--- a/rest/src/main/java/discord4j/rest/RestClient.java
+++ b/rest/src/main/java/discord4j/rest/RestClient.java
@@ -42,6 +42,7 @@ public class RestClient {
     private final EmojiService emojiService;
     private final GatewayService gatewayService;
     private final GuildService guildService;
+    private final InteractionService interactionService;
     private final InviteService inviteService;
     private final UserService userService;
     private final VoiceService voiceService;
@@ -82,6 +83,7 @@ public class RestClient {
         this.emojiService = new EmojiService(router);
         this.gatewayService = new GatewayService(router);
         this.guildService = new GuildService(router);
+        this.interactionService = new InteractionService(router);
         this.inviteService = new InviteService(router);
         this.userService = new UserService(router);
         this.voiceService = new VoiceService(router);
@@ -401,6 +403,14 @@ public class RestClient {
      */
     public GuildService getGuildService() {
         return guildService;
+    }
+
+    /**
+     * Access a low-level representation of the API endpoints for the Interaction resource.
+     * @return a handle to perform low-level requests to the API
+     */
+    public InteractionService getInteractionService() {
+        return interactionService;
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/http/ExchangeStrategies.java
+++ b/rest/src/main/java/discord4j/rest/http/ExchangeStrategies.java
@@ -51,6 +51,7 @@ public interface ExchangeStrategies {
     static ExchangeStrategies jackson(ObjectMapper mapper) {
         List<WriterStrategy<?>> writerStrategies = new ArrayList<>();
         writerStrategies.add(new MultipartWriterStrategy(mapper));
+        writerStrategies.add(new WebhookMultipartWriterStrategy(mapper));
         writerStrategies.add(new JacksonWriterStrategy(mapper));
         writerStrategies.add(new EmptyWriterStrategy());
         List<ReaderStrategy<?>> readerStrategies = new ArrayList<>();

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -29,7 +29,7 @@ public abstract class Routes {
      * The base URL for all API requests.
      *
      * @see <a href="https://discord.com/developers/docs/reference#base-url">
-     *         https://discord.com/developers/docs/reference#base-url</a>
+     * https://discord.com/developers/docs/reference#base-url</a>
      */
     public static final String BASE_URL = "https://discord.com/api/v6";
 
@@ -43,7 +43,7 @@ public abstract class Routes {
      * establish a connection using the cached version of the URL.
      *
      * @see <a href="https://discord.com/developers/docs/topics/gateway#get-gateway">
-     *         https://discord.com/developers/docs/topics/gateway#get-gateway</a>
+     * https://discord.com/developers/docs/topics/gateway#get-gateway</a>
      */
     public static final Route GATEWAY_GET = Route.get("/gateway");
 
@@ -56,7 +56,7 @@ public abstract class Routes {
      * the same per-call, and changes as the bot joins/leaves guilds.
      *
      * @see <a href="https://discord.com/developers/docs/topics/gateway#get-gateway-bot">
-     *         https://discord.com/developers/docs/topics/gateway#get-gateway-bot</a>
+     * https://discord.com/developers/docs/topics/gateway#get-gateway-bot</a>
      */
     public static final Route GATEWAY_BOT_GET = Route.get("/gateway/bot");
 
@@ -68,7 +68,7 @@ public abstract class Routes {
      * Returns an audit log object for the guild. Requires the 'VIEW_AUDIT_LOG' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log">
-     *         https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log</a>
+     * https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log</a>
      */
     public static final Route AUDIT_LOG_GET = Route.get("/guilds/{guild.id}/audit-logs");
 
@@ -80,7 +80,7 @@ public abstract class Routes {
      * Get a channel by ID. Returns a guild channel or dm channel object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#get-channel">
-     *         https://discord.com/developers/docs/resources/channel#get-channel</a>
+     * https://discord.com/developers/docs/resources/channel#get-channel</a>
      */
     public static final Route CHANNEL_GET = Route.get("/channels/{channel.id}");
 
@@ -89,7 +89,7 @@ public abstract class Routes {
      * success, and a 400 BAD REQUEST on invalid parameters. Fires a Channel Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#modify-channel">
-     *         https://discord.com/developers/docs/resources/channel#modify-channel</a>
+     * https://discord.com/developers/docs/resources/channel#modify-channel</a>
      */
     public static final Route CHANNEL_MODIFY = Route.put("/channels/{channel.id}");
 
@@ -99,7 +99,7 @@ public abstract class Routes {
      * are optional.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#modify-channel">
-     *         https://discord.com/developers/docs/resources/channel#modify-channel</a>
+     * https://discord.com/developers/docs/resources/channel#modify-channel</a>
      */
     public static final Route CHANNEL_MODIFY_PARTIAL = Route.patch("/channels/{channel.id}");
 
@@ -108,7 +108,7 @@ public abstract class Routes {
      * Returns a guild channel or dm channel object on success. Fires a Channel Delete Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#deleteclose-channel">
-     *         https://discord.com/developers/docs/resources/channel#deleteclose-channel</a>
+     * https://discord.com/developers/docs/resources/channel#deleteclose-channel</a>
      */
     public static final Route CHANNEL_DELETE = Route.delete("/channels/{channel.id}");
 
@@ -117,7 +117,7 @@ public abstract class Routes {
      * permission to be present on the current user. Returns an array of message objects on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#get-channel-messages">
-     *         https://discord.com/developers/docs/resources/channel#get-channel-messages</a>
+     * https://discord.com/developers/docs/resources/channel#get-channel-messages</a>
      */
     public static final Route MESSAGES_GET = Route.get("/channels/{channel.id}/messages");
 
@@ -126,7 +126,7 @@ public abstract class Routes {
      * 'READ_MESSAGE_HISTORY' permission to be present on the current user. Returns a message object on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#get-channel-message">
-     *         https://discord.com/developers/docs/resources/channel#get-channel-message</a>
+     * https://discord.com/developers/docs/resources/channel#get-channel-message</a>
      */
     public static final Route MESSAGE_GET = Route.get("/channels/{channel.id}/messages/{message.id}");
 
@@ -141,7 +141,7 @@ public abstract class Routes {
      * JSON body as a form value for payload_json.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#create-message">
-     *         https://discord.com/developers/docs/resources/channel#create-message</a>
+     * https://discord.com/developers/docs/resources/channel#create-message</a>
      */
     public static final Route MESSAGE_CREATE = Route.post("/channels/{channel.id}/messages");
 
@@ -152,7 +152,7 @@ public abstract class Routes {
      * success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#create-reaction">
-     *         https://discord.com/developers/docs/resources/channel#create-reaction</a>
+     * https://discord.com/developers/docs/resources/channel#create-reaction</a>
      */
     public static final Route REACTION_CREATE = Route.put("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me");
 
@@ -160,7 +160,7 @@ public abstract class Routes {
      * Delete a reaction the current user has made for the message. Returns a 204 empty response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-own-reaction">
-     *         https://discord.com/developers/docs/resources/channel#delete-own-reaction</a>
+     * https://discord.com/developers/docs/resources/channel#delete-own-reaction</a>
      */
     public static final Route REACTION_DELETE_OWN = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me");
 
@@ -169,7 +169,7 @@ public abstract class Routes {
      * current user. Returns a 204 empty response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-user-reaction">
-     *         https://discord.com/developers/docs/resources/channel#delete-user-reaction</a>
+     * https://discord.com/developers/docs/resources/channel#delete-user-reaction</a>
      */
     public static final Route REACTION_DELETE_USER = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user.id}");
 
@@ -178,7 +178,7 @@ public abstract class Routes {
      * to be present on the current user.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji">
-     *         https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji</a>
+     * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji</a>
      */
     public static final Route REACTION_DELETE = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}");
 
@@ -186,7 +186,7 @@ public abstract class Routes {
      * Get a list of users that reacted with this emoji. Returns an array of user objects on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#get-reactions">
-     *         https://discord.com/developers/docs/resources/channel#get-reactions</a>
+     * https://discord.com/developers/docs/resources/channel#get-reactions</a>
      */
     public static final Route REACTIONS_GET = Route.get("/channels/{channel.id}/messages/{message.id}/reactions/{emoji}");
 
@@ -195,7 +195,7 @@ public abstract class Routes {
      * current user.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-all-reactions">
-     *         https://discord.com/developers/docs/resources/channel#delete-all-reactions</a>
+     * https://discord.com/developers/docs/resources/channel#delete-all-reactions</a>
      */
     public static final Route REACTIONS_DELETE_ALL = Route.delete("/channels/{channel.id}/messages/{message.id}/reactions");
 
@@ -204,7 +204,7 @@ public abstract class Routes {
      * message object. Fires a Message Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#edit-message">
-     *         https://discord.com/developers/docs/resources/channel#edit-message</a>
+     * https://discord.com/developers/docs/resources/channel#edit-message</a>
      */
     public static final Route MESSAGE_EDIT = Route.patch("/channels/{channel.id}/messages/{message.id}");
 
@@ -214,7 +214,7 @@ public abstract class Routes {
      * Fires a Message Delete Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-message">
-     *         https://discord.com/developers/docs/resources/channel#delete-message</a>
+     * https://discord.com/developers/docs/resources/channel#delete-message</a>
      */
     public static final Route MESSAGE_DELETE = Route.delete("/channels/{channel.id}/messages/{message.id}");
 
@@ -231,7 +231,7 @@ public abstract class Routes {
      * that. An endpoint will be added in the future to prune messages older than 2 weeks from a channel.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#bulk-delete-messages">
-     *         https://discord.com/developers/docs/resources/channel#bulk-delete-messages</a>
+     * https://discord.com/developers/docs/resources/channel#bulk-delete-messages</a>
      */
     public static final Route MESSAGE_DELETE_BULK = Route.post("/channels/{channel.id}/messages/bulk-delete");
 
@@ -242,7 +242,7 @@ public abstract class Routes {
      * Returns a 204 empty response on success. Fires a Message Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#suppress-message-embeds">
-     *         https://discord.com/developers/docs/resources/channel#suppress-message-embeds</a>
+     * https://discord.com/developers/docs/resources/channel#suppress-message-embeds</a>
      */
     @Experimental
     public static final Route MESSAGE_SUPPRESS_EMBEDS = Route.post("/channels/{channel.id}/messages/{message.id}/suppress-embeds");
@@ -255,7 +255,7 @@ public abstract class Routes {
      * Returns a 204 empty response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#crosspost-message">
-     *         https://discord.com/developers/docs/resources/channel#crosspost-message</a>
+     * https://discord.com/developers/docs/resources/channel#crosspost-message</a>
      */
     public static final Route CROSSPOST_MESSAGE = Route.post("/channels/{channel.id}/messages/{message.id}/crosspost");
 
@@ -265,7 +265,7 @@ public abstract class Routes {
      * see permissions.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#edit-channel-permissions">
-     *         https://discord.com/developers/docs/resources/channel#edit-channel-permissions</a>
+     * https://discord.com/developers/docs/resources/channel#edit-channel-permissions</a>
      */
     public static final Route CHANNEL_PERMISSIONS_EDIT = Route.put("/channels/{channel.id}/permissions/{overwrite.id}");
 
@@ -274,7 +274,7 @@ public abstract class Routes {
      * Requires the 'MANAGE_CHANNELS' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#get-channel-invites">
-     *         https://discord.com/developers/docs/resources/channel#get-channel-invites</a>
+     * https://discord.com/developers/docs/resources/channel#get-channel-invites</a>
      */
     public static final Route CHANNEL_INVITES_GET = Route.get("/channels/{channel.id}/invites");
 
@@ -284,7 +284,7 @@ public abstract class Routes {
      * sending any fields, you still have to send an empty JSON object ({}). Returns an invite object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#create-channel-invite">
-     *         https://discord.com/developers/docs/resources/channel#create-channel-invite</a>
+     * https://discord.com/developers/docs/resources/channel#create-channel-invite</a>
      */
     public static final Route CHANNEL_INVITE_CREATE = Route.post("/channels/{channel.id}/invites");
 
@@ -294,7 +294,7 @@ public abstract class Routes {
      * see permissions.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-channel-permission">
-     *         https://discord.com/developers/docs/resources/channel#delete-channel-permission</a>
+     * https://discord.com/developers/docs/resources/channel#delete-channel-permission</a>
      */
     public static final Route CHANNEL_PERMISSION_DELETE = Route.delete("/channels/{channel.id}/permissions/{overwrite.id}");
 
@@ -303,7 +303,7 @@ public abstract class Routes {
      * target channel. Returns a followed channel object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#follow-news-channel">
-     *         https://discord.com/developers/docs/resources/channel#follow-news-channel</a>
+     * https://discord.com/developers/docs/resources/channel#follow-news-channel</a>
      */
     public static final Route FOLLOW_NEWS_CHANNEL = Route.post("/channels/{channel.id}/followers");
 
@@ -314,7 +314,7 @@ public abstract class Routes {
      * Typing Start Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#trigger-typing-indicator">
-     *         https://discord.com/developers/docs/resources/channel#trigger-typing-indicator</a>
+     * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator</a>
      */
     public static final Route TYPING_INDICATOR_TRIGGER = Route.post("/channels/{channel.id}/typing");
 
@@ -322,7 +322,7 @@ public abstract class Routes {
      * Returns all pinned messages in the channel as an array of message objects.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#get-pinned-messages">
-     *         https://discord.com/developers/docs/resources/channel#get-pinned-messages</a>
+     * https://discord.com/developers/docs/resources/channel#get-pinned-messages</a>
      */
     public static final Route MESSAGES_PINNED_GET = Route.get("/channels/{channel.id}/pins");
 
@@ -330,7 +330,7 @@ public abstract class Routes {
      * Pin a message in a channel. Requires the 'MANAGE_MESSAGES' permission. Returns a 204 empty response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#add-pinned-channel-message">
-     *         https://discord.com/developers/docs/resources/channel#add-pinned-channel-message</a>
+     * https://discord.com/developers/docs/resources/channel#add-pinned-channel-message</a>
      */
     public static final Route MESSAGES_PINNED_ADD = Route.put("/channels/{channel.id}/pins/{message.id}");
 
@@ -339,7 +339,7 @@ public abstract class Routes {
      * success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message">
-     *         https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message</a>
+     * https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message</a>
      */
     public static final Route MESSAGES_PINNED_DELETE = Route.delete("/channels/{channel.id}/pins/{message.id}");
 
@@ -347,7 +347,7 @@ public abstract class Routes {
      * Adds a recipient to a Group DM using their access token.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#group-dm-add-recipient">
-     *         https://discord.com/developers/docs/resources/channel#group-dm-add-recipient</a>
+     * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient</a>
      */
     public static final Route GROUP_DM_RECIPIENT_ADD = Route.put("/channels/{channel.id}/recipients/{user.id}");
 
@@ -355,7 +355,7 @@ public abstract class Routes {
      * Removes a recipient from a Group DM.
      *
      * @see <a href="https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient">
-     *         https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient</a>
+     * https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient</a>
      */
     public static final Route GROUP_DM_RECIPIENT_DELETE = Route.delete("/channels/{channel.id}/recipients/{user.id}");
 
@@ -367,7 +367,7 @@ public abstract class Routes {
      * Returns a list of emoji objects for the given guild.
      *
      * @see <a href="https://discord.com/developers/docs/resources/emoji#list-guild-emojis">
-     *         https://discord.com/developers/docs/resources/emoji#list-guild-emojis</a>
+     * https://discord.com/developers/docs/resources/emoji#list-guild-emojis</a>
      */
     public static final Route GUILD_EMOJIS_GET = Route.get("/guilds/{guild.id}/emojis");
 
@@ -375,7 +375,7 @@ public abstract class Routes {
      * Returns an emoji object for the given guild and emoji IDs.
      *
      * @see <a href="https://discord.com/developers/docs/resources/emoji#get-guild-emoji">
-     *         https://discord.com/developers/docs/resources/emoji#get-guild-emoji</a>
+     * https://discord.com/developers/docs/resources/emoji#get-guild-emoji</a>
      */
     public static final Route GUILD_EMOJI_GET = Route.get("/guilds/{guild.id}/emojis/{emoji.id}");
 
@@ -384,7 +384,7 @@ public abstract class Routes {
      * event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/emoji#create-guild-emoji">
-     *         https://discord.com/developers/docs/resources/emoji#create-guild-emoji</a>
+     * https://discord.com/developers/docs/resources/emoji#create-guild-emoji</a>
      */
     public static final Route GUILD_EMOJI_CREATE = Route.post("/guilds/{guild.id}/emojis");
 
@@ -392,7 +392,7 @@ public abstract class Routes {
      * Modify the given emoji. Returns the updated emoji object on success. Fires a Guild Emojis Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/emoji#modify-guild-emoji">
-     *         https://discord.com/developers/docs/resources/emoji#modify-guild-emoji</a>
+     * https://discord.com/developers/docs/resources/emoji#modify-guild-emoji</a>
      */
     public static final Route GUILD_EMOJI_MODIFY = Route.patch("/guilds/{guild.id}/emojis/{emoji.id}");
 
@@ -400,7 +400,7 @@ public abstract class Routes {
      * Delete the given emoji. Returns 204 No Content on success. Fires a Guild Emojis Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/emoji#delete-guild-emoji">
-     *         https://discord.com/developers/docs/resources/emoji#delete-guild-emoji</a>
+     * https://discord.com/developers/docs/resources/emoji#delete-guild-emoji</a>
      */
     public static final Route GUILD_EMOJI_DELETE = Route.delete("/guilds/{guild.id}/emojis/{emoji.id}");
 
@@ -415,7 +415,7 @@ public abstract class Routes {
      * applications.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#create-guild">
-     *         https://discord.com/developers/docs/resources/guild#create-guild</a>
+     * https://discord.com/developers/docs/resources/guild#create-guild</a>
      */
     public static final Route GUILD_CREATE = Route.post("/guilds");
 
@@ -423,7 +423,7 @@ public abstract class Routes {
      * Returns the guild object for the given id.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild">
-     *         https://discord.com/developers/docs/resources/guild#get-guild</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild</a>
      */
     public static final Route GUILD_GET = Route.get("/guilds/{guild.id}");
 
@@ -431,7 +431,7 @@ public abstract class Routes {
      * Modify a guild's settings. Returns the updated guild object on success. Fires a Guild Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild</a>
      */
     public static final Route GUILD_MODIFY = Route.patch("/guilds/{guild.id}");
 
@@ -440,7 +440,7 @@ public abstract class Routes {
      * event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#delete-guild">
-     *         https://discord.com/developers/docs/resources/guild#delete-guild</a>
+     * https://discord.com/developers/docs/resources/guild#delete-guild</a>
      */
     public static final Route GUILD_DELETE = Route.delete("/guilds/{guild.id}");
 
@@ -448,7 +448,7 @@ public abstract class Routes {
      * Returns a list of guild channel objects.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-channels">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-channels</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-channels</a>
      */
     public static final Route GUILD_CHANNELS_GET = Route.get("/guilds/{guild.id}/channels");
 
@@ -457,7 +457,7 @@ public abstract class Routes {
      * object on success. Fires a Channel Create Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#create-guild-channel">
-     *         https://discord.com/developers/docs/resources/guild#create-guild-channel</a>
+     * https://discord.com/developers/docs/resources/guild#create-guild-channel</a>
      */
     public static final Route GUILD_CHANNEL_CREATE = Route.post("/guilds/{guild.id}/channels");
 
@@ -466,7 +466,7 @@ public abstract class Routes {
      * list of all of the guild's role objects on success. Fires multiple Guild Role Update Gateway events.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions</a>
      */
     public static final Route GUILD_CHANNEL_POSITIONS_MODIFY = Route.patch("/guilds/{guild.id}/channels");
 
@@ -474,7 +474,7 @@ public abstract class Routes {
      * Returns a guild member object for the specified user.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-member">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-member</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-member</a>
      */
     public static final Route GUILD_MEMBER_GET = Route.get("/guilds/{guild.id}/members/{user.id}");
 
@@ -482,7 +482,7 @@ public abstract class Routes {
      * Returns a list of guild member objects that are members of the guild.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#list-guild-members">
-     *         https://discord.com/developers/docs/resources/guild#list-guild-members</a>
+     * https://discord.com/developers/docs/resources/guild#list-guild-members</a>
      */
     public static final Route GUILD_MEMBERS_LIST = Route.get("/guilds/{guild.id}/members");
 
@@ -492,7 +492,7 @@ public abstract class Routes {
      * bot to have the CREATE_INSTANT_INVITE permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#add-guild-member">
-     *         https://discord.com/developers/docs/resources/guild#add-guild-member</a>
+     * https://discord.com/developers/docs/resources/guild#add-guild-member</a>
      */
     public static final Route GUILD_MEMBER_ADD = Route.put("/guilds/{guild.id}/members/{user.id}");
 
@@ -501,7 +501,7 @@ public abstract class Routes {
      * Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-member">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-member</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild-member</a>
      */
     public static final Route GUILD_MEMBER_MODIFY = Route.patch("/guilds/{guild.id}/members/{user.id}");
 
@@ -510,7 +510,7 @@ public abstract class Routes {
      * Member Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-current-user-nick">
-     *         https://discord.com/developers/docs/resources/guild#modify-current-user-nick</a>
+     * https://discord.com/developers/docs/resources/guild#modify-current-user-nick</a>
      */
     public static final Route NICKNAME_MODIFY_OWN = Route.patch("/guilds/{guild.id}/members/@me/nick");
 
@@ -519,7 +519,7 @@ public abstract class Routes {
      * Fires a Guild Member Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#add-guild-member-role">
-     *         https://discord.com/developers/docs/resources/guild#add-guild-member-role</a>
+     * https://discord.com/developers/docs/resources/guild#add-guild-member-role</a>
      */
     public static final Route GUILD_MEMBER_ROLE_ADD = Route.put("/guilds/{guild.id}/members/{user.id}/roles/{role.id}");
 
@@ -528,7 +528,7 @@ public abstract class Routes {
      * success. Fires a Guild Member Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#remove-guild-member-role">
-     *         https://discord.com/developers/docs/resources/guild#remove-guild-member-role</a>
+     * https://discord.com/developers/docs/resources/guild#remove-guild-member-role</a>
      */
     public static final Route GUILD_MEMBER_ROLE_REMOVE = Route.delete("/guilds/{guild.id}/members/{user.id}/roles/{role.id}");
 
@@ -537,7 +537,7 @@ public abstract class Routes {
      * a Guild Member Remove Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#remove-guild-member">
-     *         https://discord.com/developers/docs/resources/guild#remove-guild-member</a>
+     * https://discord.com/developers/docs/resources/guild#remove-guild-member</a>
      */
     public static final Route GUILD_MEMBER_REMOVE = Route.delete("/guilds/{guild.id}/members/{user.id}");
 
@@ -545,7 +545,7 @@ public abstract class Routes {
      * Returns a list of ban objects for the users banned from this guild. Requires the 'BAN_MEMBERS' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-bans">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-bans</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-bans</a>
      */
     public static final Route GUILD_BANS_GET = Route.get("/guilds/{guild.id}/bans");
 
@@ -554,7 +554,7 @@ public abstract class Routes {
      * permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-ban">
-     *     https://discord.com/developers/docs/resources/guild#get-guild-ban</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-ban</a>
      */
     public static final Route GUILD_BAN_GET = Route.get("/guilds/{guild.id}/bans/{user.id}");
 
@@ -563,7 +563,7 @@ public abstract class Routes {
      * permission. Returns a 204 empty response on success. Fires a Guild Ban Add Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#create-guild-ban">
-     *         https://discord.com/developers/docs/resources/guild#create-guild-ban</a>
+     * https://discord.com/developers/docs/resources/guild#create-guild-ban</a>
      */
     public static final Route GUILD_BAN_CREATE = Route.put("/guilds/{guild.id}/bans/{user.id}");
 
@@ -572,7 +572,7 @@ public abstract class Routes {
      * Fires a Guild Ban Remove Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#remove-guild-ban">
-     *         https://discord.com/developers/docs/resources/guild#remove-guild-ban</a>
+     * https://discord.com/developers/docs/resources/guild#remove-guild-ban</a>
      */
     public static final Route GUILD_BAN_REMOVE = Route.delete("/guilds/{guild.id}/bans/{user.id}");
 
@@ -580,7 +580,7 @@ public abstract class Routes {
      * Returns a list of role objects for the guild. Requires the 'MANAGE_ROLES' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-roles">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-roles</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-roles</a>
      */
     public static final Route GUILD_ROLES_GET = Route.get("/guilds/{guild.id}/roles");
 
@@ -589,7 +589,7 @@ public abstract class Routes {
      * Fires a Guild Role Create Gateway event. All JSON params are optional.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#create-guild-role">
-     *         https://discord.com/developers/docs/resources/guild#create-guild-role</a>
+     * https://discord.com/developers/docs/resources/guild#create-guild-role</a>
      */
     public static final Route GUILD_ROLE_CREATE = Route.post("/guilds/{guild.id}/roles");
 
@@ -598,7 +598,7 @@ public abstract class Routes {
      * list of all of the guild's role objects on success. Fires multiple Guild Role Update Gateway events.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-role-positions">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-role-positions</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild-role-positions</a>
      */
     public static final Route GUILD_ROLE_POSITIONS_MODIFY = Route.patch("/guilds/{guild.id}/roles");
 
@@ -607,7 +607,7 @@ public abstract class Routes {
      * Role Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-role">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-role</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild-role</a>
      */
     public static final Route GUILD_ROLE_MODIFY = Route.patch("/guilds/{guild.id}/roles/{role.id}");
 
@@ -616,7 +616,7 @@ public abstract class Routes {
      * Guild Role Delete Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#delete-guild-role">
-     *         https://discord.com/developers/docs/resources/guild#delete-guild-role</a>
+     * https://discord.com/developers/docs/resources/guild#delete-guild-role</a>
      */
     public static final Route GUILD_ROLE_DELETE = Route.delete("/guilds/{guild.id}/roles/{role.id}");
 
@@ -625,7 +625,7 @@ public abstract class Routes {
      * operation. Requires the 'KICK_MEMBERS' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-prune-count">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-prune-count</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-prune-count</a>
      */
     public static final Route GUILD_PRUNE_COUNT_GET = Route.get("/guilds/{guild.id}/prune");
 
@@ -635,7 +635,7 @@ public abstract class Routes {
      * Gateway events.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#begin-guild-prune">
-     *         https://discord.com/developers/docs/resources/guild#begin-guild-prune</a>
+     * https://discord.com/developers/docs/resources/guild#begin-guild-prune</a>
      */
     public static final Route GUILD_PRUNE_BEGIN = Route.post("/guilds/{guild.id}/prune");
 
@@ -644,7 +644,7 @@ public abstract class Routes {
      * when the guild is VIP-enabled.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-voice-regions">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-voice-regions</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-voice-regions</a>
      */
     public static final Route GUILD_VOICE_REGIONS_GET = Route.get("/guilds/{guild.id}/regions");
 
@@ -652,7 +652,7 @@ public abstract class Routes {
      * Returns a list of invite objects (with invite metadata) for the guild. Requires the 'MANAGE_GUILD' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-invites">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-invites</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-invites</a>
      */
     public static final Route GUILD_INVITES_GET = Route.get("/guilds/{guild.id}/invites");
 
@@ -660,7 +660,7 @@ public abstract class Routes {
      * Returns a list of integration objects for the guild. Requires the 'MANAGE_GUILD' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-integrations">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-integrations</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-integrations</a>
      */
     public static final Route GUILD_INTEGRATIONS_GET = Route.get("/guilds/{guild.id}/integrations");
 
@@ -669,7 +669,7 @@ public abstract class Routes {
      * a 204 empty response on success. Fires a Guild Integrations Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#create-guild-integration">
-     *         https://discord.com/developers/docs/resources/guild#create-guild-integration</a>
+     * https://discord.com/developers/docs/resources/guild#create-guild-integration</a>
      */
     public static final Route GUILD_INTEGRATION_CREATE = Route.post("/guilds/{guild.id}/integrations");
 
@@ -678,7 +678,7 @@ public abstract class Routes {
      * Returns a 204 empty response on success. Fires a Guild Integrations Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-integration">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-integration</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild-integration</a>
      */
     public static final Route GUILD_INTEGRATION_MODIFY = Route.patch("/guilds/{guild.id}/integrations/{integration.id}");
 
@@ -687,7 +687,7 @@ public abstract class Routes {
      * empty response on success. Fires a Guild Integrations Update Gateway event.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#delete-guild-integration">
-     *         https://discord.com/developers/docs/resources/guild#delete-guild-integration</a>
+     * https://discord.com/developers/docs/resources/guild#delete-guild-integration</a>
      */
     public static final Route GUILD_INTEGRATION_DELETE = Route.delete("/guilds/{guild.id}/integrations/{integration.id}");
 
@@ -695,7 +695,7 @@ public abstract class Routes {
      * Sync an integration. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#sync-guild-integration">
-     *         https://discord.com/developers/docs/resources/guild#sync-guild-integration</a>
+     * https://discord.com/developers/docs/resources/guild#sync-guild-integration</a>
      */
     public static final Route GUILD_INTEGRATION_SYNC = Route.post("/guilds/{guild.id}/integrations/{integration.id}/sync");
 
@@ -703,8 +703,8 @@ public abstract class Routes {
      * Returns the guild embed object. Requires the 'MANAGE_GUILD' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-embed">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-embed</a>
-	 * @deprecated Use {@code Routes.GUILD_WIDGET_GET} instead.
+     * https://discord.com/developers/docs/resources/guild#get-guild-embed</a>
+     * @deprecated Use {@code Routes.GUILD_WIDGET_GET} instead.
      */
     @Deprecated
     public static final Route GUILD_EMBED_GET = Route.get("/guilds/{guild.id}/embed");
@@ -713,7 +713,7 @@ public abstract class Routes {
      * Returns the guild widget object. Requires the 'MANAGE_GUILD' permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-widget">
-     *         https://discord.com/developers/docs/resources/guild#get-guild-widget</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-widget</a>
      */
     public static final Route GUILD_WIDGET_GET = Route.get("/guilds/{guild.id}/widget");
 
@@ -722,8 +722,8 @@ public abstract class Routes {
      * 'MANAGE_GUILD' permission. Returns the updated guild embed object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-embed">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-embed</a>
-	 * @deprecated Use {@code Routes.GUILD_WIDGET_MODIFY} instead.
+     * https://discord.com/developers/docs/resources/guild#modify-guild-embed</a>
+     * @deprecated Use {@code Routes.GUILD_WIDGET_MODIFY} instead.
      */
     @Deprecated
     public static final Route GUILD_EMBED_MODIFY = Route.patch("/guilds/{guild.id}/embed");
@@ -733,7 +733,7 @@ public abstract class Routes {
      * 'MANAGE_GUILD' permission. Returns the updated guild widget object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#modify-guild-widget">
-     *         https://discord.com/developers/docs/resources/guild#modify-guild-widget</a>
+     * https://discord.com/developers/docs/resources/guild#modify-guild-widget</a>
      */
     public static final Route GUILD_WIDGET_MODIFY = Route.patch("/guilds/{guild.id}/widget");
 
@@ -741,7 +741,7 @@ public abstract class Routes {
      * Returns the guild preview object. If the user is not in the guild, then the guild must be Discoverable.
      *
      * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-preview">
-     *     https://discord.com/developers/docs/resources/guild#get-guild-preview</a>
+     * https://discord.com/developers/docs/resources/guild#get-guild-preview</a>
      */
     public static final Route GUILD_PREVIEW_GET = Route.get("/guilds/{guild.id}/preview");
 
@@ -753,7 +753,7 @@ public abstract class Routes {
      * Returns an invite object for the given code.
      *
      * @see <a href="https://discord.com/developers/docs/resources/invite#get-invite">
-     *         https://discord.com/developers/docs/resources/invite#get-invite</a>
+     * https://discord.com/developers/docs/resources/invite#get-invite</a>
      */
     public static final Route INVITE_GET = Route.get("/invites/{invite.code}");
 
@@ -761,7 +761,7 @@ public abstract class Routes {
      * Delete an invite. Requires the MANAGE_CHANNELS permission. Returns an invite object on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/invite#delete-invite">
-     *         https://discord.com/developers/docs/resources/invite#delete-invite</a>
+     * https://discord.com/developers/docs/resources/invite#delete-invite</a>
      */
     public static final Route INVITE_DELETE = Route.delete("/invites/{invite.code}");
 
@@ -770,7 +770,7 @@ public abstract class Routes {
      * users (via an OAuth2 Bearer token). Bot users are disallowed. Returns an invite object on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/invite#accept-invite">
-     *         https://discord.com/developers/docs/resources/invite#accept-invite</a>
+     * https://discord.com/developers/docs/resources/invite#accept-invite</a>
      */
     public static final Route INVITE_ACCEPT = Route.post("/invites/{invite.code}");
 
@@ -783,7 +783,7 @@ public abstract class Routes {
      * return the object without an email, and optionally the email scope, which returns the object with an email.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#get-current-user">
-     *         https://discord.com/developers/docs/resources/user#get-current-user</a>
+     * https://discord.com/developers/docs/resources/user#get-current-user</a>
      */
     public static final Route CURRENT_USER_GET = Route.get("/users/@me");
 
@@ -791,7 +791,7 @@ public abstract class Routes {
      * Returns a user object for a given user ID.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#get-user">
-     *         https://discord.com/developers/docs/resources/user#get-user</a>
+     * https://discord.com/developers/docs/resources/user#get-user</a>
      */
     public static final Route USER_GET = Route.get("/users/{user.id}");
 
@@ -799,7 +799,7 @@ public abstract class Routes {
      * Modify the requester's user account settings. Returns a user object on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#modify-current-user">
-     *         https://discord.com/developers/docs/resources/user#modify-current-user</a>
+     * https://discord.com/developers/docs/resources/user#modify-current-user</a>
      */
     public static final Route CURRENT_USER_MODIFY = Route.patch("/users/@me");
 
@@ -807,7 +807,7 @@ public abstract class Routes {
      * Returns a list of partial guild objects the current user is a member of. Requires the guilds OAuth2 scope.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#get-current-user-guilds">
-     *         https://discord.com/developers/docs/resources/user#get-current-user-guilds</a>
+     * https://discord.com/developers/docs/resources/user#get-current-user-guilds</a>
      */
     public static final Route CURRENT_USER_GUILDS_GET = Route.get("/users/@me/guilds");
 
@@ -815,7 +815,7 @@ public abstract class Routes {
      * Leave a guild. Returns a 204 empty response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#leave-guild">
-     *         https://discord.com/developers/docs/resources/user#leave-guild</a>
+     * https://discord.com/developers/docs/resources/user#leave-guild</a>
      */
     public static final Route GUILD_LEAVE = Route.delete("/users/@me/guilds/{guild.id}");
 
@@ -823,7 +823,7 @@ public abstract class Routes {
      * Returns a list of DM channel objects.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#get-user-dms">
-     *         https://discord.com/developers/docs/resources/user#get-user-dms</a>
+     * https://discord.com/developers/docs/resources/user#get-user-dms</a>
      */
     public static final Route USER_DMS_GET = Route.get("/users/@me/channels");
 
@@ -831,7 +831,7 @@ public abstract class Routes {
      * Create a new DM channel with a user. Returns a DM channel object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#create-dm">
-     *         https://discord.com/developers/docs/resources/user#create-dm</a>
+     * https://discord.com/developers/docs/resources/user#create-dm</a>
      */
     public static final Route USER_DM_CREATE = Route.post("/users/@me/channels");
 
@@ -839,7 +839,7 @@ public abstract class Routes {
      * Create a new group DM channel with multiple users. Returns a DM channel object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#create-group-dm">
-     *         https://discord.com/developers/docs/resources/user#create-group-dm</a>
+     * https://discord.com/developers/docs/resources/user#create-group-dm</a>
      */
     public static final Route GROUP_DM_CREATE = Route.post("/users/@me/channels");
 
@@ -847,7 +847,7 @@ public abstract class Routes {
      * Returns a list of connection objects. Requires the connections OAuth2 scope.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#get-user-connections">
-     *         https://discord.com/developers/docs/resources/user#get-user-connections</a>
+     * https://discord.com/developers/docs/resources/user#get-user-connections</a>
      */
     public static final Route USER_CONNECTIONS_GET = Route.get("/users/@me/connections");
 
@@ -859,7 +859,7 @@ public abstract class Routes {
      * Returns an array of voice region objects that can be used when creating servers.
      *
      * @see <a href="https://discord.com/developers/docs/resources/voice#list-voice-regions">
-     *         https://discord.com/developers/docs/resources/voice#list-voice-regions</a>
+     * https://discord.com/developers/docs/resources/voice#list-voice-regions</a>
      */
     public static final Route VOICE_REGION_LIST = Route.get("/voice/regions");
 
@@ -871,7 +871,7 @@ public abstract class Routes {
      * Create a new webhook. Returns a webhook object on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#create-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#create-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#create-webhook</a>
      */
     public static final Route CHANNEL_WEBHOOK_CREATE = Route.post("/channels/{channel.id}/webhooks");
 
@@ -879,7 +879,7 @@ public abstract class Routes {
      * Returns a list of channel webhook objects.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#get-channel-webhooks">
-     *         https://discord.com/developers/docs/resources/webhook#get-channel-webhooks</a>
+     * https://discord.com/developers/docs/resources/webhook#get-channel-webhooks</a>
      */
     public static final Route CHANNEL_WEBHOOKS_GET = Route.get("/channels/{channel.id}/webhooks");
 
@@ -887,7 +887,7 @@ public abstract class Routes {
      * Returns a list of guild webhook objects.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#get-guild-webhooks">
-     *         https://discord.com/developers/docs/resources/webhook#get-guild-webhooks</a>
+     * https://discord.com/developers/docs/resources/webhook#get-guild-webhooks</a>
      */
     public static final Route GUILD_WEBHOOKS_GET = Route.get("/guilds/{guild.id}/webhooks");
 
@@ -895,7 +895,7 @@ public abstract class Routes {
      * Returns the new webhook object for the given id.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#get-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#get-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#get-webhook</a>
      */
     public static final Route WEBHOOK_GET = Route.get("/webhooks/{webhook.id}");
 
@@ -904,7 +904,7 @@ public abstract class Routes {
      * webhook object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#get-webhook-with-token"
-     *         >https://discord.com/developers/docs/resources/webhook#get-webhook-with-token</a>
+     * >https://discord.com/developers/docs/resources/webhook#get-webhook-with-token</a>
      */
     public static final Route WEBHOOK_TOKEN_GET = Route.get("/webhooks/{webhook.id}/{webhook.token}");
 
@@ -912,7 +912,7 @@ public abstract class Routes {
      * Modify a webhook. Returns the updated webhook object on success. All parameters to this endpoint are optional.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#modify-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#modify-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#modify-webhook</a>
      */
     public static final Route WEBHOOK_MODIFY = Route.patch("/webhooks/{webhook.id}");
 
@@ -921,7 +921,7 @@ public abstract class Routes {
      * webhook object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token">
-     *         https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token</a>
+     * https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token</a>
      */
     public static final Route WEBHOOK_TOKEN_MODIFY = Route.patch("/webhooks/{webhook.id}/{webhook.token}");
 
@@ -929,7 +929,7 @@ public abstract class Routes {
      * Delete a webhook permanently. User must be owner. Returns a 204 NO CONTENT response on success.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#delete-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#delete-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#delete-webhook</a>
      */
     public static final Route WEBHOOK_DELETE = Route.delete("/webhooks/{webhook.id}");
 
@@ -937,7 +937,7 @@ public abstract class Routes {
      * Same as above, except this call does not require authentication.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token">
-     *         https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token</a>
+     * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token</a>
      */
     public static final Route WEBHOOK_TOKEN_DELETE = Route.delete("/webhooks/{webhook.id}/{webhook.token}");
 
@@ -948,27 +948,65 @@ public abstract class Routes {
      * body as a form value for payload_json.
      *
      * @see <a href="https://discord.com/developers/docs/resources/webhook#execute-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#execute-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#execute-webhook</a>
      */
     public static final Route WEBHOOK_EXECUTE = Route.post("/webhooks/{webhook.id}/{webhook.token}");
 
     /**
      * @see <a href="https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook</a>
      */
     public static final Route WEBHOOK_EXECUTE_SLACK = Route.post("/webhooks/{webhook.id}/{webhook.token}/slack");
 
     /**
      * @see <a href="https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook">
-     *         https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook</a>
+     * https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook</a>
      */
     public static final Route WEBHOOK_EXECUTE_GITHUB = Route.post("/webhooks/{webhook.id}/{webhook.token}/github");
+
+    /**
+     * @see <a href="https://discord.com/developers/docs/resources/webhook#edit-webhook-message">
+     * https://discord.com/developers/docs/resources/webhook#edit-webhook-message</a>
+     */
+    public static final Route WEBHOOK_MESSAGE_EDIT = Route.patch("/webhooks/{webhook.id}/{webhook.token}/messages/{message.id}");
+
+    /**
+     * @see <a href="https://discord.com/developers/docs/resources/webhook#delete-webhook-message">
+     * https://discord.com/developers/docs/resources/webhook#delete-webhook-message</a>
+     */
+    public static final Route WEBHOOK_MESSAGE_DELETE = Route.delete("/webhooks/{webhook.id}/{webhook.token}/messages/{message.id}");
+
+    ///////////////////////////////////////////
+    ////////// Application Resource ///////////
+    ///////////////////////////////////////////
 
     /**
      * Returns the bot's OAuth2 application info.
      *
      * @see <a href=https://discord.com/developers/docs/topics/oauth2#get-current-application-information>
-     *         https://discord.com/developers/docs/topics/oauth2#get-current-application-information</a>
+     * https://discord.com/developers/docs/topics/oauth2#get-current-application-information</a>
      */
     public static final Route APPLICATION_INFO_GET = Route.get("/oauth2/applications/@me");
+
+    public static final Route GLOBAL_APPLICATION_COMMANDS_GET = Route.get("/applications/{application.id}/commands");
+
+    public static final Route GLOBAL_APPLICATION_COMMANDS_CREATE = Route.post("/applications/{application.id}/commands");
+
+    public static final Route GLOBAL_APPLICATION_COMMAND_MODIFY = Route.patch("/applications/{application.id}/commands/{command.id}");
+
+    public static final Route GLOBAL_APPLICATION_COMMAND_DELETE = Route.delete("/applications/{application.id}/commands/{command.id}");
+
+    public static final Route GUILD_APPLICATION_COMMANDS_GET = Route.get("/applications/{application.id}/guilds/{guild.id}/commands");
+
+    public static final Route GUILD_APPLICATION_COMMANDS_CREATE = Route.post("/applications/{application.id}/guilds/{guild.id}/commands");
+
+    public static final Route GUILD_APPLICATION_COMMAND_MODIFY = Route.patch("/applications/{application.id}/guilds/{guild.id}/commands/{command.id}");
+
+    public static final Route GUILD_APPLICATION_COMMAND_DELETE = Route.delete("/applications/{application.id}/guilds/{guild.id}/commands/{command.id}");
+
+    ///////////////////////////////////////////
+    ////////// Interaction Resource ///////////
+    ///////////////////////////////////////////
+
+    public static final Route INTERACTION_RESPONSE_CREATE = Route.post("/interactions/{interaction.id}/{interaction.token}/callback");
 }

--- a/rest/src/main/java/discord4j/rest/service/ApplicationService.java
+++ b/rest/src/main/java/discord4j/rest/service/ApplicationService.java
@@ -40,56 +40,56 @@ public class ApplicationService extends RestService {
                 .bodyToMono(ApplicationInfoData.class);
     }
 
-    public Flux<ApplicationCommandData> getGlobalApplicationCommands(Snowflake applicationId) {
-        return Routes.GLOBAL_APPLICATION_COMMANDS_GET.newRequest(applicationId.asString())
+    public Flux<ApplicationCommandData> getGlobalApplicationCommands(long applicationId) {
+        return Routes.GLOBAL_APPLICATION_COMMANDS_GET.newRequest(applicationId)
             .exchange(getRouter())
             .bodyToMono(ApplicationCommandData[].class)
             .flatMapMany(Flux::fromArray);
     }
 
-    public Mono<ApplicationCommandData> createGlobalApplicationCommand(Snowflake applicationId, ApplicationCommandRequest request) {
-        return Routes.GLOBAL_APPLICATION_COMMANDS_CREATE.newRequest(applicationId.asString())
+    public Mono<ApplicationCommandData> createGlobalApplicationCommand(long applicationId, ApplicationCommandRequest request) {
+        return Routes.GLOBAL_APPLICATION_COMMANDS_CREATE.newRequest(applicationId)
             .body(request)
             .exchange(getRouter())
             .bodyToMono(ApplicationCommandData.class);
     }
 
-    public Mono<ApplicationCommandData> modifyGlobalApplicationCommand(Snowflake applicationId, Snowflake commandId, ApplicationCommandRequest request) {
-        return Routes.GLOBAL_APPLICATION_COMMAND_MODIFY.newRequest(applicationId.asString(), commandId.asString())
+    public Mono<ApplicationCommandData> modifyGlobalApplicationCommand(long applicationId, long commandId, ApplicationCommandRequest request) {
+        return Routes.GLOBAL_APPLICATION_COMMAND_MODIFY.newRequest(applicationId, commandId)
             .body(request)
             .exchange(getRouter())
             .bodyToMono(ApplicationCommandData.class);
     }
 
-    public Mono<Void> deleteGlobalApplicationCommand(Snowflake applicationId, Snowflake commandId) {
-        return Routes.GLOBAL_APPLICATION_COMMAND_DELETE.newRequest(applicationId.asString(), commandId.asString())
+    public Mono<Void> deleteGlobalApplicationCommand(long applicationId, long commandId) {
+        return Routes.GLOBAL_APPLICATION_COMMAND_DELETE.newRequest(applicationId, commandId)
             .exchange(getRouter())
             .bodyToMono(Void.class);
     }
 
-    public Flux<ApplicationCommandData> getGuildApplicationCommands(Snowflake applicationId, Snowflake guildId) {
-        return Routes.GUILD_APPLICATION_COMMANDS_GET.newRequest(applicationId.asString(), guildId.asString())
+    public Flux<ApplicationCommandData> getGuildApplicationCommands(long applicationId, long guildId) {
+        return Routes.GUILD_APPLICATION_COMMANDS_GET.newRequest(applicationId, guildId)
             .exchange(getRouter())
             .bodyToMono(ApplicationCommandData[].class)
             .flatMapMany(Flux::fromArray);
     }
 
-    public Mono<ApplicationCommandData> createGuildApplicationCommand(Snowflake applicationId, Snowflake guildId, ApplicationCommandRequest request) {
-        return Routes.GUILD_APPLICATION_COMMANDS_CREATE.newRequest(applicationId.asString(), guildId.asString())
+    public Mono<ApplicationCommandData> createGuildApplicationCommand(long applicationId, long guildId, ApplicationCommandRequest request) {
+        return Routes.GUILD_APPLICATION_COMMANDS_CREATE.newRequest(applicationId, guildId)
             .body(request)
             .exchange(getRouter())
             .bodyToMono(ApplicationCommandData.class);
     }
 
-    public Mono<ApplicationCommandData> modifyGuildApplicationCommand(Snowflake applicationId, Snowflake guildId, Snowflake commandId, ApplicationCommandRequest request) {
-        return Routes.GUILD_APPLICATION_COMMAND_MODIFY.newRequest(applicationId.asString(), guildId.asString(), commandId.asString())
+    public Mono<ApplicationCommandData> modifyGuildApplicationCommand(long applicationId, long guildId, long commandId, ApplicationCommandRequest request) {
+        return Routes.GUILD_APPLICATION_COMMAND_MODIFY.newRequest(applicationId, guildId, commandId)
             .body(request)
             .exchange(getRouter())
             .bodyToMono(ApplicationCommandData.class);
     }
 
-    public Mono<Void> deleteGuildApplicationCommand(Snowflake applicationId, Snowflake guildId, Snowflake commandId) {
-        return Routes.GUILD_APPLICATION_COMMAND_DELETE.newRequest(applicationId.asString(), guildId.asString(), commandId.asString())
+    public Mono<Void> deleteGuildApplicationCommand(long applicationId, long guildId, long commandId) {
+        return Routes.GUILD_APPLICATION_COMMAND_DELETE.newRequest(applicationId, guildId, commandId)
             .exchange(getRouter())
             .bodyToMono(Void.class);
     }

--- a/rest/src/main/java/discord4j/rest/service/ApplicationService.java
+++ b/rest/src/main/java/discord4j/rest/service/ApplicationService.java
@@ -16,10 +16,17 @@
  */
 package discord4j.rest.service;
 
+import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.ApplicationCommandData;
+import discord4j.discordjson.json.ApplicationCommandRequest;
 import discord4j.discordjson.json.ApplicationInfoData;
+import discord4j.discordjson.json.UserGuildData;
 import discord4j.rest.request.Router;
 import discord4j.rest.route.Routes;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 public class ApplicationService extends RestService {
 
@@ -31,5 +38,59 @@ public class ApplicationService extends RestService {
         return Routes.APPLICATION_INFO_GET.newRequest()
                 .exchange(getRouter())
                 .bodyToMono(ApplicationInfoData.class);
+    }
+
+    public Flux<ApplicationCommandData> getGlobalApplicationCommands(Snowflake applicationId) {
+        return Routes.GLOBAL_APPLICATION_COMMANDS_GET.newRequest(applicationId.asString())
+            .exchange(getRouter())
+            .bodyToMono(ApplicationCommandData[].class)
+            .flatMapMany(Flux::fromArray);
+    }
+
+    public Mono<ApplicationCommandData> createGlobalApplicationCommand(Snowflake applicationId, ApplicationCommandRequest request) {
+        return Routes.GLOBAL_APPLICATION_COMMANDS_CREATE.newRequest(applicationId.asString())
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(ApplicationCommandData.class);
+    }
+
+    public Mono<ApplicationCommandData> modifyGlobalApplicationCommand(Snowflake applicationId, Snowflake commandId, ApplicationCommandRequest request) {
+        return Routes.GLOBAL_APPLICATION_COMMAND_MODIFY.newRequest(applicationId.asString(), commandId.asString())
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(ApplicationCommandData.class);
+    }
+
+    public Mono<Void> deleteGlobalApplicationCommand(Snowflake applicationId, Snowflake commandId) {
+        return Routes.GLOBAL_APPLICATION_COMMAND_DELETE.newRequest(applicationId.asString(), commandId.asString())
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
+    }
+
+    public Flux<ApplicationCommandData> getGuildApplicationCommands(Snowflake applicationId, Snowflake guildId) {
+        return Routes.GUILD_APPLICATION_COMMANDS_GET.newRequest(applicationId.asString(), guildId.asString())
+            .exchange(getRouter())
+            .bodyToMono(ApplicationCommandData[].class)
+            .flatMapMany(Flux::fromArray);
+    }
+
+    public Mono<ApplicationCommandData> createGuildApplicationCommand(Snowflake applicationId, Snowflake guildId, ApplicationCommandRequest request) {
+        return Routes.GUILD_APPLICATION_COMMANDS_CREATE.newRequest(applicationId.asString(), guildId.asString())
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(ApplicationCommandData.class);
+    }
+
+    public Mono<ApplicationCommandData> modifyGuildApplicationCommand(Snowflake applicationId, Snowflake guildId, Snowflake commandId, ApplicationCommandRequest request) {
+        return Routes.GUILD_APPLICATION_COMMAND_MODIFY.newRequest(applicationId.asString(), guildId.asString(), commandId.asString())
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(ApplicationCommandData.class);
+    }
+
+    public Mono<Void> deleteGuildApplicationCommand(Snowflake applicationId, Snowflake guildId, Snowflake commandId) {
+        return Routes.GUILD_APPLICATION_COMMAND_DELETE.newRequest(applicationId.asString(), guildId.asString(), commandId.asString())
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/service/InteractionService.java
+++ b/rest/src/main/java/discord4j/rest/service/InteractionService.java
@@ -29,8 +29,8 @@ public class InteractionService extends RestService {
         super(router);
     }
 
-    public Mono<JsonNode> createInteractionResponse(Snowflake interactionId, String interactionToken, InteractionResponseData response) {
-        return Routes.INTERACTION_RESPONSE_CREATE.newRequest(interactionId.asString(), interactionToken)
+    public Mono<JsonNode> createInteractionResponse(long interactionId, String interactionToken, InteractionResponseData response) {
+        return Routes.INTERACTION_RESPONSE_CREATE.newRequest(interactionId, interactionToken)
             .body(response)
             .exchange(getRouter())
             .bodyToMono(JsonNode.class);

--- a/rest/src/main/java/discord4j/rest/service/InteractionService.java
+++ b/rest/src/main/java/discord4j/rest/service/InteractionService.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.rest.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.InteractionResponseData;
+import discord4j.rest.request.Router;
+import discord4j.rest.route.Routes;
+import reactor.core.publisher.Mono;
+
+public class InteractionService extends RestService {
+
+    public InteractionService(Router router) {
+        super(router);
+    }
+
+    public Mono<JsonNode> createInteractionResponse(Snowflake interactionId, String interactionToken, InteractionResponseData response) {
+        return Routes.INTERACTION_RESPONSE_CREATE.newRequest(interactionId.asString(), interactionToken)
+            .body(response)
+            .exchange(getRouter())
+            .bodyToMono(JsonNode.class);
+    }
+}

--- a/rest/src/main/java/discord4j/rest/service/WebhookService.java
+++ b/rest/src/main/java/discord4j/rest/service/WebhookService.java
@@ -17,11 +17,16 @@
 package discord4j.rest.service;
 
 import discord4j.discordjson.json.*;
+import discord4j.rest.request.DiscordWebResponse;
 import discord4j.rest.request.Router;
 import discord4j.rest.route.Routes;
+import discord4j.rest.util.MultipartRequest;
+import discord4j.rest.util.WebhookMultipartRequest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
+
+import java.util.Objects;
 
 public class WebhookService extends RestService {
 
@@ -70,6 +75,33 @@ public class WebhookService extends RestService {
                 .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter())
                 .bodyToMono(Void.class);
+    }
+
+
+    /**
+     * Executes the specified webhook.
+     *
+     * This method has been backported from 3.2.x
+     *
+     * @param wait true if you want to return message data and errors for the webhook.
+     * @return If wait is true, a mono that contains the message information of the execution or an
+     * error if the webhook is unsuccessful. If wait is false, the mono completes as soon as the request
+     * is finished sending, and DOES NOT result in an error if the message is not saved.
+     */
+    @Deprecated
+    public Mono<MessageData> executeWebhook(long webhookId, String token, boolean wait, WebhookMultipartRequest request) {
+        DiscordWebResponse response = Routes.WEBHOOK_EXECUTE
+            .newRequest(webhookId, token)
+            .query("wait", wait)
+            .header("content-type", request.getFiles().isEmpty() ? "application/json" : "multipart/form-data")
+            .body(Objects.requireNonNull(request.getFiles().isEmpty() ? request.getExecuteRequest() : request))
+            .exchange(getRouter());
+
+        if (wait) {
+            return response.bodyToMono(MessageData.class);
+        } else {
+            return response.bodyToMono(Void.class).cast(MessageData.class);
+        }
     }
 
     public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, long messageId, WebhookMessageEditRequest request) {

--- a/rest/src/main/java/discord4j/rest/service/WebhookService.java
+++ b/rest/src/main/java/discord4j/rest/service/WebhookService.java
@@ -16,9 +16,7 @@
  */
 package discord4j.rest.service;
 
-import discord4j.discordjson.json.WebhookCreateRequest;
-import discord4j.discordjson.json.WebhookData;
-import discord4j.discordjson.json.WebhookModifyRequest;
+import discord4j.discordjson.json.*;
 import discord4j.rest.request.Router;
 import discord4j.rest.route.Routes;
 import reactor.core.publisher.Flux;
@@ -72,5 +70,18 @@ public class WebhookService extends RestService {
                 .optionalHeader("X-Audit-Log-Reason", reason)
                 .exchange(getRouter())
                 .bodyToMono(Void.class);
+    }
+
+    public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, long messageId, WebhookMessageEditRequest request) {
+        return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(MessageData.class);
+    }
+
+    public Mono<Void> deleteWebhookMessage(long webhookId, String webhookToken, long messageId) {
+        return Routes.WEBHOOK_MESSAGE_DELETE.newRequest(webhookId, webhookToken, messageId)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 }

--- a/rest/src/main/java/discord4j/rest/util/ApplicationCommandOptionType.java
+++ b/rest/src/main/java/discord4j/rest/util/ApplicationCommandOptionType.java
@@ -1,0 +1,66 @@
+package discord4j.rest.util;
+
+public enum ApplicationCommandOptionType {
+    UNKNOWN(-1),
+    SUB_COMMAND(1),
+    SUB_COMMAND_GROUP(2),
+    STRING(3),
+    INTEGER(4),
+    BOOLEAN(5),
+    USER(6),
+    CHANNEL(7),
+    ROLE(8);
+
+    /**
+     * The underlying value as represented by Discord.
+     */
+    private final int value;
+
+    /**
+     * Constructs an {@code ApplicationCommandOptionType}.
+     *
+     * @param value The underlying value as represented by Discord.
+     */
+    ApplicationCommandOptionType(final int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the underlying value as represented by Discord.
+     *
+     * @return The underlying value as represented by Discord.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the type of an application command option. It is guaranteed that invoking {@link #getValue()} from the returned enum will
+     * equal ({@code ==}) the supplied {@code value}.
+     *
+     * @param value The underlying value as represented by Discord.
+     * @return The type of option.
+     */
+    public static ApplicationCommandOptionType of(final int value) {
+        switch (value) {
+            case 1:
+                return SUB_COMMAND;
+            case 2:
+                return SUB_COMMAND_GROUP;
+            case 3:
+                return STRING;
+            case 4:
+                return INTEGER;
+            case 5:
+                return BOOLEAN;
+            case 6:
+                return USER;
+            case 7:
+                return CHANNEL;
+            case 8:
+                return ROLE;
+            default:
+                return UNKNOWN;
+        }
+    }
+}

--- a/rest/src/main/java/discord4j/rest/util/ApplicationCommandOptionType.java
+++ b/rest/src/main/java/discord4j/rest/util/ApplicationCommandOptionType.java
@@ -1,5 +1,7 @@
 package discord4j.rest.util;
 
+import java.util.Arrays;
+
 public enum ApplicationCommandOptionType {
     UNKNOWN(-1),
     SUB_COMMAND(1),
@@ -42,25 +44,6 @@ public enum ApplicationCommandOptionType {
      * @return The type of option.
      */
     public static ApplicationCommandOptionType of(final int value) {
-        switch (value) {
-            case 1:
-                return SUB_COMMAND;
-            case 2:
-                return SUB_COMMAND_GROUP;
-            case 3:
-                return STRING;
-            case 4:
-                return INTEGER;
-            case 5:
-                return BOOLEAN;
-            case 6:
-                return USER;
-            case 7:
-                return CHANNEL;
-            case 8:
-                return ROLE;
-            default:
-                return UNKNOWN;
-        }
+        return Arrays.stream(values()).filter(type -> type.getValue() == value).findFirst().orElse(UNKNOWN);
     }
 }

--- a/rest/src/main/java/discord4j/rest/util/InteractionResponseType.java
+++ b/rest/src/main/java/discord4j/rest/util/InteractionResponseType.java
@@ -1,5 +1,7 @@
 package discord4j.rest.util;
 
+import java.util.Arrays;
+
 public enum InteractionResponseType {
     /**
      * Unknown type
@@ -57,19 +59,6 @@ public enum InteractionResponseType {
      * @return The type of response.
      */
     public static InteractionResponseType of(final int value) {
-        switch (value) {
-            case 1:
-                return PONG;
-            case 2:
-                return ACKNOWLEDGE;
-            case 3:
-                return CHANNEL_MESSAGE;
-            case 4:
-                return CHANNEL_MESSAGE_WITH_SOURCE;
-            case 5:
-                return ACKNOWLEDGE_WITH_SOURCE;
-            default:
-                return UNKNOWN;
-        }
+        return Arrays.stream(values()).filter(type -> type.getValue() == value).findFirst().orElse(UNKNOWN);
     }
 }

--- a/rest/src/main/java/discord4j/rest/util/InteractionResponseType.java
+++ b/rest/src/main/java/discord4j/rest/util/InteractionResponseType.java
@@ -1,0 +1,75 @@
+package discord4j.rest.util;
+
+public enum InteractionResponseType {
+    /**
+     * Unknown type
+     */
+    UNKNOWN(-1),
+    /**
+     * ACK a Ping
+     */
+    PONG(1),
+    /**
+     * ACK a command without sending a message, eating the user's input
+     */
+    ACKNOWLEDGE(2),
+    /**
+     * respond with a message, eating the user's input
+     */
+    CHANNEL_MESSAGE(3),
+    /**
+     * respond with a message, showing the user's input
+     */
+    CHANNEL_MESSAGE_WITH_SOURCE(4),
+    /**
+     * ACK a command without sending a message, showing the user's input
+     */
+    ACKNOWLEDGE_WITH_SOURCE(5);
+
+    /**
+     * The underlying value as represented by Discord.
+     */
+    private final int value;
+
+    /**
+     * Constructs an {@code InteractionResponseType}.
+     *
+     * @param value The underlying value as represented by Discord.
+     */
+    InteractionResponseType(final int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the underlying value as represented by Discord.
+     *
+     * @return The underlying value as represented by Discord.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the type of an interaction response. It is guaranteed that invoking {@link #getValue()} from the returned enum will
+     * equal ({@code ==}) the supplied {@code value}.
+     *
+     * @param value The underlying value as represented by Discord.
+     * @return The type of response.
+     */
+    public static InteractionResponseType of(final int value) {
+        switch (value) {
+            case 1:
+                return PONG;
+            case 2:
+                return ACKNOWLEDGE;
+            case 3:
+                return CHANNEL_MESSAGE;
+            case 4:
+                return CHANNEL_MESSAGE_WITH_SOURCE;
+            case 5:
+                return ACKNOWLEDGE_WITH_SOURCE;
+            default:
+                return UNKNOWN;
+        }
+    }
+}

--- a/rest/src/main/java/discord4j/rest/util/WebhookMultipartRequest.java
+++ b/rest/src/main/java/discord4j/rest/util/WebhookMultipartRequest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.util;
+
+import discord4j.discordjson.json.WebhookExecuteRequest;
+import reactor.util.annotation.Nullable;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Note: This is a hold-over class to backport webhook execute functionality from 3.2.x
+ */
+@Deprecated
+public class WebhookMultipartRequest {
+
+    private final WebhookExecuteRequest executeRequest;
+    private final List<Tuple2<String, InputStream>> files;
+
+    public WebhookMultipartRequest(WebhookExecuteRequest executeRequest) {
+        this(executeRequest, Collections.emptyList());
+    }
+
+    public WebhookMultipartRequest(WebhookExecuteRequest executeRequest, String fileName, InputStream file) {
+        this(executeRequest, Collections.singletonList(Tuples.of(fileName, file)));
+    }
+
+    public WebhookMultipartRequest(WebhookExecuteRequest executeRequest, List<Tuple2<String, InputStream>> files) {
+        this.executeRequest = executeRequest;
+        this.files = files;
+    }
+
+    @Nullable
+    public WebhookExecuteRequest getExecuteRequest() {
+        return executeRequest;
+    }
+
+    public List<Tuple2<String, InputStream>> getFiles() {
+        return files;
+    }
+}


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** This PR adds the necessary routes for creating and responding to slash commands.

**Justification:** #818 and [Discord API Changes](https://github.com/discord/discord-api-docs/pull/2295)

This PR depends on [Discord4J/discord-json#43](https://github.com/Discord4J/discord-json/pull/43).

This does **not** implement components in discord4j-core yet, as that will require a bit of extra work and design.