### PR TITLE
Add with_counts query param to GET guild

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -64,13 +64,12 @@ public class RestGuild {
     /**
      * Retrieve this guild's data upon subscription.
      *
-     * @param withCounts when true, will return approximate member and presence counts for the guild
      * @return a {@link Mono} where, upon successful completion, emits the {@link GuildUpdateData} belonging to this
      * entity. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<GuildUpdateData> getData(@Nullable Boolean withCounts) {
+    public Mono<GuildUpdateData> getData() {
         Map<String, Object> queryParams = new HashMap<>();
-        Optional.ofNullable(withCounts).ifPresent(value -> queryParams.put("with_counts", value));
+        queryParams.put("with_counts", false);
         return restClient.getGuildService().getGuild(id, queryParams);
     }
 

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -67,9 +67,9 @@ public class RestGuild {
      * @return a {@link Mono} where, upon successful completion, emits the {@link GuildUpdateData} belonging to this
      * entity. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<GuildUpdateData> getData() {
+    public Mono<GuildUpdateData> getData(@Nullable Boolean withCounts) {
         Map<String, Object> queryParams = new HashMap<>();
-        queryParams.put("with_counts", false);
+        Optional.ofNullable(withCounts).ifPresent(value -> queryParams.put("with_counts", value));
         return restClient.getGuildService().getGuild(id, queryParams);
     }
 

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -64,6 +64,8 @@ public class RestGuild {
     /**
      * Retrieve this guild's data upon subscription.
      *
+     * @param withCounts when true, will return approximate member and presence counts for the guild too.
+     * otherwise approximate member and presence counts will be null in {@link GuildUpdateData}.
      * @return a {@link Mono} where, upon successful completion, emits the {@link GuildUpdateData} belonging to this
      * entity. If an error is received, it is emitted through the {@code Mono}.
      */
@@ -71,6 +73,16 @@ public class RestGuild {
         Map<String, Object> queryParams = new HashMap<>();
         Optional.ofNullable(withCounts).ifPresent(value -> queryParams.put("with_counts", value));
         return restClient.getGuildService().getGuild(id, queryParams);
+    }
+
+    /**
+     * Retrieve this guild's data upon subscription.
+     *
+     * @return a {@link Mono} where, upon successful completion, emits the {@link GuildUpdateData} belonging to this
+     * entity. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<GuildUpdateData> getData() {
+        return getData(null);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -64,11 +64,14 @@ public class RestGuild {
     /**
      * Retrieve this guild's data upon subscription.
      *
+     * @param withCounts when true, will return approximate member and presence counts for the guild
      * @return a {@link Mono} where, upon successful completion, emits the {@link GuildUpdateData} belonging to this
      * entity. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<GuildUpdateData> getData() {
-        return restClient.getGuildService().getGuild(id);
+    public Mono<GuildUpdateData> getData(@Nullable Boolean withCounts) {
+        Map<String, Object> queryParams = new HashMap<>();
+        Optional.ofNullable(withCounts).ifPresent(value -> queryParams.put("with_counts", value));
+        return restClient.getGuildService().getGuild(id, queryParams);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -39,10 +39,17 @@ public class GuildService extends RestService {
                 .bodyToMono(GuildUpdateData.class);
     }
 
+    public Mono<GuildUpdateData> getGuild(long guildId, Map<String, Object> queryParams) {
+        return Routes.GUILD_GET.newRequest(guildId)
+            .query(queryParams)
+            .exchange(getRouter())
+            .bodyToMono(GuildUpdateData.class);
+    }
+
     public Mono<GuildUpdateData> getGuild(long guildId) {
         return Routes.GUILD_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(GuildUpdateData.class);
+            .exchange(getRouter())
+            .bodyToMono(GuildUpdateData.class);
     }
 
     public Mono<GuildUpdateData> modifyGuild(long guildId, GuildModifyRequest request, @Nullable String reason) {

--- a/rest/src/test/java/discord4j/rest/entity/RestGuildTest.java
+++ b/rest/src/test/java/discord4j/rest/entity/RestGuildTest.java
@@ -10,9 +10,7 @@ public class RestGuildTest {
         RestClient restClient = RestClient.create(System.getenv("token"));
         System.out.println(restClient.getRestResources().getJacksonResources().toString());
         RestGuild restGuild = restClient.getGuildById(Snowflake.of(System.getenv("guildId")));
-        Mono<GuildUpdateData> updateDataMono =  restGuild.getData(true); // Get data with possibility of requesting with query parameter "with_count"
+        Mono<GuildUpdateData> updateDataMono =  restGuild.getData();
         GuildUpdateData updateData = updateDataMono.block();
-        System.out.println(updateData.approximateMemberCount().get()); // Will just work if getData(withCounts == true)
-        System.out.println(updateData.approximatePresenceCount().get()); // Will just work if getData(withCounts == true)
     }
 }

--- a/rest/src/test/java/discord4j/rest/entity/RestGuildTest.java
+++ b/rest/src/test/java/discord4j/rest/entity/RestGuildTest.java
@@ -10,7 +10,7 @@ public class RestGuildTest {
         RestClient restClient = RestClient.create(System.getenv("token"));
         System.out.println(restClient.getRestResources().getJacksonResources().toString());
         RestGuild restGuild = restClient.getGuildById(Snowflake.of(System.getenv("guildId")));
-        Mono<GuildUpdateData> updateDataMono =  restGuild.getData();
+        Mono<GuildUpdateData> updateDataMono =  restGuild.getData(true);
         GuildUpdateData updateData = updateDataMono.block();
     }
 }

--- a/rest/src/test/java/discord4j/rest/entity/RestGuildTest.java
+++ b/rest/src/test/java/discord4j/rest/entity/RestGuildTest.java
@@ -1,0 +1,18 @@
+package discord4j.rest.entity;
+
+import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.GuildUpdateData;
+import discord4j.rest.RestClient;
+import reactor.core.publisher.Mono;
+
+public class RestGuildTest {
+    public static void main(String[] args) {
+        RestClient restClient = RestClient.create(System.getenv("token"));
+        System.out.println(restClient.getRestResources().getJacksonResources().toString());
+        RestGuild restGuild = restClient.getGuildById(Snowflake.of(System.getenv("guildId")));
+        Mono<GuildUpdateData> updateDataMono =  restGuild.getData(true); // Get data with possibility of requesting with query parameter "with_count"
+        GuildUpdateData updateData = updateDataMono.block();
+        System.out.println(updateData.approximateMemberCount().get()); // Will just work if getData(withCounts == true)
+        System.out.println(updateData.approximatePresenceCount().get()); // Will just work if getData(withCounts == true)
+    }
+}


### PR DESCRIPTION
**Description:** This PR adds the with_counts query parameter to the GET guild request. It should fix issue #795.

**Justification:** The query parameter is given in the official Discord Developer Documentation. https://discord.com/developers/docs/resources/guild#get-guild