### PR TITLE
AuditLogEntry.getOption() does not return the right class types

### DIFF
--- a/core/src/main/java/discord4j/core/object/audit/OptionKey.java
+++ b/core/src/main/java/discord4j/core/object/audit/OptionKey.java
@@ -18,37 +18,45 @@ package discord4j.core.object.audit;
 
 import discord4j.common.util.Snowflake;
 
+import java.util.function.Function;
+
 public class OptionKey<T> {
 
     /** Number of days after which inactive members were kicked. */
-    public static final OptionKey<String> DELETE_MEMBER_DAYS = optionKey("delete_member_days");
+    public static final OptionKey<String> DELETE_MEMBER_DAYS = optionKey("delete_member_days", Function.identity());
     /** Number of members removed by the prune. */
-    public static final OptionKey<String> MEMBERS_REMOVED = optionKey("members_removed");
+    public static final OptionKey<String> MEMBERS_REMOVED = optionKey("members_removed", Function.identity());
     /** Channel in which the entities were targeted. */
-    public static final OptionKey<Snowflake> CHANNEL_ID = optionKey("channel_id");
+    public static final OptionKey<Snowflake> CHANNEL_ID = optionKey("channel_id", Snowflake::of);
     /** Id of the message that was targeted. */
-    public static final OptionKey<Snowflake> MESSAGE_ID = optionKey("message_id");
+    public static final OptionKey<Snowflake> MESSAGE_ID = optionKey("message_id", Snowflake::of);
     /** Number of entities that were targeted. */
-    public static final OptionKey<Integer> COUNT = optionKey("count");
+    public static final OptionKey<Integer> COUNT = optionKey("count", Integer::parseInt);
     /** Id of the overwritten entity. */
-    public static final OptionKey<Snowflake> ID = optionKey("id");
+    public static final OptionKey<Snowflake> ID = optionKey("id", Snowflake::of);
     /** Type of overwritten entity ("member" or "role"). */
-    public static final OptionKey<String> TYPE = optionKey("type");
+    public static final OptionKey<String> TYPE = optionKey("type", Function.identity());
     /** Name of the role if type is "role". */
-    public static final OptionKey<String> ROLE_NAME = optionKey("role_name");
+    public static final OptionKey<String> ROLE_NAME = optionKey("role_name", Function.identity());
 
-    private static <T> OptionKey<T> optionKey(String field) {
-        return new OptionKey<>(field);
+    private static <T> OptionKey<T> optionKey(String field, Function<String, T> parser) {
+        return new OptionKey<>(field, parser);
     }
 
     private final String field;
+    private final Function<String, T> parser;
 
-    private OptionKey(String field) {
+    private OptionKey(String field, Function<String, T> parser) {
         this.field = field;
+        this.parser = parser;
     }
 
     public String getField() {
         return field;
+    }
+
+    public T parseValue(String value) {
+        return parser.apply(value);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/util/AuditLogUtil.java
+++ b/core/src/main/java/discord4j/core/util/AuditLogUtil.java
@@ -38,28 +38,28 @@ public class AuditLogUtil {
     public static Map<String, ?> createOptionMap(AuditEntryInfoData options) {
         HashMap<String, Object> map = new HashMap<>();
         if (!options.deleteMemberDays().isAbsent()) {
-            map.put(OptionKey.DELETE_MEMBER_DAYS.getField(), options.deleteMemberDays().get());
+            map.put(OptionKey.DELETE_MEMBER_DAYS.getField(), OptionKey.DELETE_MEMBER_DAYS.parseValue(options.deleteMemberDays().get()));
         }
         if (!options.membersRemoved().isAbsent()) {
-            map.put(OptionKey.MEMBERS_REMOVED.getField(), options.membersRemoved().get());
+            map.put(OptionKey.MEMBERS_REMOVED.getField(), OptionKey.MEMBERS_REMOVED.parseValue(options.membersRemoved().get()));
         }
         if (!options.channelId().isAbsent()) {
-            map.put(OptionKey.CHANNEL_ID.getField(), Snowflake.of(options.channelId().get()));
+            map.put(OptionKey.CHANNEL_ID.getField(), OptionKey.CHANNEL_ID.parseValue(options.channelId().get()));
         }
         if (!options.messageId().isAbsent()) {
-            map.put(OptionKey.MESSAGE_ID.getField(), Snowflake.of(options.messageId().get()));
+            map.put(OptionKey.MESSAGE_ID.getField(), OptionKey.MESSAGE_ID.parseValue(options.messageId().get()));
         }
         if (!options.count().isAbsent()) {
-            map.put(OptionKey.COUNT.getField(), Integer.parseInt(options.count().get()));
+            map.put(OptionKey.COUNT.getField(), OptionKey.COUNT.parseValue(options.count().get()));
         }
         if (!options.id().isAbsent()) {
-            map.put(OptionKey.ID.getField(), Snowflake.of(options.id().get()));
+            map.put(OptionKey.ID.getField(), OptionKey.ID.parseValue(options.id().get()));
         }
         if (!options.type().isAbsent()) {
-            map.put(OptionKey.TYPE.getField(), options.type().get());
+            map.put(OptionKey.TYPE.getField(), OptionKey.TYPE.parseValue(options.type().get()));
         }
         if (!options.roleName().isAbsent()) {
-            map.put(OptionKey.ROLE_NAME.getField(), options.roleName().get());
+            map.put(OptionKey.ROLE_NAME.getField(), OptionKey.ROLE_NAME.parseValue(options.roleName().get()));
         }
         return map;
     }

--- a/core/src/main/java/discord4j/core/util/AuditLogUtil.java
+++ b/core/src/main/java/discord4j/core/util/AuditLogUtil.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.util;
 
+import discord4j.common.util.Snowflake;
 import discord4j.discordjson.json.AuditEntryInfoData;
 import discord4j.discordjson.json.AuditLogChangeData;
 import discord4j.core.object.audit.AuditLogChange;
@@ -43,16 +44,16 @@ public class AuditLogUtil {
             map.put(OptionKey.MEMBERS_REMOVED.getField(), options.membersRemoved().get());
         }
         if (!options.channelId().isAbsent()) {
-            map.put(OptionKey.CHANNEL_ID.getField(), options.channelId().get());
+            map.put(OptionKey.CHANNEL_ID.getField(), Snowflake.of(options.channelId().get()));
         }
         if (!options.messageId().isAbsent()) {
-            map.put(OptionKey.MESSAGE_ID.getField(), options.messageId().get());
+            map.put(OptionKey.MESSAGE_ID.getField(), Snowflake.of(options.messageId().get()));
         }
         if (!options.count().isAbsent()) {
-            map.put(OptionKey.COUNT.getField(), options.count().get());
+            map.put(OptionKey.COUNT.getField(), Integer.parseInt(options.count().get()));
         }
         if (!options.id().isAbsent()) {
-            map.put(OptionKey.ID.getField(), options.id().get());
+            map.put(OptionKey.ID.getField(), Snowflake.of(options.id().get()));
         }
         if (!options.type().isAbsent()) {
             map.put(OptionKey.TYPE.getField(), options.type().get());


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** 
The AuditLogUtil#createOptionMap now returns a Map<String, ?> with the values being of the correct class type.
Before the returned Map was basically always a Map<String, String>.

**Justification:**
The value class types of the Map now correspond to the specified types in the pre-defined OptionKey[s].
Therefore Issue #851 is fixed.