### PR TITLE
Allow populating EmbedCreateSpec from existing Embed

### DIFF
--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpec.java
@@ -166,6 +166,22 @@ public class EmbedCreateSpec implements Spec<EmbedData> {
         return this;
     }
 
+    /**
+     * Populate the spec from an existing embed.
+     * This will override all previously set values including fields!
+     *
+     * @param embedData The embed to populate this spec from.
+     * @return This spec.
+     */
+    public EmbedCreateSpec from(EmbedData embedData) {
+        requestBuilder.from(embedData);
+        this.fields.clear();
+        this.fields.addAll(embedData.fields()
+            .toOptional()
+            .orElseGet(ArrayList::new));
+        return this;
+    }
+
     @Override
     public EmbedData asRequest() {
         requestBuilder.fields(this.fields);


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->

Add a convenience method to allow populating an `EmbedCreateSpec` from an existing `EmbedData`.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->

It seems like a sensible convenience method, adding similar functionality in the consuming code is possible but cumbersome.