### PR TITLE
[3.2.x] Adds message types 16, 17 and 20

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -809,8 +809,14 @@ public final class Message implements Entity {
         /** A message created when the Guild is requalified for Discovery Feature **/
         GUILD_DISCOVERY_REQUALIFIED(15),
 
+        GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING(16),
+
+        GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING(17),
+
         /** A message created with a reply */
-        REPLY(19);
+        REPLY(19),
+
+        APPLICATION_COMMAND(20);
 
         /**
          * The underlying value as represented by Discord.

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -865,6 +865,10 @@ public final class Message implements Entity {
                 case 12: return CHANNEL_FOLLOW_ADD;
                 case 14: return GUILD_DISCOVERY_DISQUALIFIED;
                 case 15: return GUILD_DISCOVERY_REQUALIFIED;
+                case 16: return GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING;
+                case 17: return GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING;
+                case 19: return REPLY;
+                case 20: return APPLICATION_COMMAND;
                 default: return UNKNOWN;
             }
         }


### PR DESCRIPTION
**Description:** Adds message types 16, 17 and 20. 
I don't really know how to document this because I don't really know what it does...

**Justification:** https://github.com/discord/discord-api-docs/pull/1779