### PR TITLE
Remove USER_DMS_GET

### DIFF
--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -903,6 +903,7 @@ public abstract class Routes {
      * @see <a href="https://discord.com/developers/docs/resources/user#get-user-dms">
      * https://discord.com/developers/docs/resources/user#get-user-dms</a>
      */
+    @Deprecated
     public static final Route USER_DMS_GET = Route.get("/users/@me/channels");
 
     /**

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -898,14 +898,6 @@ public abstract class Routes {
     public static final Route GUILD_LEAVE = Route.delete("/users/@me/guilds/{guild.id}");
 
     /**
-     * Returns a list of DM channel objects.
-     *
-     * @see <a href="https://discord.com/developers/docs/resources/user#get-user-dms">
-     * https://discord.com/developers/docs/resources/user#get-user-dms</a>
-     */
-    public static final Route USER_DMS_GET = Route.get("/users/@me/channels");
-
-    /**
      * Create a new DM channel with a user. Returns a DM channel object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#create-dm">

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -898,6 +898,14 @@ public abstract class Routes {
     public static final Route GUILD_LEAVE = Route.delete("/users/@me/guilds/{guild.id}");
 
     /**
+     * Returns a list of DM channel objects.
+     *
+     * @see <a href="https://discord.com/developers/docs/resources/user#get-user-dms">
+     * https://discord.com/developers/docs/resources/user#get-user-dms</a>
+     */
+    public static final Route USER_DMS_GET = Route.get("/users/@me/channels");
+
+    /**
      * Create a new DM channel with a user. Returns a DM channel object.
      *
      * @see <a href="https://discord.com/developers/docs/resources/user#create-dm">

--- a/rest/src/main/java/discord4j/rest/service/UserService.java
+++ b/rest/src/main/java/discord4j/rest/service/UserService.java
@@ -64,13 +64,6 @@ public class UserService extends RestService {
                 .bodyToMono(Void.class);
     }
 
-    public Flux<ChannelData> getUserDMs() {
-        return Routes.USER_DMS_GET.newRequest()
-                .exchange(getRouter())
-                .bodyToMono(ChannelData[].class)
-                .flatMapMany(Flux::fromArray);
-    }
-
     public Mono<ChannelData> createDM(DMCreateRequest request) {
         return Routes.USER_DM_CREATE.newRequest()
                 .body(request)

--- a/rest/src/main/java/discord4j/rest/service/UserService.java
+++ b/rest/src/main/java/discord4j/rest/service/UserService.java
@@ -64,6 +64,7 @@ public class UserService extends RestService {
                 .bodyToMono(Void.class);
     }
 
+    @Deprecated
     public Flux<ChannelData> getUserDMs() {
         return Routes.USER_DMS_GET.newRequest()
                 .exchange(getRouter())

--- a/rest/src/main/java/discord4j/rest/service/UserService.java
+++ b/rest/src/main/java/discord4j/rest/service/UserService.java
@@ -64,6 +64,13 @@ public class UserService extends RestService {
                 .bodyToMono(Void.class);
     }
 
+    public Flux<ChannelData> getUserDMs() {
+        return Routes.USER_DMS_GET.newRequest()
+                .exchange(getRouter())
+                .bodyToMono(ChannelData[].class)
+                .flatMapMany(Flux::fromArray);
+    }
+
     public Mono<ChannelData> createDM(DMCreateRequest request) {
         return Routes.USER_DM_CREATE.newRequest()
                 .body(request)

--- a/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
@@ -79,11 +79,6 @@ public class UserServiceTest {
     }
 
     @Test
-    public void testGetUserDMs() {
-        userService.getUserDMs().then().block();
-    }
-
-    @Test
     public void testCreateDM() {
         DMCreateRequest req = DMCreateRequest.builder().recipientId(Snowflake.asString(user)).build();
         userService.createDM(req).block();

--- a/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
+++ b/rest/src/test/java/discord4j/rest/service/UserServiceTest.java
@@ -79,6 +79,11 @@ public class UserServiceTest {
     }
 
     @Test
+    public void testGetUserDMs() {
+        userService.getUserDMs().then().block();
+    }
+
+    @Test
     public void testCreateDM() {
         DMCreateRequest req = DMCreateRequest.builder().recipientId(Snowflake.asString(user)).build();
         userService.createDM(req).block();


### PR DESCRIPTION
**Description:** Removes `USER_DMS_GET` route. This endpoint returns an empty list and is now useless.

**Justification:** https://github.com/discord/discord-api-docs/pull/2770/files