### PR TITLE
Allow passing in member for calculating effective permissions

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildChannel.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.object.entity.channel;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.ExtendedPermissionOverwrite;
 import discord4j.core.object.PermissionOverwrite;
@@ -27,7 +28,6 @@ import discord4j.core.util.PermissionUtil;
 import discord4j.discordjson.json.ChannelData;
 import discord4j.discordjson.json.PermissionsEditRequest;
 import discord4j.rest.util.PermissionSet;
-import discord4j.common.util.Snowflake;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
@@ -97,10 +97,13 @@ class BaseGuildChannel extends BaseChannel implements GuildChannel {
 
     @Override
     public Mono<PermissionSet> getEffectivePermissions(Snowflake memberId) {
-        Mono<Member> getMember = getClient().getMemberById(getGuildId(), memberId);
-        Mono<PermissionSet> getBasePerms = getMember.flatMap(Member::getBasePermissions);
+        return getClient().getMemberById(getGuildId(), memberId)
+            .flatMap(this::getEffectivePermissions);
+    }
 
-        return Mono.zip(getMember, getBasePerms, (member, basePerms) -> {
+    @Override
+    public Mono<PermissionSet> getEffectivePermissions(Member member) {
+        return member.getBasePermissions().map(basePerms -> {
             PermissionOverwrite everyoneOverwrite = getOverwriteForRole(getGuildId()).orElse(null);
 
             List<PermissionOverwrite> roleOverwrites = member.getRoleIds().stream()

--- a/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/BaseGuildMessageChannel.java
@@ -106,6 +106,11 @@ class BaseGuildMessageChannel extends BaseChannel implements GuildMessageChannel
     }
 
     @Override
+    public Mono<PermissionSet> getEffectivePermissions(Member member) {
+        return guildChannel.getEffectivePermissions(member);
+    }
+
+    @Override
     public String getName() {
         return guildChannel.getName();
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/GuildChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/GuildChannel.java
@@ -16,13 +16,14 @@
  */
 package discord4j.core.object.entity.channel;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.object.ExtendedPermissionOverwrite;
 import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.Guild;
+import discord4j.core.object.entity.Member;
 import discord4j.core.retriever.EntityRetrievalStrategy;
-import discord4j.rest.util.PermissionSet;
-import discord4j.common.util.Snowflake;
 import discord4j.core.util.OrderUtil;
+import discord4j.rest.util.PermissionSet;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
@@ -86,6 +87,14 @@ public interface GuildChannel extends Channel {
      * @return The permissions for the given member.
      */
     Mono<PermissionSet> getEffectivePermissions(Snowflake memberId);
+
+    /**
+     * Gets the permissions for the given member, taking into account permission overwrites in this channel.
+     *
+     * @param member The member to get permissions for.
+     * @return The permissions for the given member.
+     */
+    Mono<PermissionSet> getEffectivePermissions(Member member);
 
     /**
      * Gets the name of the channel.


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->

Allow passing in a proper `Member` object into `GuildChannel#getEffectivePermissions` instead of just a `SnowflakeId`.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->

This allows optimizations of rest requests in certain situations.
When the GUILDS intent is used, but not the GUILD_MEMBERS intent, calling `getEffectivePermissions` with just the SnowflakeId of the user will result in a REST request to fetch the member (but no other request, as the owner, role data, etc can be served from the entity cache). In some situations it is unnecessary to fetch the member from the API. A `MessageCreateEvent` contains a `Member` object for the author, so if we wanted to check their permissions, we could avoid that API request by passing that member object to `getEffectivePermissions`, reducing the amount of necessary API requests to 0.

Another smaller use case would be checking self permissions. At a large scale, with the GUILD_MEMBERS intent not enabled, a bot author might want to have the option to handle caching their self member objects outside the entity cache, to heuristically reduce API calls for certain non-critical self permissions checks.