### PR TITLE
Conserve order for user mentions, role mentions and reactions on message

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -237,7 +237,7 @@ public final class Message implements Entity {
         return data.mentions().stream()
                 .map(UserData::id)
                 .map(Snowflake::of)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -270,7 +270,7 @@ public final class Message implements Entity {
     public Set<Snowflake> getRoleMentionIds() {
         return data.mentionRoles().stream()
                 .map(Snowflake::of)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -330,7 +330,9 @@ public final class Message implements Entity {
      */
     public Set<Reaction> getReactions() {
         return data.reactions().toOptional()
-                .map(reactions -> reactions.stream().map(data -> new Reaction(gateway, data)).collect(Collectors.toSet()))
+                .map(reactions -> reactions.stream()
+                        .map(data -> new Reaction(gateway, data))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
                 .orElse(Collections.emptySet());
 
     }

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -228,16 +228,18 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the IDs of the users specifically mentioned in this message.
+     * Gets the IDs of the users specifically mentioned in this message, without duplication and with the same
+     * order as in the message.
      *
-     * @return The IDs of the users specifically mentioned in this message.
+     * @return The IDs of the users specifically mentioned in this message, without duplication and with the same
+     * order as in the message.
      */
-    public Set<Snowflake> getUserMentionIds() {
+    public List<Snowflake> getUserMentionIds() {
         // TODO FIXME we throw away member data here
         return data.mentions().stream()
                 .map(UserData::id)
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     /**
@@ -263,14 +265,16 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the IDs of the roles specifically mentioned in this message.
+     * Gets the IDs of the roles specifically mentioned in this message, without duplication and with the same
+     * order as in the message.
      *
-     * @return The IDs of the roles specifically mentioned in this message.
+     * @return The IDs of the roles specifically mentioned in this message, without duplication and with the same
+     * order as in the message.
      */
-    public Set<Snowflake> getRoleMentionIds() {
+    public List<Snowflake> getRoleMentionIds() {
         return data.mentionRoles().stream()
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     /**
@@ -324,16 +328,16 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the reactions to this message.
+     * Gets the reactions to this message, the order is the same as in the message.
      *
-     * @return The reactions to this message.
+     * @return The reactions to this message, the order is the same as in the message.
      */
-    public Set<Reaction> getReactions() {
+    public List<Reaction> getReactions() {
         return data.reactions().toOptional()
                 .map(reactions -> reactions.stream()
                         .map(data -> new Reaction(gateway, data))
-                        .collect(Collectors.toCollection(LinkedHashSet::new)))
-                .orElse(new LinkedHashSet<>());
+                        .collect(Collectors.toCollection(LinkedList::new)))
+                .orElse(new LinkedList<>());
 
     }
 
@@ -576,15 +580,17 @@ public final class Message implements Entity {
 
     /**
      * Requests to publish (crosspost) this message if the {@code channel} is of type 'news'.
-     * Requires 'SEND_MESSAGES' permission if the current user sent the message, or additionally the 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
+     * Requires 'SEND_MESSAGES' permission if the current user sent the message, or additionally the
+     * 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds.
+     * If an error is
      * received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> publish() {
         return gateway.getRestClient().getChannelService()
-            .publishMessage(getChannelId().asLong(), getId().asLong())
-            .map(data -> new Message(gateway, data));
+                .publishMessage(getChannelId().asLong(), getId().asLong())
+                .map(data -> new Message(gateway, data));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -230,7 +230,7 @@ public final class Message implements Entity {
     /**
      * Gets the IDs of the users specifically mentioned in this message, with the same order as in the message.
      *
-     * @return The IDs of the users specifically mentioned in this message, the same order as in the message.
+     * @return The IDs of the users specifically mentioned in this message, with the same order as in the message.
      */
     public Set<Snowflake> getUserMentionIds() {
         // TODO FIXME we throw away member data here
@@ -580,8 +580,7 @@ public final class Message implements Entity {
      * 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
      *
      * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds.
-     * If an error is
-     * received, it is emitted through the {@code Mono}.
+     * If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> publish() {
         return gateway.getRestClient().getChannelService()

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -228,18 +228,16 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the IDs of the users specifically mentioned in this message, without duplication and with the same
-     * order as in the message.
+     * Gets the IDs of the users specifically mentioned in this message, with the same order as in the message.
      *
-     * @return The IDs of the users specifically mentioned in this message, without duplication and with the same
-     * order as in the message.
+     * @return The IDs of the users specifically mentioned in this message, the same order as in the message.
      */
-    public List<Snowflake> getUserMentionIds() {
+    public Set<Snowflake> getUserMentionIds() {
         // TODO FIXME we throw away member data here
         return data.mentions().stream()
                 .map(UserData::id)
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedList::new));
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -265,16 +263,14 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the IDs of the roles specifically mentioned in this message, without duplication and with the same
-     * order as in the message.
+     * Gets the IDs of the roles specifically mentioned in this message, with the same order as in the message.
      *
-     * @return The IDs of the roles specifically mentioned in this message, without duplication and with the same
-     * order as in the message.
+     * @return The IDs of the roles specifically mentioned in this message, with the same order as in the message.
      */
-    public List<Snowflake> getRoleMentionIds() {
+    public Set<Snowflake> getRoleMentionIds() {
         return data.mentionRoles().stream()
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedList::new));
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -332,12 +328,12 @@ public final class Message implements Entity {
      *
      * @return The reactions to this message, the order is the same as in the message.
      */
-    public List<Reaction> getReactions() {
+    public Set<Reaction> getReactions() {
         return data.reactions().toOptional()
                 .map(reactions -> reactions.stream()
                         .map(data -> new Reaction(gateway, data))
-                        .collect(Collectors.toCollection(LinkedList::new)))
-                .orElse(new LinkedList<>());
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
+                .orElse(new LinkedHashSet<>());
 
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -333,7 +333,7 @@ public final class Message implements Entity {
                 .map(reactions -> reactions.stream()
                         .map(data -> new Reaction(gateway, data))
                         .collect(Collectors.toCollection(LinkedHashSet::new)))
-                .orElse(Collections.emptySet());
+                .orElse(new LinkedHashSet<>());
 
     }
 


### PR DESCRIPTION
**Description:** Conserve order for user mentions, role mentions and reactions on message.

**Justification:** This is needed if you do some computations based on the order.
https://discord.com/channels/208023865127862272/451125724766535710/819270463238701057