### PR TITLE
Use UserData when possible

### DIFF
--- a/core/src/main/java/discord4j/core/object/Invite.java
+++ b/core/src/main/java/discord4j/core/object/Invite.java
@@ -148,26 +148,13 @@ public class Invite implements DiscordObject {
     }
 
     /**
-     * Requests to retrieve the user who created the invite.
+     * Gets the user who created the invite, if present.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User user} who created the invite. If
-     * an error is received, it is emitted through the {@code Mono}.
+     * @return The user who created the invite, if present.
      */
-    public final Mono<User> getInviter() {
-        return getInviterId().map(gateway::getUserById).orElse(Mono.empty());
-    }
-
-    /**
-     * Requests to retrieve the user who created the invite, using the given retrieval strategy.
-     *
-     * @param retrievalStrategy the strategy to use to get the inviter
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User user} who created the invite. If
-     * an error is received, it is emitted through the {@code Mono}.
-     */
-    public final Mono<User> getInviter(EntityRetrievalStrategy retrievalStrategy) {
-        return getInviterId()
-                .map(id -> gateway.withRetrievalStrategy(retrievalStrategy).getUserById(id))
-                .orElse(Mono.empty());
+    public final Optional<User> getInviter() {
+        return data.inviter().toOptional()
+                .map(data -> new User(gateway, data));
     }
 
     /**
@@ -182,26 +169,13 @@ public class Invite implements DiscordObject {
     }
 
     /**
-     * Requests to retrieve the target user this invite is associated to.
+     * Gets the target user this invite is associated to, if present.
      *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User target user} this invite is
-     * associated to. If an error is received, it is emitted through the {@code Mono}.
+     * @return The target user this invite is associated to, if present.
      */
-    public final Mono<User> getTargetUser() {
-        return getTargetUserId().map(gateway::getUserById).orElse(Mono.empty());
-    }
-
-    /**
-     * Requests to retrieve the target user this invite is associated to, using the given retrieval strategy.
-     *
-     * @param retrievalStrategy the strategy to use to get the target user
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User target user} this invite is
-     * associated to. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public final Mono<User> getTargetUser(EntityRetrievalStrategy retrievalStrategy) {
-        return getTargetUserId()
-                .map(id -> gateway.withRetrievalStrategy(retrievalStrategy).getUserById(id))
-                .orElse(Mono.empty());
+    public final Optional<User> getTargetUser() {
+        return data.targetUser().toOptional()
+                .map(data -> new User(gateway, data));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/PrivateChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/PrivateChannel.java
@@ -25,6 +25,7 @@ import discord4j.common.util.Snowflake;
 import reactor.core.publisher.Flux;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -56,25 +57,16 @@ public final class PrivateChannel extends BaseMessageChannel {
     }
 
     /**
-     * Requests to retrieve the recipients for this private channel.
+     * Gets the recipients for this private channel.
      *
-     * @return A {@link Flux} that continually emits the {@link User recipients} for this private channel. If an error
-     * is received, it is emitted through the {@code Flux}.
+     * @return The recipients for this private channel.
      */
-    public Flux<User> getRecipients() {
-        return Flux.fromIterable(getRecipientIds()).flatMap(getClient()::getUserById);
-    }
-
-    /**
-     * Requests to retrieve the recipients for this private channel, using the given retrieval strategy.
-     *
-     * @param retrievalStrategy the strategy to use to get the recipients
-     * @return A {@link Flux} that continually emits the {@link User recipients} for this private channel. If an error
-     * is received, it is emitted through the {@code Flux}.
-     */
-    public Flux<User> getRecipients(EntityRetrievalStrategy retrievalStrategy) {
-        return Flux.fromIterable(getRecipientIds())
-                .flatMap(id -> getClient().withRetrievalStrategy(retrievalStrategy).getUserById(id));
+    public Set<User> getRecipients() {
+        return getData().recipients().toOptional()
+                .map(recipients -> recipients.stream()
+                        .map(data -> new User(getClient(), data))
+                        .collect(Collectors.toSet()))
+                .orElse(Collections.emptySet());
     }
 
     @Override


### PR DESCRIPTION
**Description:** 
- `PrivateChannel#getRecipients` returns `Set<User>` instead of `Flux<User>`
- `Invite#getInviter` returns `Optional<User>` instead of `Mono<User>`
- `Inviter#getTargetUser` returns `Optional<User>` instead of `Mono<User>`

**Justification:** There were already commits adressing the fact that UserData or MemberData are thrown away to just use the ID and request the full object to the gateway. This pull request aims to fix the last methods (that I could find) that do this. This is a breaking change without deprecation but I think it will be easier for users to manipulate Set and Optional rather than Flux and Mono.