### PR TITLE
Add role and hierarchy comparison to RestMember similar to in Member

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestMember.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMember.java
@@ -17,10 +17,18 @@
 
 package discord4j.rest.entity;
 
-import discord4j.discordjson.json.MemberData;
-import discord4j.rest.RestClient;
+import java.util.Collection;
+import java.util.List;
+
 import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.GuildUpdateData;
+import discord4j.discordjson.json.MemberData;
+import discord4j.discordjson.json.RoleData;
+import discord4j.rest.RestClient;
+import discord4j.rest.util.OrderUtil;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.math.MathFlux;
 
 /**
  * Represents a user (bot or normal) that is member of a specific guild.
@@ -53,16 +61,147 @@ public class RestMember {
         return new RestMember(restClient, guildId, id);
     }
 
+    /**
+     * Create a {@link RestGuild} with data from this Member. This method does not perform any API request.
+     *
+     * @return a {@code RestGuild} represented by the data from this Member
+     */
     public RestGuild guild() {
         return RestGuild.create(restClient, guildId);
     }
 
+    /**
+     * Create a {@link RestUser} with daa from this Member. This method does not perform any API request.
+     *
+     * @return a {@code RestUser} represented by the data from this Member
+     */
     public RestUser user() {
         return RestUser.create(restClient, id);
     }
 
+    /**
+     * Requests to retrieve the Member's {@link MemberData}
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the Member's {@link MemberData}. If an error
+     * is received, it is emitted through the Mono.
+     */
     public Mono<MemberData> getData() {
         return restClient.getGuildService()
-                .getGuildMember(guildId, id);
+            .getGuildMember(guildId, id);
+    }
+
+    /**
+     * Requests to retrieve the member's highest guild role.
+     * <p>
+     * The highest role is defined to be the role with the highest position, based on Discord's ordering. This is the
+     * role that appears at the <b>top</b> in Discord's UI.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the member's highest {@link RoleData role}. If
+     * an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<RoleData> getHighestRole() {
+        return getData()
+            .map(MemberData::roles)
+            .flatMap(roles -> MathFlux.max(Flux.fromIterable(roles)
+                    .map(id -> restClient.getRoleById(Snowflake.of(guildId), Snowflake.of(id)))
+                    .flatMap(RestRole::getData),
+                OrderUtil.ROLE_ORDER));
+    }
+
+    /**
+     * Requests to determine if this member is higher in the role hierarchy than the provided member or signal
+     * {@code IllegalArgumentException} if the provided member is in a different guild than this member.
+     *
+     * @param otherMember The member to compare in the role hierarchy with this member.
+     * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the
+     * role hierarchy than the provided member, {@code false} otherwise. If an error is received, it is emitted
+     * through the @{code Mono}.
+     */
+    public Mono<Boolean> isHigher(RestMember otherMember) {
+        if (guildId != otherMember.guildId) {
+            return Mono.error(new IllegalArgumentException("The provided member is in a different guild."));
+        }
+
+        // A member is not considered to be higher in the role hierarchy than themself
+        if (this.equals(otherMember)) {
+            return Mono.just(false);
+        }
+
+        return guild().getData().map(GuildUpdateData::ownerId)
+            .flatMap(ownerId -> {
+                // The owner of the guild is higher in the role hierarchy than everyone
+                if (ownerId.equals(String.valueOf(id))) {
+                    return Mono.just(true);
+                }
+
+                if (ownerId.equals(String.valueOf(otherMember.id))) {
+                    return Mono.just(false);
+                }
+
+                return otherMember.getData()
+                    .flatMapMany(data -> Flux.fromIterable(data.roles()))
+                    .map(Snowflake::of)
+                    .collectList()
+                    .flatMap(this::hasHigherRoles);
+            });
+    }
+
+    /**
+     * Requests to determine if this member is nigher in the role hierarchy than the member as represented by the
+     * supplied ID or signal {@code IllegalArgumentException} if the member as represented by the supplied ID is in a
+     * different guild than this member.
+     * This is determined by the positions of each of the members' highest roles.
+     *
+     * @param id The ID of the member to compare in the role hierarchy with this member.
+     * @return A {@link Mono} where, upon successful completion, emits {@code true} if this member is higher in the
+     * role hierarchy than the member as represented by the supplied ID, {@code false} otherwise. If an error is
+     * received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Boolean> isHigher(Snowflake id) {
+        return Mono.just(restClient.getMemberById(Snowflake.of(guildId), id)).flatMap(this::isHigher);
+    }
+
+    /**
+     * Requests to determine if the position of this member's highest role is greater than the highest position of
+     * the provided roles.
+     * <p>
+     * The behavior of this operation is undefined if a given role is from a different guild.
+     *
+     * @param otherRoles The collection of roles to compare in the role hierarchy with this member's roles.
+     * @return A {@link Mono} where, upon successful completion, emits {@code true} if the position of this member's
+     * highest role is greater than the highest position of the provided roles, {@code false} otherwise.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Boolean> hasHigherRoles(Collection<Snowflake> otherRoles) {
+        return guild().getRoles()
+            .transform(OrderUtil::orderRoles)
+            .collectList()
+            .flatMap(guildRoles -> { // Get the sorted list of guild roles
+                Mono<List<Snowflake>> thisRoleIds = this.getData()
+                    .map(MemberData::roles)
+                    .flatMapMany(Flux::fromIterable)
+                    .map(Snowflake::of)
+                    .collectList()
+                    .cache();
+
+                // Get the position of this member's highest role by finding the maximum element in guildRoles which
+                // the member has and then finding its index in the sorted list of guild roles (the role's actual
+                // position). The @everyone role is not included, so if we end up with empty, that is their only
+                // role which is always at position 0.
+                Mono<Integer> thisHighestRolePos = thisRoleIds.map(thisRoles ->
+                    guildRoles.stream()
+                        .filter(role -> thisRoles.contains(Snowflake.of(role.id())))
+                        .max(OrderUtil.ROLE_ORDER)
+                        .map(guildRoles::indexOf)
+                        .orElse(0));
+
+                int otherHighestPos = guildRoles.stream()
+                    .filter(role -> otherRoles.contains(Snowflake.of(role.id())))
+                    .max(OrderUtil.ROLE_ORDER)
+                    .map(guildRoles::indexOf)
+                    .orElse(0);
+
+                return thisHighestRolePos.map(thisPos -> thisPos > otherHighestPos);
+            });
     }
 }

--- a/rest/src/main/java/discord4j/rest/util/OrderUtil.java
+++ b/rest/src/main/java/discord4j/rest/util/OrderUtil.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.rest.util;
+
+import java.util.Comparator;
+
+import javax.management.relation.Role;
+
+import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.RoleData;
+import reactor.core.publisher.Flux;
+
+/**
+ * A utility class for the sorting of {@link  discord4j.rest.entity.RestRole}.
+ */
+
+public class OrderUtil {
+
+    /**
+     * The ordering of Discord {@link Role roles}.
+     * <p>
+     * In Discord, two orderable entities may have the same "raw position," the position as reported by the "position"
+     * field.
+     * This conflict is resolved by comparing the creation time of the entities, reflected in their
+     * {@link discord4j.common.util.Snowflake IDs}.
+     */
+    public static final Comparator<RoleData> ROLE_ORDER =
+        Comparator.comparing(RoleData::position).thenComparing(OrderUtil::idFromRoleData);
+
+    /**
+     * Sorts {@link RoleData roles} according to visual ordering in Discord. Roles at the bottom of the list are first.
+     * <p>
+     * sorts roles according to {@link #ROLE_ORDER}.
+     *
+     * @param roles The roles to sort.
+     * @return The sorted roles.
+     */
+    public static Flux<RoleData> orderRoles(Flux<RoleData> roles) {
+        return roles.sort(OrderUtil.ROLE_ORDER);
+    }
+
+    /**
+     * Simple utility method for getting a Snowflake ID from RoleData for comparison.
+     *
+     * @param data RoleData to get the ID from
+     * @return A Snowflake representation of the role's ID
+     */
+    private static Snowflake idFromRoleData(RoleData data) {
+        return Snowflake.of(data.id());
+    }
+}

--- a/rest/src/main/java/discord4j/rest/util/OrderUtil.java
+++ b/rest/src/main/java/discord4j/rest/util/OrderUtil.java
@@ -17,13 +17,12 @@
 
 package discord4j.rest.util;
 
-import java.util.Comparator;
-
-import javax.management.relation.Role;
-
 import discord4j.common.util.Snowflake;
 import discord4j.discordjson.json.RoleData;
 import reactor.core.publisher.Flux;
+
+import java.util.Comparator;
+import javax.management.relation.Role;
 
 /**
  * A utility class for the sorting of {@link  discord4j.rest.entity.RestRole}.
@@ -40,7 +39,7 @@ public class OrderUtil {
      * {@link discord4j.common.util.Snowflake IDs}.
      */
     public static final Comparator<RoleData> ROLE_ORDER =
-        Comparator.comparing(RoleData::position).thenComparing(OrderUtil::idFromRoleData);
+            Comparator.comparing(RoleData::position).thenComparing(OrderUtil::idFromRoleData);
 
     /**
      * Sorts {@link RoleData roles} according to visual ordering in Discord. Roles at the bottom of the list are first.


### PR DESCRIPTION
### **Description:**
Adds in role and hierarchy comparison to RestMember similar to the existing methods in Member to more easily check Member hierarchy through REST without needing the DiscordGatewayClient

Also added documentation to these new methods, as well as finished the documentation for RestMember as some existing methods were not yet documented.

### **Justification:**
This functionality existed in the Member class, however, it required the DiscordGatewayClient, even though these methods only need to use REST requests. This makes it significantly easier to compare users' roles without requiring a full gateway connection.

Came across the need for this while working on a section of my bot's backend that only has access to the D4J rest client (DiscordClient). Rather than re-invent the wheel to compare these roles, I added in the functionality to the RestMember than the Member class already had.