### PR TITLE
Add convenience methods for MessageCreateSpec (and MessageEditSpec)

### DIFF
--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -33,7 +33,6 @@ import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -57,6 +57,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest>, Appendable {
     private MessageReferenceData messageReferenceData;
 
 
+    // Constants
     public final static byte MARKDOWN_ITALIC = 0;
     public final static byte MARKDOWN_BOLD = 1;
     public final static byte MARKDOWN_STRIKETHROUGH = 2;
@@ -86,7 +87,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest>, Appendable {
 
 
     /**
-     * Resets the specs contents.
+     * Resets this specs contents.
      *
      * @return This spec.
      */

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -182,7 +182,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest>, Appendable {
         contentBuilder
             .append("```");
         if (language != null) {
-            contentBuilder.append("\n").append(language);
+            contentBuilder.append(language);
         }
         contentBuilder
             .append("\n")

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -96,19 +96,77 @@ public class MessageCreateSpec implements Spec<MultipartRequest>, Appendable {
     }
 
     /**
+     * Resets the embed.
+     *
+     * @return This spec.
+     */
+    public MessageCreateSpec resetEmbed() {
+        embed = null;
+        return this;
+    }
+
+    /**
+     * Resets the files.
+     *
+     * @return This spec.
+     */
+    public MessageCreateSpec resetFiles() {
+        files = null;
+        return this;
+    }
+
+    /**
+     * Resets allowed mentions.
+     *
+     * @return This spec.
+     */
+    public MessageCreateSpec resetAllowedMentions() {
+        allowedMentionsData = null;
+        return this;
+    }
+
+    /**
+     * Resets this spec.
+     *
+     * @return This spec.
+     */
+    public MessageCreateSpec reset() {
+        return this
+            .resetAllowedMentions()
+            .resetContent()
+            .resetEmbed()
+            .resetFiles()
+            .resetMessageReference();
+    }
+
+    /**
+     * Resets the message reference.
+     *
+     * @return This spec.
+     */
+    public MessageCreateSpec resetMessageReference() {
+        messageReferenceData = null;
+        return this;
+    }
+
+    /**
      * Adds formatted text to this spec.
      * @param content The content to be formatted and added.
      * @param formats {@link #MARKDOWN_ITALIC}, {@link #MARKDOWN_BOLD}, {@link #MARKDOWN_UNDERLINE} or {@link #MARKDOWN_CODELINE}
      * @return This spec.
      */
     public MessageCreateSpec appendFormatted(String content, byte... formats) {
+        ArrayList<String> tags = new ArrayList<>();
         for (byte format : formats) {
             String tag = getMarkdownTag(format);
             if (tag == null) {
                 throw new IllegalArgumentException("Invalid markdown format!");
             }
-            contentBuilder.append(tag).append(content).append(tag);
+            tags.add(tag);
         }
+        tags.forEach(contentBuilder::append);
+        contentBuilder.append(content);
+        tags.forEach(contentBuilder::append);
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -289,7 +289,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest>, Appendable {
     }
 
     @Override
-    public Appendable append(char c) throws IOException {
+    public Appendable append(char c) {
         contentBuilder.append(c);
         return this;
     }


### PR DESCRIPTION
**Description:** 
Makes the MessageCreateSpec (and MessageEditSpec) like JDA's MessageBuilder.
Idea by: OSfrog#1392

**Justification:**
- Content uses a StringBuilder instead of a String
- New methods added for convenience.
- Spec now extends Appendable.