### PR TITLE
Apply RestResource#getAllowedMentions to message edit requests

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -493,6 +493,9 @@ public final class Message implements Entity {
         return Mono.defer(
                 () -> {
                     MessageEditSpec mutatedSpec = new MessageEditSpec();
+                    getClient().getRestClient().getRestResources()
+                        .getAllowedMentions()
+                        .ifPresent(mutatedSpec::setAllowedMentions);
                     spec.accept(mutatedSpec);
                     return gateway.getRestClient().getChannelService()
                             .editMessage(getChannelId().asLong(), getId().asLong(), mutatedSpec.asRequest());


### PR DESCRIPTION
**Description:** Apply `RestResource#getAllowedMentions` to message edit requests.

**Justification:** 
Discord API is a wonderful place where everything makes sense. 
https://github.com/discord/discord-api-docs/commit/1f6b82cf564aa34738d6e9f996275ee5c725bbb2