### PR TITLE
Add low(er) level ClientPresence and ClientActivity factory methods

### DIFF
--- a/core/src/main/java/discord4j/core/object/presence/ClientActivity.java
+++ b/core/src/main/java/discord4j/core/object/presence/ClientActivity.java
@@ -17,6 +17,9 @@
 package discord4j.core.object.presence;
 
 import discord4j.discordjson.json.ActivityUpdateRequest;
+import reactor.util.annotation.Nullable;
+
+import java.util.Optional;
 
 /**
  * Activity data that can be sent to Discord.
@@ -28,38 +31,30 @@ import discord4j.discordjson.json.ActivityUpdateRequest;
 public class ClientActivity {
 
     public static ClientActivity playing(String name) {
-        return new ClientActivity(ActivityUpdateRequest.builder()
-                .name(name)
-                .type(Activity.Type.PLAYING.getValue())
-                .build());
+        return of(Activity.Type.PLAYING, name, null);
     }
 
     public static ClientActivity streaming(String name, String url) {
-        return new ClientActivity(ActivityUpdateRequest.builder()
-                .name(name)
-                .type(Activity.Type.STREAMING.getValue())
-                .url(url)
-                .build());
+        return of(Activity.Type.STREAMING, name, url);
     }
 
     public static ClientActivity listening(String name) {
-        return new ClientActivity(ActivityUpdateRequest.builder()
-                .name(name)
-                .type(Activity.Type.LISTENING.getValue())
-                .build());
+        return of(Activity.Type.LISTENING, name, null);
     }
 
     public static ClientActivity watching(String name) {
-        return new ClientActivity(ActivityUpdateRequest.builder()
-                .name(name)
-                .type(Activity.Type.WATCHING.getValue())
-                .build());
+        return of(Activity.Type.WATCHING, name, null);
     }
 
     public static ClientActivity competing(String name) {
+        return of(Activity.Type.COMPETING, name, null);
+    }
+
+    public static ClientActivity of(Activity.Type type, String name, @Nullable String url) {
         return new ClientActivity(ActivityUpdateRequest.builder()
+                .type(type.getValue())
                 .name(name)
-                .type(Activity.Type.COMPETING.getValue())
+                .url(Optional.ofNullable(url))
                 .build());
     }
 

--- a/core/src/main/java/discord4j/core/object/presence/ClientPresence.java
+++ b/core/src/main/java/discord4j/core/object/presence/ClientPresence.java
@@ -16,10 +16,13 @@
  */
 package discord4j.core.object.presence;
 
+import discord4j.discordjson.json.ActivityUpdateRequest;
 import discord4j.discordjson.json.gateway.StatusUpdate;
+import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -36,65 +39,43 @@ import java.util.function.Function;
 public class ClientPresence {
 
     public static ClientPresence online() {
-        return new ClientPresence(StatusUpdate.builder()
-                .status(Status.ONLINE.getValue())
-                .activities(Optional.empty())
-                .afk(false)
-                .since(Optional.empty())
-                .build());
+        return of(Status.ONLINE, null);
     }
 
     public static ClientPresence online(ClientActivity activity) {
-        return new ClientPresence(StatusUpdate.builder()
-                .status(Status.ONLINE.getValue())
-                .activities(Collections.singletonList(activity.getActivityUpdateRequest()))
-                .afk(false)
-                .since(Optional.empty())
-                .build());
+        return of(Status.ONLINE, activity);
     }
 
     public static ClientPresence doNotDisturb() {
-        return new ClientPresence(StatusUpdate.builder()
-                .status(Status.DO_NOT_DISTURB.getValue())
-                .activities(Optional.empty())
-                .afk(false)
-                .since(Optional.empty())
-                .build());
+        return of(Status.DO_NOT_DISTURB, null);
     }
 
     public static ClientPresence doNotDisturb(ClientActivity activity) {
-        return new ClientPresence(StatusUpdate.builder()
-                .status(Status.DO_NOT_DISTURB.getValue())
-                .activities(Collections.singletonList(activity.getActivityUpdateRequest()))
-                .afk(false)
-                .since(Optional.empty())
-                .build());
+        return of(Status.DO_NOT_DISTURB, activity);
     }
 
     public static ClientPresence idle() {
-        return new ClientPresence(StatusUpdate.builder()
-                .status(Status.IDLE.getValue())
-                .activities(Optional.empty())
-                .afk(true)
-                .since(Instant.now().toEpochMilli())
-                .build());
+        return of(Status.IDLE, null);
     }
 
     public static ClientPresence idle(ClientActivity activity) {
-        return new ClientPresence(StatusUpdate.builder()
-                .status(Status.IDLE.getValue())
-                .activities(Collections.singletonList(activity.getActivityUpdateRequest()))
-                .afk(true)
-                .since(Instant.now().toEpochMilli())
-                .build());
+        return of(Status.INVISIBLE, activity);
     }
 
     public static ClientPresence invisible() {
+        return of(Status.INVISIBLE, null);
+    }
+
+    public static ClientPresence of(Status status, @Nullable ClientActivity activity) {
+        Optional<List<ActivityUpdateRequest>> activities = Optional.ofNullable(activity)
+                .map(ClientActivity::getActivityUpdateRequest)
+                .map(Collections::singletonList);
+
         return new ClientPresence(StatusUpdate.builder()
-                .status(Status.INVISIBLE.getValue())
-                .activities(Optional.empty())
-                .afk(false)
-                .since(Optional.empty())
+                .status(status.getValue())
+                .activities(activities)
+                .afk(false) // doesn't do anything
+                .since(0) // doesn't do anything
                 .build());
     }
 


### PR DESCRIPTION
**Description:**
Adds
- `ClientPresence.of(Status status, @Nullable ClientActivity activity)`
- `ClientActivity.of(Activity.Type type, String name, @Nullable String url)`

I also changed the common constructor for `ClientPresence` to always have `afk=false` and `since=0`. I tested every presence, and this works, but we might want some more confirmation that this is intended.

**Justification:**
This allows for cleaner automatic construction (as opposed to hardcoded values which the other static factories serve perfectly).