### PR TITLE
Access low-level response from ClientException

### DIFF
--- a/rest/src/main/java/discord4j/rest/http/client/ClientException.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientException.java
@@ -70,8 +70,7 @@ import java.util.function.Predicate;
 public class ClientException extends RuntimeException {
 
     private final ClientRequest request;
-    private final HttpResponseStatus status;
-    private final HttpHeaders headers;
+    private final HttpClientResponse response;
     private final ErrorResponse errorResponse;
 
     /**
@@ -85,8 +84,7 @@ public class ClientException extends RuntimeException {
         super(request.getMethod().toString() + " " + request.getUrl() + " returned " + response.status().toString() +
                 (errorResponse != null ? " with response " + errorResponse.getFields() : ""));
         this.request = request;
-        this.status = response.status();
-        this.headers = response.responseHeaders();
+        this.response = response;
         this.errorResponse = errorResponse;
     }
 
@@ -100,13 +98,22 @@ public class ClientException extends RuntimeException {
     }
 
     /**
+     * Return the {@link HttpClientResponse} encapsulating a low-level Discord API response.
+     *
+     * @return the low-level response that caused this exception
+     */
+    public HttpClientResponse getResponse() {
+        return response;
+    }
+
+    /**
      * Return the {@link HttpResponseStatus} with information related to the HTTP error. The actual status code can be
      * obtained through {@link HttpResponseStatus#code()}.
      *
      * @return the HTTP error associated to this exception
      */
     public HttpResponseStatus getStatus() {
-        return status;
+        return getResponse().status();
     }
 
     /**
@@ -116,7 +123,7 @@ public class ClientException extends RuntimeException {
      * @return the HTTP response headers
      */
     public HttpHeaders getHeaders() {
-        return headers;
+        return getResponse().responseHeaders();
     }
 
     /**


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
This allows access to the low-level netty response in the `ClientException`
The ABI of `ClientException` already exposes netty-internal classes so I think adding another one is fine.

This allows subsequently custom implementations of a `Router` to get the reactive context from the response, which contains the request time set on it in the `DiscordWebClient`.

Example code:
```kotlin
/**
 * Collect metrics about the executed web requests against the Discord API
 */
class InstrumentedRouter(private val delegate: Router, routerOptions: RouterOptions) : Router {

	private val reactorResources: ReactorResources = routerOptions.reactorResources

	override fun exchange(request: DiscordWebRequest): DiscordWebResponse {
		val exchange = delegate.exchange(request)

		val instrumentedResponse = exchange.mono()
			.doOnNext { instrumentNext(it, request) }
			.doOnError { instrumentError(it, request) }

		return DiscordWebResponse(instrumentedResponse, reactorResources)
	}

	private fun instrumentNext(response: ClientResponse, request: DiscordWebRequest) {
		val status = response.httpResponse.status()
		val method = request.route.method
		val uriTemplate = request.route.uriTemplate
		val contextView = response.httpResponse.currentContextView()
		val requestStarted = Instant.ofEpochMilli(contextView.get(DiscordWebClient.KEY_REQUEST_TIMESTAMP))
		val responseTime = Duration.between(requestStarted, Instant.now()).toMillis()

		// Instrument
		logger().info("$method $uriTemplate returned $status in ${responseTime}ms")
	}

	private fun instrumentError(error: Throwable, request: DiscordWebRequest) {
		if (error is ClientException) {
			val status = error.status
			val method = request.route.method
			val uriTemplate = request.route.uriTemplate
			val errorReponseContent = error.errorResponse.map { it.fields }
			val message = errorReponseContent.map { it["message"] }.orElse(null)
			val code = errorReponseContent.map { it["code"] }.orElse(-1)

-------->		val contextView = error.response.currentContextView()
			val requestStarted = Instant.ofEpochMilli(contextView.get(DiscordWebClient.KEY_REQUEST_TIMESTAMP))
			val responseTime = Duration.between(requestStarted, Instant.now()).toMillis()

			// Instrument
			logger().info("$method $uriTemplate returned $status in ${responseTime}ms with error $code $message")
		}
	}
}
```

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
Implements the last necessary piece for #866