### PR TITLE
Add USE_SLASH_COMMANDS permissions

### DIFF
--- a/rest/src/main/java/discord4j/rest/util/Permission.java
+++ b/rest/src/main/java/discord4j/rest/util/Permission.java
@@ -121,6 +121,9 @@ public enum Permission {
     /** Allows management and editing of emojis. */
     MANAGE_EMOJIS(0x40000000, true),
 
+    /** Allows members to use slash commands in text channels. */
+    USE_SLASH_COMMANDS(0x80000000, false),
+
     /**
      * Allows for requesting to speak in stage channels.
      */


### PR DESCRIPTION
**Description:** Adds user slash commands permissions.

**Justification:** https://github.com/discord/discord-api-docs/pull/2632/files