### PR TITLE
Use better exception types than AssertionError

### DIFF
--- a/common/src/main/java/discord4j/common/store/Store.java
+++ b/common/src/main/java/discord4j/common/store/Store.java
@@ -102,7 +102,7 @@ public final class Store {
                         case VOICE_STATES:
                             return dataAccessor.countVoiceStatesInGuild(action.getGuildId());
                         default:
-                            throw new AssertionError("Unhandled entity " + action.getEntity());
+                            throw new IllegalArgumentException("Unhandled entity " + action.getEntity());
                     }
                 })
                 .map(CountTotalAction.class, action -> {
@@ -126,7 +126,7 @@ public final class Store {
                         case VOICE_STATES:
                             return dataAccessor.countVoiceStates();
                         default:
-                            throw new AssertionError("Unhandled entity " + action.getEntity());
+                            throw new IllegalArgumentException("Unhandled entity " + action.getEntity());
                     }
                 })
                 .map(GetChannelsAction.class, action -> dataAccessor.getChannels())

--- a/common/src/main/java/discord4j/common/store/action/gateway/GatewayActions.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/GatewayActions.java
@@ -28,7 +28,7 @@ import discord4j.discordjson.json.gateway.*;
 public class GatewayActions {
 
     private GatewayActions() {
-        throw new AssertionError();
+        throw new AssertionError("No discord4j.common.store.action.gateway.GatewayActions instances for you!");
     }
 
     /**

--- a/common/src/main/java/discord4j/common/store/action/read/ReadActions.java
+++ b/common/src/main/java/discord4j/common/store/action/read/ReadActions.java
@@ -28,7 +28,7 @@ import discord4j.common.store.api.object.ExactResultNotAvailableException;
 public class ReadActions {
 
     private ReadActions() {
-        throw new AssertionError();
+        throw new AssertionError("No discord4j.common.store.action.read.ReadActions instances for you!");
     }
 
     /**

--- a/common/src/main/java/discord4j/common/store/legacy/LegacyStoreLayout.java
+++ b/common/src/main/java/discord4j/common/store/legacy/LegacyStoreLayout.java
@@ -324,7 +324,7 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
             case GUILD_STORE: return saveChannel(dispatch);
             case DM:
             case GROUP_DM: return Mono.empty();
-            default: throw new AssertionError("Unhandled channel type " + dispatch.channel().type());
+            default: throw new IllegalArgumentException("Unhandled channel type " + dispatch.channel().type());
         }
     }
 
@@ -356,7 +356,7 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
             case GUILD_STORE: return deleteChannel(dispatch);
             case DM:
             case GROUP_DM: return Mono.empty();
-            default: throw new AssertionError("Unhandled channel type " + dispatch.channel().type());
+            default: throw new IllegalArgumentException("Unhandled channel type " + dispatch.channel().type());
         }
     }
 
@@ -388,7 +388,7 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
             case GUILD_STORE: return updateChannel(dispatch);
             case DM:
             case GROUP_DM: return Mono.empty();
-            default: throw new AssertionError("Unhandled channel type " + dispatch.channel().type());
+            default: throw new IllegalArgumentException("Unhandled channel type " + dispatch.channel().type());
         }
     }
 

--- a/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ChannelDispatchHandlers.java
@@ -52,7 +52,7 @@ class ChannelDispatchHandlers {
                 case GUILD_CATEGORY: return new CategoryCreateEvent(gateway, context.getShardInfo(), new Category(gateway, channel));
                 case GUILD_NEWS: return new NewsChannelCreateEvent(gateway, context.getShardInfo(), new NewsChannel(gateway, channel));
                 case GUILD_STORE: return new StoreChannelCreateEvent(gateway, context.getShardInfo(), new StoreChannel(gateway, channel));
-                default: throw new AssertionError("Unhandled channel type " + context.getDispatch().channel().type());
+                default: throw new IllegalArgumentException("Unhandled channel type " + context.getDispatch().channel().type());
             }
         });
     }
@@ -74,7 +74,7 @@ class ChannelDispatchHandlers {
                 case GUILD_CATEGORY: return new CategoryDeleteEvent(gateway, context.getShardInfo(), new Category(gateway, channel));
                 case GUILD_NEWS: return new NewsChannelDeleteEvent(gateway, context.getShardInfo(), new NewsChannel(gateway, channel));
                 case GUILD_STORE: return new StoreChannelDeleteEvent(gateway, context.getShardInfo(), new StoreChannel(gateway, channel));
-                default: throw new AssertionError("Unhandled channel type " + context.getDispatch().channel().type());
+                default: throw new IllegalArgumentException("Unhandled channel type " + context.getDispatch().channel().type());
             }
         });
     }
@@ -122,7 +122,7 @@ class ChannelDispatchHandlers {
                 case GUILD_STORE: return new StoreChannelUpdateEvent(gateway, context.getShardInfo(),
                         new StoreChannel(gateway, channel),
                         oldData.map(old -> new StoreChannel(gateway, old)).orElse(null));
-                default: throw new AssertionError("Unhandled channel type " + context.getDispatch().channel().type());
+                default: throw new IllegalArgumentException("Unhandled channel type " + context.getDispatch().channel().type());
             }
         });
     }
@@ -131,7 +131,7 @@ class ChannelDispatchHandlers {
         switch (Channel.Type.of(channel.type())) {
             case GUILD_NEWS: return new NewsChannel(gateway, channel);
             case GUILD_TEXT: return new TextChannel(gateway, channel);
-            default: throw new AssertionError("Unhandled channel type " + channel.type());
+            default: throw new IllegalArgumentException("Unhandled channel type " + channel.type());
         }
     }
 }

--- a/core/src/main/java/discord4j/core/object/presence/Presence.java
+++ b/core/src/main/java/discord4j/core/object/presence/Presence.java
@@ -60,7 +60,8 @@ public final class Presence {
             case DESKTOP: return data.clientStatus().desktop().toOptional().map(Status::of);
             case MOBILE: return data.clientStatus().mobile().toOptional().map(Status::of);
             case WEB: return data.clientStatus().web().toOptional().map(Status::of);
-            default: throw new AssertionError("Unhandled platform " + platform);
+            // TODO: Remove in Java 12+. The switch is exhaustive assuming Platform is not compiled separately.
+            default: throw new IllegalArgumentException("Unhandled platform " + platform);
         }
     }
 

--- a/gateway/src/main/java/discord4j/gateway/intent/IntentSet.java
+++ b/gateway/src/main/java/discord4j/gateway/intent/IntentSet.java
@@ -37,8 +37,7 @@ public final class IntentSet extends AbstractSet<Intent> {
 
     private static final long ALL_RAW = Arrays.stream(Intent.values())
             .mapToLong(Intent::getValue)
-            .reduce((a, b) -> a | b)
-            .orElseThrow(AssertionError::new);
+            .reduce(0, (a, b) -> a | b);
     private static final long NONE_RAW = 0;
 
     /**

--- a/gateway/src/main/java/discord4j/gateway/state/DispatchStoreLayer.java
+++ b/gateway/src/main/java/discord4j/gateway/state/DispatchStoreLayer.java
@@ -137,7 +137,6 @@ public class DispatchStoreLayer {
                 .filter(entry -> entry.predicate.test(actualDispatch))
                 .map(entry -> entry.actionFactory))
                 .singleOrEmpty()
-                .onErrorMap(IndexOutOfBoundsException.class, AssertionError::new)
                 .map(actionFactory -> actionFactory.apply(shardInfo.getIndex(), actualDispatch))
                 .flatMap(action -> Mono.from(store.execute(action)))
                 .<StatefulDispatch<?, ?>>map(oldState -> StatefulDispatch.of(shardInfo, actualDispatch, oldState))

--- a/rest/src/main/java/discord4j/rest/util/PermissionSet.java
+++ b/rest/src/main/java/discord4j/rest/util/PermissionSet.java
@@ -36,8 +36,7 @@ public final class PermissionSet extends AbstractSet<Permission> {
 
     private static final long ALL_RAW = Arrays.stream(Permission.values())
         .mapToLong(Permission::getValue)
-        .reduce((a, b) -> a | b)
-        .orElseThrow(AssertionError::new);
+        .reduce(0, (a, b) -> a | b);
     private static final long NONE_RAW = 0;
 
     /** Common instance for {@code all()}. */


### PR DESCRIPTION
**Description:**
Following up on quantic's comments [here](https://github.com/Discord4J/Discord4J/pull/875#pullrequestreview-622656074). Change/remove uses of `AssertionError`. Most were changed to `IllegalArgumentException`, but some were just removed without a change in behavior.

**Justification:**
Semantically, `AssertionError` isn't the correct exception to use for most of these cases. This is especially true for the ones relating to Discord types where we get new ones all the time/with no warning.

Ultimately, this is really a nitpick with no real consequences, because Reactor won't handle these any differently, and no one should really be trying to handle these themselves anyways. 

Also note that if/when we upgrade to a more recent minimum java version, we can replace _some_ (not the Discord type ones, but the enums which are actually fully in our control) of these with exhaustive switch expressions.