### PR TITLE
Fix audit log option and change parsing

### DIFF
--- a/core/src/main/java/discord4j/core/object/audit/AuditLogChangeParser.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogChangeParser.java
@@ -1,0 +1,57 @@
+package discord4j.core.object.audit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.ExtendedPermissionOverwrite;
+import discord4j.discordjson.json.OverwriteData;
+import discord4j.rest.util.PermissionSet;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+public interface AuditLogChangeParser<T> extends BiFunction<AuditLogEntry, JsonNode, T> {
+
+    AuditLogChangeParser<String> STRING_PARSER = (entry, node) -> node.asText();
+
+    AuditLogChangeParser<Integer> INTEGER_PARSER = (entry, node) -> node.asInt();
+
+    AuditLogChangeParser<Boolean> BOOLEAN_PARSER = (entry, node) -> node.asBoolean();
+
+    AuditLogChangeParser<Snowflake> SNOWFLAKE_PARSER = (entry, node) -> Snowflake.of(node.asText());
+
+    AuditLogChangeParser<PermissionSet> PERMISSION_SET_PARSER = (entry, node) -> PermissionSet.of(node.asText());
+
+    AuditLogChangeParser<Set<AuditLogRole>> AUDIT_LOG_ROLES_PARSER = (entry, node) -> {
+        Set<AuditLogRole> roles = new HashSet<>();
+        for (JsonNode obj : node) {
+            roles.add(new AuditLogRole(Snowflake.asLong(obj.get("id").asText()), obj.get("name").asText()));
+        }
+        return roles;
+    };
+
+    AuditLogChangeParser<Set<ExtendedPermissionOverwrite>> OVERWRITES_PARSER = (entry, node) -> {
+        try {
+            GatewayDiscordClient client = entry.getClient();
+            ObjectMapper mapper = client.getCoreResources().getJacksonResources().getObjectMapper();
+            List<OverwriteData> overwrites = mapper.readerForListOf(OverwriteData.class).readValue(node);
+
+            long guildId = entry.getParent().getGuildId().asLong();
+            long channelId = entry.getTargetId()
+                    .orElseThrow(() -> new NoSuchElementException("Audit log entry has no target ID"))
+                    .asLong();
+
+            return overwrites.stream()
+                    .map(overwriteData -> new ExtendedPermissionOverwrite(client, overwriteData, guildId, channelId))
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not parse audit log overwrite data");
+        }
+    };
+}

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogChangeParser.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogChangeParser.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package discord4j.core.object.audit;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogEntry.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogEntry.java
@@ -23,8 +23,24 @@ import discord4j.core.object.entity.User;
 import discord4j.core.util.AuditLogUtil;
 import discord4j.discordjson.json.AuditLogEntryData;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
+/**
+ * A single action recorded by an {@link AuditLogPart}.
+ * <p>
+ * Use {@link #getActionType()} to determine what kind of action occurred, and then {@link #getChange(ChangeKey)} to
+ * get information about what changed. For example,
+ * <pre>
+ * {@code
+ * if (entry.getActionType() == CHANNEL_UPDATE) {
+ *     entry.getChange(ChangeKey.NAME)
+ *         .flatMap(AuditLogChange::getCurrentValue)
+ *         .ifPresent(newName -> System.out.println("The channel's new name is " + newName));
+ * }
+ * }
+ * </pre>
+ */
 public class AuditLogEntry implements Entity {
 
     /** The maximum amount of characters that can be in an audit log reason. */
@@ -33,11 +49,14 @@ public class AuditLogEntry implements Entity {
     /** The gateway associated to this object. */
     private final GatewayDiscordClient gateway;
 
+    /** The audit log part this entry belongs to. */
     private final AuditLogPart auditLogPart;
 
+    /** The raw data as represented by Discord. */
     private final AuditLogEntryData data;
 
-    public AuditLogEntry(final GatewayDiscordClient gateway, final AuditLogPart auditLogPart, final AuditLogEntryData data) {
+    AuditLogEntry(final GatewayDiscordClient gateway, final AuditLogPart auditLogPart,
+                  final AuditLogEntryData data) {
         this.gateway = gateway;
         this.auditLogPart = auditLogPart;
         this.data = data;
@@ -59,18 +78,17 @@ public class AuditLogEntry implements Entity {
      */
     public Optional<Snowflake> getTargetId() {
         return data.targetId()
-            .filter(it -> !it.equals("0"))
-            .map(Snowflake::of);
+                .filter(it -> !it.equals("0"))
+                .map(Snowflake::of);
     }
 
     /**
-     * Gets the user who made the changes.
+     * Gets the ID of the user who made the changes, if present.
      *
-     * @return The user who made the changes.
-     * @deprecated Use {@link AuditLogEntry#getUserId}
+     * @return The ID of the user who made the changes, if present.
      */
-    public Snowflake getResponsibleUserId() {
-        return getUserId().orElse(null);
+    public Optional<Snowflake> getResponsibleUserId() {
+        return data.userId().map(Snowflake::of);
     }
 
     /**
@@ -78,13 +96,10 @@ public class AuditLogEntry implements Entity {
      *
      * @return The user who made the changes, if present.
      */
-    public Optional<Snowflake> getUserId() {
-        return data.userId().map(Snowflake::of);
-    }
-
-    public User getResponsibleUser() {
-        return auditLogPart.getUserById(getResponsibleUserId())
-                .orElseThrow(() -> new AssertionError("Audit log users does not contain responsible user ID."));
+    public Optional<User> getResponsibleUser() {
+        return getResponsibleUserId()
+                .map(id -> auditLogPart.getUserById(id)
+                        .orElseThrow(() -> new NoSuchElementException("Audit log users does not contain responsible user ID.")));
     }
 
     /**
@@ -106,11 +121,11 @@ public class AuditLogEntry implements Entity {
     }
 
     /**
-     * Gets the changes made to the target id, if present.
+     * Gets a change that was recorded by this entry. The possible changes correspond to each {@link ChangeKey}.
      *
      * @param changeKey The audit log change key.
      * @param <T> The type of the audit log change key.
-     * @return The changes made to the target id, if present.
+     * @return The change made to the target, if present.
      */
     public <T> Optional<AuditLogChange<T>> getChange(ChangeKey<T> changeKey) {
         return data.changes().toOptional()
@@ -129,12 +144,25 @@ public class AuditLogEntry implements Entity {
                 });
     }
 
+    /**
+     * Gets one of the optional extra pieces of information recorded by an audit log entry. The possible options
+     * correspond to each {@link OptionKey}.
+     *
+     * @param optionKey The option key.
+     * @param <T> The type of the option key.
+     * @return The option, if present.
+     */
     public <T> Optional<T> getOption(OptionKey<T> optionKey) {
         return data.options().toOptional()
                 .map(AuditLogUtil::createOptionMap)
                 .map(map -> optionKey.parseValue(map.get(optionKey.getField())));
     }
 
+    /**
+     * Gets the {@link AuditLogPart audit log part} that this entry belongs to.
+     *
+     * @return The audit log part that this entry belongs to.
+     */
     public AuditLogPart getParent() {
         return auditLogPart;
     }

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogPart.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogPart.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package discord4j.core.object.audit;
 
 import discord4j.common.util.Snowflake;

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogPart.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogPart.java
@@ -1,0 +1,94 @@
+package discord4j.core.object.audit;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.User;
+import discord4j.core.object.entity.Webhook;
+import discord4j.discordjson.json.AuditLogData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AuditLogPart {
+
+    private final long guildId;
+
+    private final List<Webhook> webhooks;
+
+    private final List<User> users;
+
+    private final List<AuditLogEntry> entries;
+
+    public AuditLogPart(long guildId, GatewayDiscordClient gateway, AuditLogData data) {
+        this.guildId = guildId;
+
+        this.webhooks = data.webhooks().stream()
+                .map(webhookData -> new Webhook(gateway, webhookData))
+                .collect(Collectors.toList());
+
+        this.users = data.users().stream()
+                .map(userData -> new User(gateway, userData))
+                .collect(Collectors.toList());
+
+        this.entries = data.auditLogEntries()
+                .stream().map(auditLogEntryData -> new AuditLogEntry(gateway, this, auditLogEntryData))
+                .collect(Collectors.toList());
+    }
+
+    private AuditLogPart(long guildId, List<Webhook> webhooks, List<User> users, List<AuditLogEntry> entries) {
+        this.guildId = guildId;
+        this.webhooks = webhooks;
+        this.users = users;
+        this.entries = entries;
+    }
+
+    public List<Webhook> getWebhooks() {
+        return webhooks;
+    }
+
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public List<AuditLogEntry> getEntries() {
+        return entries;
+    }
+
+    public Optional<Webhook> getWebhookById(Snowflake webhookId) {
+        return webhooks.stream()
+                .filter(webhook -> webhook.getId().equals(webhookId))
+                .findFirst();
+    }
+
+    public Optional<User> getUserById(Snowflake userId) {
+        return users.stream()
+                .filter(user -> user.getId().equals(userId))
+                .findFirst();
+    }
+
+    public Snowflake getGuildId() {
+        return Snowflake.of(guildId);
+    }
+
+    public AuditLogPart combine(AuditLogPart other) {
+        if (other.guildId != this.guildId) {
+            throw new IllegalArgumentException("Cannot combine audit log parts from two different guilds.");
+        }
+
+        List<Webhook> combinedWebhooks = new ArrayList<>(this.webhooks.size() + other.webhooks.size());
+        combinedWebhooks.addAll(this.webhooks);
+        combinedWebhooks.addAll(other.webhooks);
+
+        List<User> combinedUsers = new ArrayList<>(this.users.size() + other.users.size());
+        combinedUsers.addAll(this.users);
+        combinedUsers.addAll(other.users);
+
+        List<AuditLogEntry> combinedEntries = new ArrayList<>(this.entries.size() + other.entries.size());
+        combinedEntries.addAll(this.entries);
+        combinedEntries.addAll(other.entries);
+
+        return new AuditLogPart(guildId, combinedWebhooks, combinedUsers, combinedEntries);
+    }
+}

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogRole.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogRole.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package discord4j.core.object.audit;
 
 import discord4j.common.util.Snowflake;

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogRole.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogRole.java
@@ -1,0 +1,49 @@
+package discord4j.core.object.audit;
+
+import discord4j.common.util.Snowflake;
+
+import java.util.Objects;
+
+public final class AuditLogRole {
+
+    private final long id;
+    private final String name;
+
+    public AuditLogRole(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Snowflake getId() {
+        return Snowflake.of(id);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AuditLogRole that = (AuditLogRole) o;
+        return id == that.id && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "AuditLogRole{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogRole.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogRole.java
@@ -17,25 +17,28 @@
 package discord4j.core.object.audit;
 
 import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.AuditLogPartialRoleData;
 
 import java.util.Objects;
 
+/**
+ * A partial role with only an ID and a name. This is returned by Discord in an {@link AuditLogChange} for
+ * {@link ChangeKey#ROLES_ADD} and {@link ChangeKey#ROLES_REMOVE}.
+ */
 public final class AuditLogRole {
 
-    private final long id;
-    private final String name;
+    private final AuditLogPartialRoleData data;
 
-    public AuditLogRole(long id, String name) {
-        this.id = id;
-        this.name = name;
+    public AuditLogRole(AuditLogPartialRoleData data) {
+        this.data = data;
     }
 
     public Snowflake getId() {
-        return Snowflake.of(id);
+        return Snowflake.of(data.id());
     }
 
     public String getName() {
-        return name;
+        return data.name();
     }
 
     @Override
@@ -47,19 +50,18 @@ public final class AuditLogRole {
             return false;
         }
         AuditLogRole that = (AuditLogRole) o;
-        return id == that.id && Objects.equals(name, that.name);
+        return Objects.equals(data, that.data);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name);
+        return Objects.hash(data);
     }
 
     @Override
     public String toString() {
         return "AuditLogRole{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
+                "data=" + data +
                 '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/audit/ChangeKey.java
+++ b/core/src/main/java/discord4j/core/object/audit/ChangeKey.java
@@ -16,15 +16,18 @@
  */
 package discord4j.core.object.audit;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.ExtendedPermissionOverwrite;
 import discord4j.core.object.entity.Guild;
-import discord4j.core.object.entity.Role;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.rest.util.Color;
 import discord4j.rest.util.PermissionSet;
 
 import java.util.Set;
+import java.util.function.BiFunction;
+
+import static discord4j.core.object.audit.AuditLogChangeParser.*;
 
 /**
  * Represents the various audit log change key.
@@ -36,123 +39,130 @@ import java.util.Set;
 public final class ChangeKey<T> {
 
     /** Name changed */
-    public static final ChangeKey<String> NAME = changeKey("name");
+    public static final ChangeKey<String> NAME = changeKey("name", STRING_PARSER);
     /** Description changed */
-    public static final ChangeKey<String> DESCRIPTION = changeKey("description");
+    public static final ChangeKey<String> DESCRIPTION = changeKey("description", STRING_PARSER);
     /** Icon changed */
-    public static final ChangeKey<String> ICON = changeKey("icon_hash");
+    public static final ChangeKey<String> ICON = changeKey("icon_hash", STRING_PARSER);
     /** Invite splash page artwork changed */
-    public static final ChangeKey<String> SPLASH = changeKey("splash_hash");
+    public static final ChangeKey<String> SPLASH = changeKey("splash_hash", STRING_PARSER);
     /** Discovery splash changed */
-    public static final ChangeKey<String> DISCOVERY_SPLASH = changeKey("discovery_splash_hash");
+    public static final ChangeKey<String> DISCOVERY_SPLASH = changeKey("discovery_splash_hash", STRING_PARSER);
     /** Banner changed */
-    public static final ChangeKey<String> BANNER = changeKey("banner_hash");
+    public static final ChangeKey<String> BANNER = changeKey("banner_hash", STRING_PARSER);
     /** Owner changed */
-    public static final ChangeKey<Snowflake> OWNER = changeKey("owner_id");
+    public static final ChangeKey<Snowflake> OWNER = changeKey("owner_id", SNOWFLAKE_PARSER);
     /** Region changed */
-    public static final ChangeKey<String> REGION = changeKey("region");
+    public static final ChangeKey<String> REGION = changeKey("region", STRING_PARSER);
     /** Preferred locale changed */
-    public static final ChangeKey<String> PREFERRED_LOCALE = changeKey("preferred_locale");
+    public static final ChangeKey<String> PREFERRED_LOCALE = changeKey("preferred_locale", STRING_PARSER);
     /** Afk channel changed */
-    public static final ChangeKey<Snowflake> AFK_CHANNEL = changeKey("afk_channel_id");
+    public static final ChangeKey<Snowflake> AFK_CHANNEL = changeKey("afk_channel_id", SNOWFLAKE_PARSER);
     /** Afk timeout duration changed */
-    public static final ChangeKey<Integer> AFK_TIMEOUT = changeKey("afk_timeout");
+    public static final ChangeKey<Integer> AFK_TIMEOUT = changeKey("afk_timeout", INTEGER_PARSER);
     /** Id of the rules channel changed */
-    public static final ChangeKey<Snowflake> RULES_CHANNEL = changeKey("rules_channel_id");
+    public static final ChangeKey<Snowflake> RULES_CHANNEL = changeKey("rules_channel_id", SNOWFLAKE_PARSER);
     /** Od of the public updates channel changed */
-    public static final ChangeKey<Snowflake> PUBLIC_UPDATES_CHANNEL = changeKey("public_updates_channel_id");
+    public static final ChangeKey<Snowflake> PUBLIC_UPDATES_CHANNEL = changeKey("public_updates_channel_id", SNOWFLAKE_PARSER);
     /** Two-factor auth requirement changed */
-    public static final ChangeKey<Guild.MfaLevel> MFA_LEVEL = changeKey("mfa_level");
+    public static final ChangeKey<Guild.MfaLevel> MFA_LEVEL = changeKey("mfa_level", INTEGER_PARSER.andThen(Guild.MfaLevel::of));
     /** Required verification level changed */
-    public static final ChangeKey<Guild.VerificationLevel> VERIFICATION_LEVEL = changeKey("verification_level");
+    public static final ChangeKey<Guild.VerificationLevel> VERIFICATION_LEVEL = changeKey("verification_level", INTEGER_PARSER.andThen(Guild.VerificationLevel::of));
     /** Change in whose messages are scanned and deleted for explicit content in the server */
-    public static final ChangeKey<Guild.ContentFilterLevel> CONTENT_FILTER_LEVEL = changeKey("explicit_content_filter");
+    public static final ChangeKey<Guild.ContentFilterLevel> CONTENT_FILTER_LEVEL = changeKey("explicit_content_filter", INTEGER_PARSER.andThen(Guild.ContentFilterLevel::of));
     /** Default message notification level changed */
-    public static final ChangeKey<Guild.NotificationLevel> NOTIFICATION_LEVEL =
-            changeKey("default_message_notifications");
+    public static final ChangeKey<Guild.NotificationLevel> NOTIFICATION_LEVEL = changeKey("default_message_notifications", INTEGER_PARSER.andThen(Guild.NotificationLevel::of));
     /** Invite vanity url changed */
-    public static final ChangeKey<String> VANITY_URL = changeKey("vanity_url_code");
+    public static final ChangeKey<String> VANITY_URL = changeKey("vanity_url_code", STRING_PARSER);
     /** New role added */
-    public static final ChangeKey<Set<Role>> ROLES_ADD = changeKey("$add");
+    public static final ChangeKey<Set<AuditLogRole>> ROLES_ADD = changeKey("$add", AUDIT_LOG_ROLES_PARSER);
     /** Role removed */
-    public static final ChangeKey<Set<Role>> ROLES_REMOVE = changeKey("$remove");
+    public static final ChangeKey<Set<AuditLogRole>> ROLES_REMOVE = changeKey("$remove", AUDIT_LOG_ROLES_PARSER);
     /** Change in number of days after which inactive and role-unassigned members are kicked */
-    public static final ChangeKey<Integer> PRUNE_DAYS = changeKey("prune_delete_days");
+    public static final ChangeKey<Integer> PRUNE_DAYS = changeKey("prune_delete_days", INTEGER_PARSER);
     /** Server widget enabled/disable */
-    public static final ChangeKey<Boolean> WIDGET_ENABLED = changeKey("widget_enabled");
+    public static final ChangeKey<Boolean> WIDGET_ENABLED = changeKey("widget_enabled", BOOLEAN_PARSER);
     /** Channel id of the server widget changed */
-    public static final ChangeKey<Snowflake> WIDGET_CHANNEL = changeKey("widget_channel_id");
+    public static final ChangeKey<Snowflake> WIDGET_CHANNEL = changeKey("widget_channel_id", SNOWFLAKE_PARSER);
     /** Id of the system channel changed */
-    public static final ChangeKey<Snowflake> SYSTEM_CHANNEL = changeKey("system_channel_id");
+    public static final ChangeKey<Snowflake> SYSTEM_CHANNEL = changeKey("system_channel_id", SNOWFLAKE_PARSER);
     /** Text or voice channel position changed */
-    public static final ChangeKey<Integer> POSITION = changeKey("position");
+    public static final ChangeKey<Integer> POSITION = changeKey("position", INTEGER_PARSER);
     /** Text channel topic changed */
-    public static final ChangeKey<String> TOPIC = changeKey("topic");
+    public static final ChangeKey<String> TOPIC = changeKey("topic", STRING_PARSER);
     /** Voice channel bitrate changed */
-    public static final ChangeKey<Integer> BITRATE = changeKey("bitrate");
+    public static final ChangeKey<Integer> BITRATE = changeKey("bitrate", INTEGER_PARSER);
     /** Permissions on a channel changed */
-    public static final ChangeKey<Set<ExtendedPermissionOverwrite>> OVERWRITES = changeKey("permission_overwrites");
+    public static final ChangeKey<Set<ExtendedPermissionOverwrite>> OVERWRITES = changeKey("permission_overwrites", OVERWRITES_PARSER);
     /** Channel nsfw restriction changed */
-    public static final ChangeKey<Boolean> NSFW = changeKey("nsfw");
+    public static final ChangeKey<Boolean> NSFW = changeKey("nsfw", BOOLEAN_PARSER);
     /** Application id of the added or removed webhook or bot */
-    public static final ChangeKey<Snowflake> APPLICATION_ID = changeKey("application_id");
+    public static final ChangeKey<Snowflake> APPLICATION_ID = changeKey("application_id", SNOWFLAKE_PARSER);
     /** Amount of seconds a user has to wait before sending another message changed */
-    public static final ChangeKey<Integer> RATE_LIMIT_PER_USER = changeKey("rate_limit_per_user");
+    public static final ChangeKey<Integer> RATE_LIMIT_PER_USER = changeKey("rate_limit_per_user", INTEGER_PARSER);
     /** Permissions for a role changed */
-    public static final ChangeKey<PermissionSet> PERMISSIONS = changeKey("permissions");
+    public static final ChangeKey<PermissionSet> PERMISSIONS = changeKey("permissions", PERMISSION_SET_PARSER);
     /** Role color changed */
-    public static final ChangeKey<Color> COLOR = changeKey("color");
+    public static final ChangeKey<Color> COLOR = changeKey("color", INTEGER_PARSER.andThen(Color::of));
     /** Role is now displayed/no longer displayed separate from online users */
-    public static final ChangeKey<Boolean> HOIST = changeKey("hoist");
+    public static final ChangeKey<Boolean> HOIST = changeKey("hoist", BOOLEAN_PARSER);
     /** Role is now mentionable/unmentionable */
-    public static final ChangeKey<Boolean> MENTIONABLE = changeKey("mentionable");
+    public static final ChangeKey<Boolean> MENTIONABLE = changeKey("mentionable", BOOLEAN_PARSER);
     /** A permission on a text or voice channel was allowed for a role */
-    public static final ChangeKey<PermissionSet> ALLOW = changeKey("allow");
+    public static final ChangeKey<PermissionSet> ALLOW = changeKey("allow", PERMISSION_SET_PARSER);
     /** A permission on a text or voice channel was denied for a role */
-    public static final ChangeKey<PermissionSet> DENY = changeKey("deny");
+    public static final ChangeKey<PermissionSet> DENY = changeKey("deny", PERMISSION_SET_PARSER);
     /** Invite code changed */
-    public static final ChangeKey<String> INVITE_CODE = changeKey("code");
+    public static final ChangeKey<String> INVITE_CODE = changeKey("code", STRING_PARSER);
     /** Channel for invite code changed */
-    public static final ChangeKey<Snowflake> INVITE_CHANNEL_ID = changeKey("channel_id");
+    public static final ChangeKey<Snowflake> INVITE_CHANNEL_ID = changeKey("channel_id", SNOWFLAKE_PARSER);
     /** Person who created invite code changed */
-    public static final ChangeKey<Snowflake> INVITER_ID = changeKey("inviter_id");
+    public static final ChangeKey<Snowflake> INVITER_ID = changeKey("inviter_id", SNOWFLAKE_PARSER);
     /** Change to max number of times invite code can be used */
-    public static final ChangeKey<Integer> INVITE_MAX_USES = changeKey("max_uses");
+    public static final ChangeKey<Integer> INVITE_MAX_USES = changeKey("max_uses", INTEGER_PARSER);
     /** Number of times invite code used changed */
-    public static final ChangeKey<Integer> INVITE_USES = changeKey("uses");
+    public static final ChangeKey<Integer> INVITE_USES = changeKey("uses", INTEGER_PARSER);
     /** How long invite code lasts changed */
-    public static final ChangeKey<Integer> INVITE_MAX_AGE = changeKey("max_age");
+    public static final ChangeKey<Integer> INVITE_MAX_AGE = changeKey("max_age", INTEGER_PARSER);
     /** Invite code is temporary/never expires */
-    public static final ChangeKey<Boolean> INVITE_TEMPORARY = changeKey("temporary");
+    public static final ChangeKey<Boolean> INVITE_TEMPORARY = changeKey("temporary", BOOLEAN_PARSER);
     /** User server deafened/undeafened */
-    public static final ChangeKey<Boolean> USER_DEAFENED = changeKey("deaf");
+    public static final ChangeKey<Boolean> USER_DEAFENED = changeKey("deaf", BOOLEAN_PARSER);
     /** User server muted/unmuted */
-    public static final ChangeKey<Boolean> USER_MUTED = changeKey("mute");
+    public static final ChangeKey<Boolean> USER_MUTED = changeKey("mute", BOOLEAN_PARSER);
     /** User nickname changed */
-    public static final ChangeKey<String> USER_NICK = changeKey("nick");
+    public static final ChangeKey<String> USER_NICK = changeKey("nick", STRING_PARSER);
     /** User avatar changed */
-    public static final ChangeKey<String> USER_AVATAR = changeKey("avatar_hash");
+    public static final ChangeKey<String> USER_AVATAR = changeKey("avatar_hash", STRING_PARSER);
     /** The id of the changed entity - sometimes used in conjunction with other keys */
-    public static final ChangeKey<Snowflake> ID = changeKey("id");
+    public static final ChangeKey<Snowflake> ID = changeKey("id", SNOWFLAKE_PARSER);
     /** Type of entity created */
-    public static final ChangeKey<Channel.Type> CHANNEL_TYPE = changeKey("type");
+    public static final ChangeKey<Channel.Type> CHANNEL_TYPE = changeKey("type",
+            INTEGER_PARSER.andThen(Channel.Type::of));
     /** Integration emoticons enabled/disabled */
-    public static final ChangeKey<Boolean> ENABLE_EMOTICONS = changeKey("enable_emoticons");
+    public static final ChangeKey<Boolean> ENABLE_EMOTICONS = changeKey("enable_emoticons", BOOLEAN_PARSER);
     /** Integration expiring subscriber behavior changed */
-    public static final ChangeKey<Integer> EXPIRE_BEHAVIOR = changeKey("expire_behavior");
+    public static final ChangeKey<Integer> EXPIRE_BEHAVIOR = changeKey("expire_behavior", INTEGER_PARSER);
     /** Integration expire grace period changed */
-    public static final ChangeKey<Integer> EXPIRE_GRACE_PERIOD = changeKey("expire_grace_period");
+    public static final ChangeKey<Integer> EXPIRE_GRACE_PERIOD = changeKey("expire_grace_period", INTEGER_PARSER);
     /** New user limit in a voice channel */
-    public static final ChangeKey<Integer> USER_LIMIT = changeKey("user_limit");
+    public static final ChangeKey<Integer> USER_LIMIT = changeKey("user_limit", INTEGER_PARSER);
 
-    private static <T> ChangeKey<T> changeKey(String name) {
-        return new ChangeKey<>(name);
+    private static <T> ChangeKey<T> changeKey(String name, BiFunction<AuditLogEntry, JsonNode, T> parser) {
+        return new ChangeKey<>(name, parser);
     }
 
     private final String name;
 
-    private ChangeKey(String name) {
+    private final BiFunction<AuditLogEntry, JsonNode, T> parser;
+
+    private ChangeKey(String name, BiFunction<AuditLogEntry, JsonNode, T> parser) {
         this.name = name;
+        this.parser = parser;
+    }
+
+    public T parseValue(AuditLogEntry entry, JsonNode value) {
+        return parser.apply(entry, value);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/audit/OptionKey.java
+++ b/core/src/main/java/discord4j/core/object/audit/OptionKey.java
@@ -18,37 +18,45 @@ package discord4j.core.object.audit;
 
 import discord4j.common.util.Snowflake;
 
+import java.util.function.Function;
+
 public class OptionKey<T> {
 
     /** Number of days after which inactive members were kicked. */
-    public static final OptionKey<String> DELETE_MEMBER_DAYS = optionKey("delete_member_days");
+    public static final OptionKey<String> DELETE_MEMBER_DAYS = optionKey("delete_member_days", Function.identity());
     /** Number of members removed by the prune. */
-    public static final OptionKey<String> MEMBERS_REMOVED = optionKey("members_removed");
+    public static final OptionKey<String> MEMBERS_REMOVED = optionKey("members_removed", Function.identity());
     /** Channel in which the entities were targeted. */
-    public static final OptionKey<Snowflake> CHANNEL_ID = optionKey("channel_id");
+    public static final OptionKey<Snowflake> CHANNEL_ID = optionKey("channel_id", Snowflake::of);
     /** Id of the message that was targeted. */
-    public static final OptionKey<Snowflake> MESSAGE_ID = optionKey("message_id");
+    public static final OptionKey<Snowflake> MESSAGE_ID = optionKey("message_id", Snowflake::of);
     /** Number of entities that were targeted. */
-    public static final OptionKey<Integer> COUNT = optionKey("count");
+    public static final OptionKey<Integer> COUNT = optionKey("count", Integer::parseInt);
     /** Id of the overwritten entity. */
-    public static final OptionKey<Snowflake> ID = optionKey("id");
+    public static final OptionKey<Snowflake> ID = optionKey("id", Snowflake::of);
     /** Type of overwritten entity ("member" or "role"). */
-    public static final OptionKey<String> TYPE = optionKey("type");
+    public static final OptionKey<String> TYPE = optionKey("type", Function.identity());
     /** Name of the role if type is "role". */
-    public static final OptionKey<String> ROLE_NAME = optionKey("role_name");
+    public static final OptionKey<String> ROLE_NAME = optionKey("role_name", Function.identity());
 
-    private static <T> OptionKey<T> optionKey(String field) {
-        return new OptionKey<>(field);
+    private static <T> OptionKey<T> optionKey(String field, Function<String, T> parser) {
+        return new OptionKey<>(field, parser);
     }
 
     private final String field;
+    private final Function<String, T> parser;
 
-    private OptionKey(String field) {
+    private OptionKey(String field, Function<String, T> parser) {
         this.field = field;
+        this.parser = parser;
     }
 
     public String getField() {
         return field;
+    }
+
+    public T parseValue(String value) {
+        return parser.apply(value);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/audit/OptionKey.java
+++ b/core/src/main/java/discord4j/core/object/audit/OptionKey.java
@@ -20,12 +20,19 @@ import discord4j.common.util.Snowflake;
 
 import java.util.function.Function;
 
+/**
+ * A key to be used in {@link AuditLogEntry#getOption(OptionKey)}.
+ *
+ * @param <T> The type of the optional data.
+ *
+ * @see <a href="https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info">Optional Audit Entry Info</a>
+ */
 public class OptionKey<T> {
 
     /** Number of days after which inactive members were kicked. */
-    public static final OptionKey<String> DELETE_MEMBER_DAYS = optionKey("delete_member_days", Function.identity());
+    public static final OptionKey<Integer> DELETE_MEMBER_DAYS = optionKey("delete_member_days", Integer::parseInt);
     /** Number of members removed by the prune. */
-    public static final OptionKey<String> MEMBERS_REMOVED = optionKey("members_removed", Function.identity());
+    public static final OptionKey<Integer> MEMBERS_REMOVED = optionKey("members_removed", Integer::parseInt);
     /** Channel in which the entities were targeted. */
     public static final OptionKey<Snowflake> CHANNEL_ID = optionKey("channel_id", Snowflake::of);
     /** Id of the message that was targeted. */

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -20,7 +20,7 @@ import discord4j.common.store.action.read.ReadActions;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.*;
-import discord4j.core.object.audit.AuditLogEntry;
+import discord4j.core.object.audit.AuditLogPart;
 import discord4j.core.object.entity.channel.*;
 import discord4j.core.object.presence.Presence;
 import discord4j.core.retriever.EntityRetrievalStrategy;
@@ -1287,22 +1287,40 @@ public final class Guild implements Entity {
 
     /**
      * Requests to retrieve the audit log for this guild.
+     * <p>
+     * The audit log parts can be {@link AuditLogPart#combine(AuditLogPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * guild.getAuditLog()
+     *     .take(10)
+     *     .reduce(AuditLogPart::combine)
+     * }
+     * </pre>
      *
-     * @return A {@link Flux} that continually emits entries for this guild's audit log. If an error is received, it is
-     * emitted through the {@code Flux}.
+     * @return A {@link Flux} that continually parts of this guild's audit log. If an error is received, it is emitted
+     * through the {@code Flux}.
      */
-    public Flux<AuditLogEntry> getAuditLog() {
+    public Flux<AuditLogPart> getAuditLog() {
         return getAuditLog(ignored -> {});
     }
 
     /**
      * Requests to retrieve the audit log for this guild.
+     * <p>
+     * The audit log parts can be {@link AuditLogPart#combine(AuditLogPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * guild.getAuditLog()
+     *     .take(10)
+     *     .reduce(AuditLogPart::combine)
+     * }
+     * </pre>
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link AuditLogQuerySpec} to be operated on.
-     * @return A {@link Flux} that continually emits entries for this guild's audit log. If an error is received, it is
-     * emitted through the {@code Flux}.
+     * @return A {@link Flux} that continually parts of this guild's audit log. If an error is received, it is emitted
+     * through the {@code Flux}.
      */
-    public Flux<AuditLogEntry> getAuditLog(final Consumer<? super AuditLogQuerySpec> spec) {
+    public Flux<AuditLogPart> getAuditLog(final Consumer<? super AuditLogQuerySpec> spec) {
         final Function<Map<String, Object>, Flux<AuditLogData>> makeRequest = params -> {
             final AuditLogQuerySpec mutatedSpec = new AuditLogQuerySpec();
             spec.accept(mutatedSpec);
@@ -1319,8 +1337,7 @@ public final class Guild implements Entity {
         };
 
         return PaginationUtil.paginateBefore(makeRequest, getLastEntryId, Long.MAX_VALUE, 100)
-                .flatMap(log -> Flux.fromIterable(log.auditLogEntries())
-                        .map(data -> new AuditLogEntry(gateway, data)));
+                .map(data -> new AuditLogPart(getId().asLong(), gateway, data));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/util/AuditLogUtil.java
+++ b/core/src/main/java/discord4j/core/util/AuditLogUtil.java
@@ -38,28 +38,28 @@ public class AuditLogUtil {
     public static Map<String, ?> createOptionMap(AuditEntryInfoData options) {
         HashMap<String, Object> map = new HashMap<>();
         if (!options.deleteMemberDays().isAbsent()) {
-            map.put(OptionKey.DELETE_MEMBER_DAYS.getField(), options.deleteMemberDays().get());
+            map.put(OptionKey.DELETE_MEMBER_DAYS.getField(), OptionKey.DELETE_MEMBER_DAYS.parseValue(options.deleteMemberDays().get()));
         }
         if (!options.membersRemoved().isAbsent()) {
-            map.put(OptionKey.MEMBERS_REMOVED.getField(), options.membersRemoved().get());
+            map.put(OptionKey.MEMBERS_REMOVED.getField(), OptionKey.MEMBERS_REMOVED.parseValue(options.membersRemoved().get()));
         }
         if (!options.channelId().isAbsent()) {
-            map.put(OptionKey.CHANNEL_ID.getField(), Snowflake.of(options.channelId().get()));
+            map.put(OptionKey.CHANNEL_ID.getField(), OptionKey.CHANNEL_ID.parseValue(options.channelId().get()));
         }
         if (!options.messageId().isAbsent()) {
-            map.put(OptionKey.MESSAGE_ID.getField(), Snowflake.of(options.messageId().get()));
+            map.put(OptionKey.MESSAGE_ID.getField(), OptionKey.MESSAGE_ID.parseValue(options.messageId().get()));
         }
         if (!options.count().isAbsent()) {
-            map.put(OptionKey.COUNT.getField(), Integer.parseInt(options.count().get()));
+            map.put(OptionKey.COUNT.getField(), OptionKey.COUNT.parseValue(options.count().get()));
         }
         if (!options.id().isAbsent()) {
-            map.put(OptionKey.ID.getField(), Snowflake.of(options.id().get()));
+            map.put(OptionKey.ID.getField(), OptionKey.ID.parseValue(options.id().get()));
         }
         if (!options.type().isAbsent()) {
-            map.put(OptionKey.TYPE.getField(), options.type().get());
+            map.put(OptionKey.TYPE.getField(), OptionKey.TYPE.parseValue(options.type().get()));
         }
         if (!options.roleName().isAbsent()) {
-            map.put(OptionKey.ROLE_NAME.getField(), options.roleName().get());
+            map.put(OptionKey.ROLE_NAME.getField(), OptionKey.ROLE_NAME.parseValue(options.roleName().get()));
         }
         return map;
     }

--- a/core/src/main/java/discord4j/core/util/AuditLogUtil.java
+++ b/core/src/main/java/discord4j/core/util/AuditLogUtil.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.util;
 
+import discord4j.common.util.Snowflake;
 import discord4j.discordjson.json.AuditEntryInfoData;
 import discord4j.discordjson.json.AuditLogChangeData;
 import discord4j.core.object.audit.AuditLogChange;
@@ -43,16 +44,16 @@ public class AuditLogUtil {
             map.put(OptionKey.MEMBERS_REMOVED.getField(), options.membersRemoved().get());
         }
         if (!options.channelId().isAbsent()) {
-            map.put(OptionKey.CHANNEL_ID.getField(), options.channelId().get());
+            map.put(OptionKey.CHANNEL_ID.getField(), Snowflake.of(options.channelId().get()));
         }
         if (!options.messageId().isAbsent()) {
-            map.put(OptionKey.MESSAGE_ID.getField(), options.messageId().get());
+            map.put(OptionKey.MESSAGE_ID.getField(), Snowflake.of(options.messageId().get()));
         }
         if (!options.count().isAbsent()) {
-            map.put(OptionKey.COUNT.getField(), options.count().get());
+            map.put(OptionKey.COUNT.getField(), Integer.parseInt(options.count().get()));
         }
         if (!options.id().isAbsent()) {
-            map.put(OptionKey.ID.getField(), options.id().get());
+            map.put(OptionKey.ID.getField(), Snowflake.of(options.id().get()));
         }
         if (!options.type().isAbsent()) {
             map.put(OptionKey.TYPE.getField(), options.type().get());

--- a/core/src/main/java/discord4j/core/util/AuditLogUtil.java
+++ b/core/src/main/java/discord4j/core/util/AuditLogUtil.java
@@ -16,7 +16,6 @@
  */
 package discord4j.core.util;
 
-import discord4j.common.util.Snowflake;
 import discord4j.discordjson.json.AuditEntryInfoData;
 import discord4j.discordjson.json.AuditLogChangeData;
 import discord4j.core.object.audit.AuditLogChange;
@@ -24,43 +23,26 @@ import discord4j.core.object.audit.OptionKey;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class AuditLogUtil {
 
-    public static Collector<AuditLogChangeData, ?, Map<String, AuditLogChange<?>>> changeCollector() {
-        return Collectors.toMap(
-                AuditLogChangeData::key,
-                change -> new AuditLogChange<>(change.oldValue().toOptional().orElse(null), change.newValue().toOptional().orElse(null)));
+    public static Collector<AuditLogChangeData, ?, Map<String, AuditLogChangeData>> changeCollector() {
+        return Collectors.toMap(AuditLogChangeData::key, Function.identity());
     }
 
-    public static Map<String, ?> createOptionMap(AuditEntryInfoData options) {
-        HashMap<String, Object> map = new HashMap<>();
-        if (!options.deleteMemberDays().isAbsent()) {
-            map.put(OptionKey.DELETE_MEMBER_DAYS.getField(), OptionKey.DELETE_MEMBER_DAYS.parseValue(options.deleteMemberDays().get()));
-        }
-        if (!options.membersRemoved().isAbsent()) {
-            map.put(OptionKey.MEMBERS_REMOVED.getField(), OptionKey.MEMBERS_REMOVED.parseValue(options.membersRemoved().get()));
-        }
-        if (!options.channelId().isAbsent()) {
-            map.put(OptionKey.CHANNEL_ID.getField(), OptionKey.CHANNEL_ID.parseValue(options.channelId().get()));
-        }
-        if (!options.messageId().isAbsent()) {
-            map.put(OptionKey.MESSAGE_ID.getField(), OptionKey.MESSAGE_ID.parseValue(options.messageId().get()));
-        }
-        if (!options.count().isAbsent()) {
-            map.put(OptionKey.COUNT.getField(), OptionKey.COUNT.parseValue(options.count().get()));
-        }
-        if (!options.id().isAbsent()) {
-            map.put(OptionKey.ID.getField(), OptionKey.ID.parseValue(options.id().get()));
-        }
-        if (!options.type().isAbsent()) {
-            map.put(OptionKey.TYPE.getField(), OptionKey.TYPE.parseValue(options.type().get()));
-        }
-        if (!options.roleName().isAbsent()) {
-            map.put(OptionKey.ROLE_NAME.getField(), OptionKey.ROLE_NAME.parseValue(options.roleName().get()));
-        }
+    public static Map<String, String> createOptionMap(AuditEntryInfoData options) {
+        HashMap<String, String> map = new HashMap<>();
+        options.deleteMemberDays().toOptional().ifPresent(it -> map.put(OptionKey.DELETE_MEMBER_DAYS.getField(), it));
+        options.membersRemoved().toOptional().ifPresent(it -> map.put(OptionKey.MEMBERS_REMOVED.getField(), it));
+        options.channelId().toOptional().ifPresent(it -> map.put(OptionKey.CHANNEL_ID.getField(), it.asString()));
+        options.messageId().toOptional().ifPresent(it -> map.put(OptionKey.COUNT.getField(), it.asString()));
+        options.count().toOptional().ifPresent(it -> map.put(OptionKey.COUNT.getField(), it));
+        options.id().toOptional().ifPresent(it -> map.put(OptionKey.ID.getField(), it.asString()));
+        options.type().toOptional().ifPresent(it -> map.put(OptionKey.TYPE.getField(), it));
+        options.roleName().toOptional().ifPresent(it -> map.put(OptionKey.ROLE_NAME.getField(), it));
         return map;
     }
 

--- a/core/src/test/java/discord4j/core/ExampleAuditLog.java
+++ b/core/src/test/java/discord4j/core/ExampleAuditLog.java
@@ -1,0 +1,33 @@
+package discord4j.core;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.event.domain.guild.GuildCreateEvent;
+import discord4j.core.object.audit.AuditLogEntry;
+import discord4j.core.object.audit.AuditLogPart;
+import discord4j.core.object.audit.ChangeKey;
+import discord4j.core.object.entity.Guild;
+
+import java.util.List;
+
+public class ExampleAuditLog {
+
+    public static void main(String[] args) {
+        List<AuditLogEntry> entries = DiscordClient.create(System.getenv("token"))
+                .login()
+                .flatMapMany(client -> client.on(GuildCreateEvent.class))
+                .filter(gce -> gce.getGuild().getId().equals(Snowflake.of(System.getenv("guildId"))))
+                .map(GuildCreateEvent::getGuild)
+                .next()
+                .flatMapMany(Guild::getAuditLog)
+                .take(10)
+                .reduce(AuditLogPart::combine)
+                .map(AuditLogPart::getEntries)
+                .block();
+
+        System.out.println(entries);
+
+        Snowflake snowflake = entries.get(0).getChange(ChangeKey.INVITE_CHANNEL_ID).get().getCurrentValue().get();
+        System.out.println(snowflake.asLong());
+
+    }
+}

--- a/core/src/test/java/discord4j/core/ExampleAuditLog.java
+++ b/core/src/test/java/discord4j/core/ExampleAuditLog.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package discord4j.core;
 
 import discord4j.common.util.Snowflake;

--- a/rest/src/main/java/discord4j/rest/util/PermissionSet.java
+++ b/rest/src/main/java/discord4j/rest/util/PermissionSet.java
@@ -74,6 +74,10 @@ public final class PermissionSet extends AbstractSet<Permission> {
         return new PermissionSet(rawValue);
     }
 
+    public static PermissionSet of(final String rawValue) {
+        return new PermissionSet(Long.parseUnsignedLong(rawValue));
+    }
+
     /**
      * Returns a {@code PermissionSet} containing all the supplied permissions.
      *

--- a/rest/src/main/java/discord4j/rest/util/PermissionSet.java
+++ b/rest/src/main/java/discord4j/rest/util/PermissionSet.java
@@ -74,6 +74,13 @@ public final class PermissionSet extends AbstractSet<Permission> {
         return new PermissionSet(rawValue);
     }
 
+    /**
+     * Returns a {@code PermissionSet} containing all the permissions represented by the <i>raw value</i>.
+     *
+     * @param rawValue A bit-wise OR evaluation of multiple values returned by {@link Permission#getValue()}, as a
+     * string.
+     * @return A {@code PermissionSet} containing all the permissions represented by the <i>raw value</i>.
+     */
     public static PermissionSet of(final String rawValue) {
         return new PermissionSet(Long.parseUnsignedLong(rawValue));
     }


### PR DESCRIPTION
**Description:**
Fixes the parsing of audit log entries' `options` and `changes`. Thanks to @florianhartung for the initial work with `options` in #852.
In addition to parsing, this also addresses #428.

* Adds `AuditLogPart`, a "part" of the whole audit log which has all of the webhooks, users, and audit log entries returned by a single request to `/guilds/{guild.id}/audit-logs`. It has `getXById` methods which provide easier/faster access to the webhooks and users.
* Adds `AuditLogChangeParser`, a function `(AuditLogEntry, JsonNode) -> T` which parses the `JsonNode`. The `AuditLogEntry` is used to get the client `ObjectMapper` as well as the channel and guild ID for the overwrites parser. This is used by each instance of `ChangeKey`
* Adds a parsing function `String -> T` to each `OptionKey` to get the appropriate parsed type
* Adds `AuditLogRole` is a partial Role with only the ID and name. Not sure if this is the best way to do this. 
* Adds `PermissionSet.of(String)` to create a permission set from a string. This is to handle the fact that Discord sends permissions as strings now (note that when parsing permissions from another but audit log, this constructor is not used. We instead still rely on Jackson's implicit conversion from `String` to `long`. In my opinion, this should be changed after we drop v6 support).

**Justification:**
Fixes #851 
Fixes #428 