### PR TITLE
Move the max embed characters constant to the proper context

### DIFF
--- a/core/src/main/java/discord4j/core/object/Embed.java
+++ b/core/src/main/java/discord4j/core/object/Embed.java
@@ -46,9 +46,6 @@ public final class Embed implements DiscordObject {
     /** The maximum amount of fields that can be appended to an embed. */
     public static final int MAX_FIELDS = 25;
 
-    /** The maximum amount of total characters that can be present in an embed. */
-    public static final int MAX_CHARACTER_LENGTH = 6000;
-
     /** The gateway associated to this object. */
     private final GatewayDiscordClient gateway;
 

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -59,6 +59,12 @@ public final class Message implements Entity {
     public static final int MAX_CONTENT_LENGTH = 2000;
 
     /**
+     * The maximum amount of characters that can be present when combining all title, description, field.name,
+     * field.value, footer.text, and author.name fields of all embeds for this message.
+     * */
+    public static final int MAX_TOTAL_EMBEDS_CHARACTER_LENGTH = 6000;
+
+    /**
      * The gateway associated to this object.
      */
     private final GatewayDiscordClient gateway;

--- a/core/src/main/java/discord4j/core/object/entity/Webhook.java
+++ b/core/src/main/java/discord4j/core/object/entity/Webhook.java
@@ -260,7 +260,7 @@ public final class Webhook implements Entity {
      * Requests to edit this webhook. Requires the MANAGE_WEBHOOKS permission.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link WebhookEditSpec} to be operated on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Webhook}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
     public Mono<Webhook> edit(final Consumer<? super WebhookEditSpec> spec) {
@@ -279,7 +279,7 @@ public final class Webhook implements Entity {
      * Does not require the MANAGE_WEBHOOKS permission.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link WebhookEditSpec} to be operated on.
-     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Guild}. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the edited {@link Webhook}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
     public Mono<Webhook> editWithToken(final Consumer<? super WebhookEditWithTokenSpec> spec) {


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Moves the max embed characters constant into the `Message` class, since the limit applies across all embeds of a message, not just a single embed. The name has also been changed accordingly.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
Fixes #832 