### PR TITLE
clarify UserUpdateEvent and PresenceUpdateEvent JavaDocs

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/PresenceUpdateEvent.java
@@ -31,7 +31,7 @@ import reactor.util.annotation.Nullable;
 import java.util.Optional;
 
 /**
- * Dispatched when a user's presence changes.
+ * Dispatched when a user's presence changes. This includes username, discriminator, and avatar changes.
  * <p>
  * The old presence may not be present if presences are not stored.
  * <p>

--- a/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/UserUpdateEvent.java
@@ -24,7 +24,7 @@ import reactor.util.annotation.Nullable;
 import java.util.Optional;
 
 /**
- * Dispatched when a user is updated.
+ * Dispatched when the bot's user is updated. {@link PresenceUpdateEvent} is dispatched for users the bot is receiving.
  * <p>
  * This event is dispatched by Discord.
  *


### PR DESCRIPTION
**Description:**
The JavaDocs for `UserUpdateEvent` and `PrescenceUpdateEvent` should be clarified for easier understanding of when/why they are dispatched.

**Justification:** 
`UserUpdateEvent` currently states that it is dispatched when "__a__ user's presence changes." while this is not the case. @quanticc mentioned in the Discord server that this should specify it is for the Bot user.

`PrescenceUpdateEvent` implies that it is only dispatched when when the user's presence changes, it is not immediately stated that this also includes username/discriminator/avatar changes.
