### PR TITLE
Improve AssertionError messages

### DIFF
--- a/common/src/main/java/discord4j/common/store/Store.java
+++ b/common/src/main/java/discord4j/common/store/Store.java
@@ -102,7 +102,7 @@ public final class Store {
                         case VOICE_STATES:
                             return dataAccessor.countVoiceStatesInGuild(action.getGuildId());
                         default:
-                            throw new AssertionError();
+                            throw new AssertionError("Unhandled entity " + action.getEntity());
                     }
                 })
                 .map(CountTotalAction.class, action -> {
@@ -126,7 +126,7 @@ public final class Store {
                         case VOICE_STATES:
                             return dataAccessor.countVoiceStates();
                         default:
-                            throw new AssertionError();
+                            throw new AssertionError("Unhandled entity " + action.getEntity());
                     }
                 })
                 .map(GetChannelsAction.class, action -> dataAccessor.getChannels())

--- a/common/src/main/java/discord4j/common/store/legacy/LegacyStoreLayout.java
+++ b/common/src/main/java/discord4j/common/store/legacy/LegacyStoreLayout.java
@@ -324,7 +324,7 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
             case GUILD_STORE: return saveChannel(dispatch);
             case DM:
             case GROUP_DM: return Mono.empty();
-            default: throw new AssertionError();
+            default: throw new AssertionError("Unhandled channel type " + dispatch.channel().type());
         }
     }
 
@@ -356,7 +356,7 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
             case GUILD_STORE: return deleteChannel(dispatch);
             case DM:
             case GROUP_DM: return Mono.empty();
-            default: throw new AssertionError();
+            default: throw new AssertionError("Unhandled channel type " + dispatch.channel().type());
         }
     }
 
@@ -388,7 +388,7 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
             case GUILD_STORE: return updateChannel(dispatch);
             case DM:
             case GROUP_DM: return Mono.empty();
-            default: throw new AssertionError();
+            default: throw new AssertionError("Unhandled channel type " + dispatch.channel().type());
         }
     }
 

--- a/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
@@ -50,7 +50,7 @@ class ChannelDispatchHandlers {
                 case GUILD_CATEGORY: return new CategoryCreateEvent(gateway, context.getShardInfo(), new Category(gateway, channel));
                 case GUILD_NEWS: return new NewsChannelCreateEvent(gateway, context.getShardInfo(), new NewsChannel(gateway, channel));
                 case GUILD_STORE: return new StoreChannelCreateEvent(gateway, context.getShardInfo(), new StoreChannel(gateway, channel));
-                default: throw new AssertionError();
+                default: throw new AssertionError("Unhandled channel type " + context.getDispatch().channel().type());
             }
         });
     }
@@ -70,7 +70,7 @@ class ChannelDispatchHandlers {
                 case GUILD_CATEGORY: return new CategoryDeleteEvent(gateway, context.getShardInfo(), new Category(gateway, channel));
                 case GUILD_NEWS: return new NewsChannelDeleteEvent(gateway, context.getShardInfo(), new NewsChannel(gateway, channel));
                 case GUILD_STORE: return new StoreChannelDeleteEvent(gateway, context.getShardInfo(), new StoreChannel(gateway, channel));
-                default: throw new AssertionError();
+                default: throw new AssertionError("Unhandled channel type " + context.getDispatch().channel().type());
             }
         });
     }
@@ -116,7 +116,7 @@ class ChannelDispatchHandlers {
                 case GUILD_STORE: return new StoreChannelUpdateEvent(gateway, context.getShardInfo(),
                         new StoreChannel(gateway, channel),
                         oldData.map(old -> new StoreChannel(gateway, old)).orElse(null));
-                default: throw new AssertionError();
+                default: throw new AssertionError("Unhandled channel type " + context.getDispatch().channel().type());
             }
         });
     }
@@ -125,7 +125,7 @@ class ChannelDispatchHandlers {
         switch (Channel.Type.of(channel.type())) {
             case GUILD_NEWS: return new NewsChannel(gateway, channel);
             case GUILD_TEXT: return new TextChannel(gateway, channel);
-            default: throw new AssertionError();
+            default: throw new AssertionError("Unhandled channel type " + channel.type());
         }
     }
 }

--- a/core/src/main/java/discord4j/core/object/presence/Presence.java
+++ b/core/src/main/java/discord4j/core/object/presence/Presence.java
@@ -193,7 +193,7 @@ public final class Presence {
             case DESKTOP: return data.clientStatus().desktop().toOptional().map(Status::of);
             case MOBILE: return data.clientStatus().mobile().toOptional().map(Status::of);
             case WEB: return data.clientStatus().web().toOptional().map(Status::of);
-            default: throw new AssertionError();
+            default: throw new AssertionError("Unhandled platform " + platform);
         }
     }
 


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->

Add more descriptive error messages to thrown `AssertionError`s throughout the codebase.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->

I got a bunch of these in my Sentry:

```
java.lang.AssertionError: null
    at discord4j.common.store.legacy.LegacyStoreLayout.onChannelUpdate(LegacyStoreLayout.java:391)
    at space.npstr.aki.discord.store.InstrumentedGatewayDataUpdater.lambda$onChannelUpdate$6(InstrumentedGatewayDataUpdater.java:111)
    at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:44)
    at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
    at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:120)
    at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
    at reactor.core.publisher.Operators$MonoInnerProducerBase.complete(Operators.java:2659)
    at reactor.core.publisher.MonoSingle$SingleSubscriber.onComplete(MonoSingle.java:180)
    at reactor.core.publisher.FluxIterable$IterableSubscription.fastPath(FluxIterable.java:360)
    at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:225)
    at reactor.core.publisher.MonoSingle$SingleSubscriber.doOnRequest(MonoSingle.java:103)
    at reactor.core.publisher.Operators$MonoInnerProducerBase.request(Operators.java:2726)
    at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2193)
    at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onSubscribe(FluxOnErrorResume.java:74)
    at reactor.core.publisher.MonoSingle$SingleSubscriber.onSubscribe(MonoSingle.java:115)
    at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:164)
    at reactor.core.publisher.FluxStream.subscribe(FluxStream.java:71)
    at reactor.core.publisher.Mono.subscribe(Mono.java:4099)
    at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:426)
    at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:387)
    at reactor.core.publisher.SerializedSubscriber.onNext(SerializedSubscriber.java:99)
    at reactor.core.publisher.FluxTakeUntilOther$TakeUntilMainSubscriber.onNext(FluxTakeUntilOther.java:216)
    at reactor.core.publisher.EmitterProcessor.drain(EmitterProcessor.java:491)
    at reactor.core.publisher.EmitterProcessor.tryEmitNext(EmitterProcessor.java:299)
    at reactor.core.publisher.SinkManySerialized.tryEmitNext(SinkManySerialized.java:97)
    at discord4j.common.sinks.ParkEmissionStrategy.emitNext(ParkEmissionStrategy.java:36)
    at discord4j.gateway.DefaultGatewayClient.handleDispatch(DefaultGatewayClient.java:393)
    at discord4j.gateway.DefaultGatewayClient.lambda$handlePayload$26(DefaultGatewayClient.java:382)
 ```