### PR TITLE
[3.1.x] Adds message types 16, 17 and 20

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -810,8 +810,14 @@ public final class Message implements Entity {
         /** A message created when the Guild is requalified for Discovery Feature **/
         GUILD_DISCOVERY_REQUALIFIED(15),
 
+        GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING(16),
+
+        GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING(17),
+
         /** A message created with a reply */
-        REPLY(0);
+        REPLY(0),
+
+        APPLICATION_COMMAND(0);
 
         /**
          * The underlying value as represented by Discord.
@@ -860,6 +866,8 @@ public final class Message implements Entity {
                 case 12: return CHANNEL_FOLLOW_ADD;
                 case 14: return GUILD_DISCOVERY_DISQUALIFIED;
                 case 15: return GUILD_DISCOVERY_REQUALIFIED;
+                case 16: return GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING;
+                case 17: return GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING;
                 default: return UNKNOWN;
             }
         }


### PR DESCRIPTION
**Description:** Adds message types 16, 17 and 20. 
```Type `19` and `20` are only in API v8. In v6, they are still type `0`.```

**Justification:** https://github.com/discord/discord-api-docs/pull/1779