### PR TITLE
Add method for constructing ReactionEmoji from codepoints using "U+" notation

### DIFF
--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -21,6 +21,7 @@ import discord4j.discordjson.json.ReactionData;
 import discord4j.common.util.Snowflake;
 import reactor.util.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -54,12 +55,46 @@ public abstract class ReactionEmoji {
 
     /**
      * Constructs a {@code ReactionEmoji} for a unicode emoji.
+     * <p>
+     * The string argument to this method should be the exact UTF-16 encoded string of the desired emoji. For example,
+     * <pre>
+     * ReactionEmoji.unicode("&#92;u2764") // "heart"
+     * ReactionEmoji.unicode("&#92;uD83D&#92;uDE00") // "grinning face"
+     * ReactionEmoji.unicode("&#92;uD83D&#92;uDC68&#92;u200D&#92;uD83E&#92;uDDB0") // "man: red hair"
+     * </pre>
+     * A full list of emoji can be found <a href="https://unicode.org/emoji/charts/full-emoji-list.html">here</a>.
+     * <p>
+     * This method does <i>not</i> accept the "U+" notation for codepoints. For that, use
+     * {@link #unicodeCodepoints(String...)}.
      *
      * @param raw The raw unicode string for the emoji.
      * @return A reaction emoji using the given information.
      */
     public static Unicode unicode(String raw) {
         return new Unicode(raw);
+    }
+
+    /**
+     * Constructs a {@code ReactionEmoji} for a unicode emoji.
+     * <p>
+     * The argument(s) to this method should use the "U+" notation for codepoints. For example,
+     * <pre>
+     * ReactionEmoji.unicodeCodepoints("U+2764") // "heart"
+     * ReactionEmoji.unicodeCodepoints("U+1F600") // "grinning face"
+     * ReactionEmoji.unicodeCodepoints("U+1F468", "U+200D", "U+1F9B0") // "man: red hair"
+     * </pre>
+     * A full list of emoji can be found <a href="https://unicode.org/emoji/charts/full-emoji-list.html">here</a>.
+     *
+     * @param codepoints The codepoints that make up the emoji.
+     * @return A reaction emoji using the given information.
+     */
+    public static Unicode unicodeCodepoints(String... codepoints) {
+        String combined = Arrays.stream(codepoints)
+                .map(c -> Integer.parseInt(c.substring(2), 16))
+                .reduce(new StringBuilder(), StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+
+        return unicode(combined);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -65,7 +65,7 @@ public abstract class ReactionEmoji {
      * A full list of emoji can be found <a href="https://unicode.org/emoji/charts/full-emoji-list.html">here</a>.
      * <p>
      * This method does <i>not</i> accept the "U+" notation for codepoints. For that, use
-     * {@link #unicodeCodepoints(String...)}.
+     * {@link #codepoints(String...)}.
      *
      * @param raw The raw unicode string for the emoji.
      * @return A reaction emoji using the given information.
@@ -79,16 +79,16 @@ public abstract class ReactionEmoji {
      * <p>
      * The argument(s) to this method should use the "U+" notation for codepoints. For example,
      * <pre>
-     * ReactionEmoji.unicodeCodepoints("U+2764") // "heart"
-     * ReactionEmoji.unicodeCodepoints("U+1F600") // "grinning face"
-     * ReactionEmoji.unicodeCodepoints("U+1F468", "U+200D", "U+1F9B0") // "man: red hair"
+     * ReactionEmoji.codepoints("U+2764") // "heart"
+     * ReactionEmoji.codepoints("U+1F600") // "grinning face"
+     * ReactionEmoji.codepoints("U+1F468", "U+200D", "U+1F9B0") // "man: red hair"
      * </pre>
      * A full list of emoji can be found <a href="https://unicode.org/emoji/charts/full-emoji-list.html">here</a>.
      *
      * @param codepoints The codepoints that make up the emoji.
      * @return A reaction emoji using the given information.
      */
-    public static Unicode unicodeCodepoints(String... codepoints) {
+    public static Unicode codepoints(String... codepoints) {
         String combined = Arrays.stream(codepoints)
                 .map(c -> Integer.parseInt(c.substring(2), 16))
                 .reduce(new StringBuilder(), StringBuilder::appendCodePoint, StringBuilder::append)


### PR DESCRIPTION
**Description:**
Adds `ReactionEmoji#unicodeCodepoints(String...)`, a convenience method for constructing a `ReactionEmoji` from Unicode codepoints using the "U+" notation. Also improves the docs for the existing `ReactionEmoji.unicode(String)` method, providing examples, and pointing to this new method for alternate inputs.

**Justification:**
Confusion with the existing `ReactionEmoji.unicode(String)` method is common-enough, that I think this solution is worth trying.
Fixes #765 