### PR TITLE
Add public accessors for IDs in rest* entities

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -64,6 +64,15 @@ public class RestChannel {
     }
 
     /**
+     * Returns the ID of this channel.
+     *
+     * @return The ID of this channel
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
      * Retrieve this channel's data upon subscription.
      *
      * @return a {@link Mono} where, upon successful completion, emits the {@link ChannelData} belonging to this

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -68,8 +68,8 @@ public class RestChannel {
      *
      * @return The ID of this channel
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/entity/RestEmoji.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestEmoji.java
@@ -57,6 +57,24 @@ public class RestEmoji {
     }
 
     /**
+     * Returns the ID of the guild this emoji belongs to.
+     *
+     * @return The ID of the the guild this emoji belongs to.
+     */
+    public long getGuildId() {
+        return guildId;
+    }
+
+    /**
+     * Returns the ID of this emoji.
+     *
+     * @return The ID of this emoji
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
      * Return this emoji's parent {@link RestGuild}. This method does not perform any API request.
      *
      * @return the parent {@code RestGuild} of this guild emoji.

--- a/rest/src/main/java/discord4j/rest/entity/RestEmoji.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestEmoji.java
@@ -61,8 +61,8 @@ public class RestEmoji {
      *
      * @return The ID of the the guild this emoji belongs to.
      */
-    public long getGuildId() {
-        return guildId;
+    public Snowflake getGuildId() {
+        return Snowflake.of(guildId);
     }
 
     /**
@@ -70,8 +70,8 @@ public class RestEmoji {
      *
      * @return The ID of this emoji
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -62,6 +62,15 @@ public class RestGuild {
     }
 
     /**
+     * Returns the ID of this guild.
+     *
+     * @return The ID of this guild
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
      * Retrieve this guild's data upon subscription.
      *
      * @param withCounts when true, will return approximate member and presence counts for the guild too.

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -66,8 +66,8 @@ public class RestGuild {
      *
      * @return The ID of this guild
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/entity/RestGuildTemplate.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuildTemplate.java
@@ -45,6 +45,15 @@ public class RestGuildTemplate {
     }
 
     /**
+     * Gets the code of this template.
+     *
+     * @return The code of this template
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
      * Retrieve this template's data upon subscription.
      *
      * @return a template object

--- a/rest/src/main/java/discord4j/rest/entity/RestInvite.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestInvite.java
@@ -46,6 +46,15 @@ public class RestInvite {
         return new RestInvite(restClient, code);
     }
 
+    /**
+     * Gets the invite code.
+     *
+     * @return The invite code
+     */
+    public String getCode() {
+        return code;
+    }
+
     public Mono<InviteData> getData() {
         return restClient.getInviteService().getInvite(code);
     }

--- a/rest/src/main/java/discord4j/rest/entity/RestMember.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMember.java
@@ -53,6 +53,24 @@ public class RestMember {
         return new RestMember(restClient, guildId, id);
     }
 
+    /**
+     * Returns the ID of the guild this member belongs to.
+     *
+     * @return The ID of the the guild this member belongs to.
+     */
+    public long getGuildId() {
+        return guildId;
+    }
+
+    /**
+     * Returns the ID of this member.
+     *
+     * @return The ID of this member
+     */
+    public long getId() {
+        return id;
+    }
+
     public RestGuild guild() {
         return RestGuild.create(restClient, guildId);
     }

--- a/rest/src/main/java/discord4j/rest/entity/RestMember.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMember.java
@@ -58,8 +58,8 @@ public class RestMember {
      *
      * @return The ID of the the guild this member belongs to.
      */
-    public long getGuildId() {
-        return guildId;
+    public Snowflake getGuildId() {
+        return Snowflake.of(guildId);
     }
 
     /**
@@ -67,8 +67,8 @@ public class RestMember {
      *
      * @return The ID of this member
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     public RestGuild guild() {

--- a/rest/src/main/java/discord4j/rest/entity/RestMessage.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMessage.java
@@ -60,8 +60,8 @@ public class RestMessage {
      *
      * @return The ID of the channel this message belongs to
      */
-    public long getChannelId() {
-        return channelId;
+    public Snowflake getChannelId() {
+        return Snowflake.of(channelId);
     }
 
     /**
@@ -69,8 +69,8 @@ public class RestMessage {
      *
      * @return The ID of this message
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     public RestChannel channel() {

--- a/rest/src/main/java/discord4j/rest/entity/RestMessage.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMessage.java
@@ -55,6 +55,24 @@ public class RestMessage {
         return new RestMessage(restClient, channelId, id);
     }
 
+    /**
+     * Returns the ID of the channel this message belongs to.
+     *
+     * @return The ID of the channel this message belongs to
+     */
+    public long getChannelId() {
+        return channelId;
+    }
+
+    /**
+     * Returns the ID of this message.
+     *
+     * @return The ID of this message
+     */
+    public long getId() {
+        return id;
+    }
+
     public RestChannel channel() {
         return RestChannel.create(restClient, channelId);
     }

--- a/rest/src/main/java/discord4j/rest/entity/RestRole.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestRole.java
@@ -61,8 +61,8 @@ public class RestRole {
      *
      * @return The ID of the the guild this role belongs to.
      */
-    public long getGuildId() {
-        return guildId;
+    public Snowflake getGuildId() {
+        return Snowflake.of(guildId);
     }
 
     /**
@@ -70,8 +70,8 @@ public class RestRole {
      *
      * @return The ID of this role
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/entity/RestRole.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestRole.java
@@ -57,6 +57,24 @@ public class RestRole {
     }
 
     /**
+     * Returns the ID of the guild this role belongs to.
+     *
+     * @return The ID of the the guild this role belongs to.
+     */
+    public long getGuildId() {
+        return guildId;
+    }
+
+    /**
+     * Returns the ID of this role.
+     *
+     * @return The ID of this role
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
      * Return the guild tied to this role as a REST operations handle.
      *
      * @return the parent guild for this role

--- a/rest/src/main/java/discord4j/rest/entity/RestUser.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestUser.java
@@ -54,6 +54,15 @@ public class RestUser {
     }
 
     /**
+     * Returns the ID of this user.
+     *
+     * @return The ID of this user
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
      * Retrieve this user's data upon subscription.
      *
      * @return a {@link Mono} where, upon successful completion, emits the {@link UserData} belonging to this user.

--- a/rest/src/main/java/discord4j/rest/entity/RestUser.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestUser.java
@@ -58,8 +58,8 @@ public class RestUser {
      *
      * @return The ID of this user
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/entity/RestWebhook.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestWebhook.java
@@ -54,6 +54,15 @@ public class RestWebhook {
     }
 
     /**
+     * Returns the ID of this webhook.
+     *
+     * @return The ID of this webhook
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
      * Retrieve this webhook's data upon subscription.
      *
      * @return a {@link Mono} where, upon successful completion, emits the {@link WebhookData} belonging to this entity.

--- a/rest/src/main/java/discord4j/rest/entity/RestWebhook.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestWebhook.java
@@ -58,8 +58,8 @@ public class RestWebhook {
      *
      * @return The ID of this webhook
      */
-    public long getId() {
-        return id;
+    public Snowflake getId() {
+        return Snowflake.of(id);
     }
 
     /**


### PR DESCRIPTION
Adds public read-only accessors to rest* entities for convenience, and to avoid the rest request for getting the data where the ID can be obtained previously. 