### PR TITLE
Correct the Webhook javadocs

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Webhook.java
+++ b/core/src/main/java/discord4j/core/object/entity/Webhook.java
@@ -260,7 +260,7 @@ public final class Webhook implements Entity {
      * Requests to edit this webhook. Requires the MANAGE_WEBHOOKS permission.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link WebhookEditSpec} to be operated on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Webhook}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
     public Mono<Webhook> edit(final Consumer<? super WebhookEditSpec> spec) {
@@ -279,7 +279,7 @@ public final class Webhook implements Entity {
      * Does not require the MANAGE_WEBHOOKS permission.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link WebhookEditSpec} to be operated on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Webhook}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
     public Mono<Webhook> editWithToken(final Consumer<? super WebhookEditWithTokenSpec> spec) {


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
The webhook javadocs incorrectly linked to the Guild object instead of the Webhook object in a couple of places - this change corrects that.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
More accurate documentation.