### PR TITLE
Conserve order and use provided user data to get user mentions

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -61,7 +61,7 @@ public final class Message implements Entity {
     /**
      * The maximum amount of characters that can be present when combining all title, description, field.name,
      * field.value, footer.text, and author.name fields of all embeds for this message.
-     * */
+     */
     public static final int MAX_TOTAL_EMBEDS_CHARACTER_LENGTH = 6000;
 
     /**
@@ -235,38 +235,44 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the IDs of the users specifically mentioned in this message.
+     * Gets the IDs of the users specifically mentioned in this message, without duplication and with the same order
+     * as in the message.
      *
-     * @return The IDs of the users specifically mentioned in this message.
+     * @return The IDs of the users specifically mentioned in this message, without duplication and with the same order
+     * as in the message.
      */
-    public Set<Snowflake> getUserMentionIds() {
+    public List<Snowflake> getUserMentionIds() {
         return data.mentions().stream()
                 .map(UserData::id)
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     /**
-     * Gets the users specifically mentioned in this message.
+     * Gets the users specifically mentioned in this message, without duplication and with the same order
+     * as in the message.
      *
-     * @return The users specifically mentioned in this message.
+     * @return The users specifically mentioned in this message, without duplication and with the same order
+     * as in the message.
      */
-    public Set<User> getUserMentions() {
+    public List<User> getUserMentions() {
         // TODO FIXME we throw away member data here
         return data.mentions().stream()
                 .map(data -> new User(gateway, data))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     /**
-     * Gets the IDs of the roles specifically mentioned in this message.
+     * Gets the IDs of the roles specifically mentioned in this message, without duplication and with the same order
+     * as in the message.
      *
-     * @return The IDs of the roles specifically mentioned in this message.
+     * @return The IDs of the roles specifically mentioned in this message, without duplication and with the same order
+     * as in the message.
      */
-    public Set<Snowflake> getRoleMentionIds() {
+    public List<Snowflake> getRoleMentionIds() {
         return data.mentionRoles().stream()
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     /**
@@ -320,16 +326,16 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets the reactions to this message.
+     * Gets the reactions to this message, the order is the same as in the message.
      *
-     * @return The reactions to this message.
+     * @return The reactions to this message, the order is the same as in the message.
      */
-    public Set<Reaction> getReactions() {
+    public List<Reaction> getReactions() {
         return data.reactions().toOptional()
                 .map(reactions -> reactions.stream()
                         .map(data -> new Reaction(gateway, data))
-                        .collect(Collectors.toCollection(LinkedHashSet::new)))
-                .orElse(new LinkedHashSet<>());
+                        .collect(Collectors.toCollection(LinkedList::new)))
+                .orElse(new LinkedList<>());
 
     }
 
@@ -439,10 +445,10 @@ public final class Message implements Entity {
      */
     public List<Sticker> getStickers() {
         return data.stickers().toOptional()
-            .orElse(Collections.emptyList())
-            .stream()
-            .map(data -> new Sticker(gateway, data))
-            .collect(Collectors.toList());
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(data -> new Sticker(gateway, data))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -452,7 +458,7 @@ public final class Message implements Entity {
      */
     public Optional<Message> getReferencedMessage() {
         return Possible.flatOpt(data.referencedMessage())
-            .map(data -> new Message(gateway, data));
+                .map(data -> new Message(gateway, data));
     }
 
     /**
@@ -595,15 +601,17 @@ public final class Message implements Entity {
 
     /**
      * Requests to publish (crosspost) this message if the {@code channel} is of type 'news'.
-     * Requires 'SEND_MESSAGES' permission if the current user sent the message, or additionally the 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
+     * Requires 'SEND_MESSAGES' permission if the current user sent the message, or additionally the
+     * 'MANAGE_MESSAGES' permission, for all other messages, to be present for the current user.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds. If an error is
+     * @return A {@link Mono} where, upon successful completion, emits the published {@link Message} in the guilds.
+     * If an error is
      * received, it is emitted through the {@code Mono}.
      */
     public Mono<Message> publish() {
         return gateway.getRestClient().getChannelService()
-            .publishMessage(getChannelId().asLong(), getId().asLong())
-            .map(data -> new Message(gateway, data));
+                .publishMessage(getChannelId().asLong(), getId().asLong())
+                .map(data -> new Message(gateway, data));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -329,7 +329,7 @@ public final class Message implements Entity {
                 .map(reactions -> reactions.stream()
                         .map(data -> new Reaction(gateway, data))
                         .collect(Collectors.toCollection(LinkedHashSet::new)))
-                .orElse(Collections.emptySet());
+                .orElse(new LinkedHashSet<>());
 
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -245,7 +245,7 @@ public final class Message implements Entity {
         return data.mentions().stream()
                 .map(UserData::id)
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedList::new));
+                .collect(Collectors.toList());
     }
 
     /**
@@ -259,7 +259,7 @@ public final class Message implements Entity {
         // TODO FIXME we throw away member data here
         return data.mentions().stream()
                 .map(data -> new User(gateway, data))
-                .collect(Collectors.toCollection(LinkedList::new));
+                .collect(Collectors.toList());
     }
 
     /**
@@ -272,7 +272,7 @@ public final class Message implements Entity {
     public List<Snowflake> getRoleMentionIds() {
         return data.mentionRoles().stream()
                 .map(Snowflake::of)
-                .collect(Collectors.toCollection(LinkedList::new));
+                .collect(Collectors.toList());
     }
 
     /**
@@ -334,8 +334,8 @@ public final class Message implements Entity {
         return data.reactions().toOptional()
                 .map(reactions -> reactions.stream()
                         .map(data -> new Reaction(gateway, data))
-                        .collect(Collectors.toCollection(LinkedList::new)))
-                .orElse(new LinkedList<>());
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
 
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -240,33 +240,22 @@ public final class Message implements Entity {
      * @return The IDs of the users specifically mentioned in this message.
      */
     public Set<Snowflake> getUserMentionIds() {
-        // TODO FIXME we throw away member data here
         return data.mentions().stream()
                 .map(UserData::id)
                 .map(Snowflake::of)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
-     * Requests to retrieve the users specifically mentioned in this message.
+     * Gets the users specifically mentioned in this message.
      *
-     * @return A {@link Flux} that continually emits {@link User users} specifically mentioned in this message. If an
-     * error is received, it is emitted through the {@code Flux}.
+     * @return The users specifically mentioned in this message.
      */
-    public Flux<User> getUserMentions() {
-        return Flux.fromIterable(getUserMentionIds()).flatMap(gateway::getUserById);
-    }
-
-    /**
-     * Requests to retrieve the users specifically mentioned in this message, using the given retrieval strategy.
-     *
-     * @param retrievalStrategy the strategy to use to get the users
-     * @return A {@link Flux} that continually emits {@link User users} specifically mentioned in this message. If an
-     * error is received, it is emitted through the {@code Flux}.
-     */
-    public Flux<User> getUserMentions(EntityRetrievalStrategy retrievalStrategy) {
-        return Flux.fromIterable(getUserMentionIds())
-                .flatMap(id -> gateway.withRetrievalStrategy(retrievalStrategy).getUserById(id));
+    public Set<User> getUserMentions() {
+        // TODO FIXME we throw away member data here
+        return data.mentions().stream()
+                .map(data -> new User(gateway, data))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -277,7 +266,7 @@ public final class Message implements Entity {
     public Set<Snowflake> getRoleMentionIds() {
         return data.mentionRoles().stream()
                 .map(Snowflake::of)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -337,7 +326,9 @@ public final class Message implements Entity {
      */
     public Set<Reaction> getReactions() {
         return data.reactions().toOptional()
-                .map(reactions -> reactions.stream().map(data -> new Reaction(gateway, data)).collect(Collectors.toSet()))
+                .map(reactions -> reactions.stream()
+                        .map(data -> new Reaction(gateway, data))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
                 .orElse(Collections.emptySet());
 
     }


### PR DESCRIPTION
**Description:** 
 - `getUserMentionIds`, `getRoleMentionIds`, `getReactions` are now returning `List` instead of `Set` to simplify manipulation on the user side. For example: getting the first mentions of a message. The implementation used is a `LinkedList` to conserve the order returned by discord which is the same as the order of the message. The documentation has been updated accordingly.
 - `getUserMentions` is now returning a `List` instead of a `Flux` because Discord already returns `UserData` in the message payload.

**Justification:** 
- Cherrypick of https://github.com/Discord4J/Discord4J/pull/857
- `getUserMentions` does not need to return a Flux because user data are already provided in `MessageData`

**Tests:**
 - [Non DM user mentioned in DM](https://pastebin.com/CTZkAVLw)
 - [Non guild member mentioned in guild](https://pastebin.com/J7wgWY3E)
 - [Guild member mentioned in guild](https://pastebin.com/ZHc9aL4u)
 - [DM user mentioned in DM](https://pastebin.com/pRJwqADd)