### PR TITLE
Add methods to EntityRetriever and RestClient to make getting self Member easier

### DIFF
--- a/core/src/main/java/discord4j/core/GatewayDiscordClient.java
+++ b/core/src/main/java/discord4j/core/GatewayDiscordClient.java
@@ -54,12 +54,14 @@ import discord4j.voice.LocalVoiceConnectionRegistry;
 import discord4j.voice.VoiceConnection;
 import discord4j.voice.VoiceConnectionFactory;
 import discord4j.voice.VoiceConnectionRegistry;
+import io.netty.handler.timeout.TimeoutException;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -690,6 +692,11 @@ public class GatewayDiscordClient implements EntityRetriever {
     @Override
     public Mono<User> getSelf() {
         return entityRetriever.getSelf();
+    }
+
+    @Override
+    public Mono<Member> getSelfMember(Snowflake guildId) {
+        return entityRetriever.getSelfMember(guildId);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/retriever/EntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/EntityRetriever.java
@@ -119,6 +119,14 @@ public interface EntityRetriever {
     Mono<User> getSelf();
 
     /**
+     * Requests to retrieve the bot user represented as a {@link Member member} of the guild with the supplied ID.
+     * @param guildId The ID of the guild.
+     * @return A {@link Mono} where, upon successful completion, emits the bot {@link Member member}. If an error is
+     *         received, it is emitted through the {@code Mono}.
+     */
+    Mono<Member> getSelfMember(Snowflake guildId);
+
+    /**
      * Requests to retrieve the guild's members.
      *
      * @param guildId   the ID of the guild.

--- a/core/src/main/java/discord4j/core/retriever/FallbackEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/FallbackEntityRetriever.java
@@ -84,6 +84,11 @@ public class FallbackEntityRetriever implements EntityRetriever {
     }
 
     @Override
+    public Mono<Member> getSelfMember(Snowflake guildId) {
+        return first.getSelfMember(guildId).switchIfEmpty(fallback.getSelfMember(guildId));
+    }
+
+    @Override
     public Flux<Member> getGuildMembers(Snowflake guildId) {
         return first.getGuildMembers(guildId).switchIfEmpty(fallback.getGuildMembers(guildId));
     }

--- a/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
@@ -113,6 +113,11 @@ public class RestEntityRetriever implements EntityRetriever {
     }
 
     @Override
+    public Mono<Member> getSelfMember(Snowflake guildId) {
+        return rest.getSelfMember(guildId).map(data -> new Member(gateway,data, guildId.asLong()));
+    }
+
+    @Override
     public Flux<Member> getGuildMembers(Snowflake guildId) {
         Function<Map<String, Object>, Flux<MemberData>> doRequest = params ->
                 rest.getGuildService().getGuildMembers(guildId.asLong(), params);

--- a/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
@@ -98,6 +98,11 @@ public class StoreEntityRetriever implements EntityRetriever {
     }
 
     @Override
+    public Mono<Member> getSelfMember(Snowflake guildId) {
+        return getMemberById(guildId, gateway.getSelfId());
+    }
+
+    @Override
     public Flux<Member> getGuildMembers(Snowflake guildId) {
         return Flux.from(store.execute(ReadActions.getExactMembersInGuild(guildId.asLong())))
                 .map(data -> new Member(gateway, data, guildId.asLong()))

--- a/rest/src/main/java/discord4j/rest/RestClient.java
+++ b/rest/src/main/java/discord4j/rest/RestClient.java
@@ -185,6 +185,16 @@ public class RestClient {
     }
 
     /**
+     * Requests to retrieve the bot member from the guild of the supplied ID
+     *
+     * @param guildId the ID of the guild.
+     * @return A {@link RestMember} of the bot user as represented by the supplied ID.
+     */
+    public RestMember selfRestMember(Snowflake guildId) {
+        return RestMember.create(this, guildId, restResources.getSelfId());
+    }
+
+    /**
      * Requests to retrieve the message represented by the supplied IDs.
      *
      * @param channelId The ID of the channel.
@@ -310,6 +320,17 @@ public class RestClient {
      */
     public Mono<UserData> getSelf() {
         return userService.getCurrentUser();
+    }
+
+    /**
+     * Requests to retrieve the bot user, represented as a member of the guild of the supplied ID
+     *
+     * @param guildId The ID of the guild
+     * @return a {@link Mono} where, upon successful completion, emits the bot {@link MemberData member}. If an error is
+     *         received, it is emitted through the {@code Mono}.
+     */
+    public Mono<MemberData> getSelfMember(Snowflake guildId) {
+        return guildService.getGuildMember(guildId.asLong(), restResources.getSelfId().asLong());
     }
 
     /**


### PR DESCRIPTION

**Description:**
This adds in methods to EntityRetriever and RestClient to directly get the bot as a Member of a guild, making chains slightly easier to read when requiring the bot as a Member of the guild, rather than just a User.

For EntityRetriever, one method `getSelfMember(guildId)` was added, along with the overrides for the 4 classes implementing.

For RestClient, two methods were added `selfRestMember(guildId)` to retrieve the RestMember of the bot, and `getSelfMember(guildId)` to retrieve the MemberData of the bot, depending on which is needed by the programmer.


This is targeting the latest master branch changes as of this commit.