### PR TITLE
Remove createFollowUp#wait parameter

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/InteractionCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/InteractionCreateEvent.java
@@ -218,9 +218,9 @@ public class InteractionCreateEvent extends Event {
         }
 
         @Override
-        public Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request, boolean wait) {
+        public Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request) {
             return restClient.getWebhookService()
-                    .executeWebhook(applicationId, interactionData.token(), wait, request);
+                    .executeWebhook(applicationId, interactionData.token(), true, request);
         }
 
         @Override

--- a/rest/src/main/java/discord4j/rest/interaction/InteractionOperations.java
+++ b/rest/src/main/java/discord4j/rest/interaction/InteractionOperations.java
@@ -151,9 +151,9 @@ class InteractionOperations implements RestInteraction, InteractionResponse, Gui
     }
 
     @Override
-    public Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request, boolean wait) {
+    public Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request) {
         return restClient.getWebhookService()
-                .executeWebhook(applicationId, interactionData.token(), wait, request);
+                .executeWebhook(applicationId, interactionData.token(), true, request);
     }
 
     @Override

--- a/rest/src/main/java/discord4j/rest/interaction/InteractionResponse.java
+++ b/rest/src/main/java/discord4j/rest/interaction/InteractionResponse.java
@@ -63,12 +63,10 @@ public interface InteractionResponse {
      * token.
      *
      * @param request the message request to be sent as followup
-     * @param wait whether to wait until the webhook is sent or fails, influences whether you can get an error
-     * through the return {@code Mono}.
      * @return a {@link Mono} where, upon successful completion, emits the sent message. If an error is received,
      * it is emitted through the {@code Mono}.
      */
-    Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request, boolean wait);
+    Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request);
 
     /**
      * Modify the given message by ID using the provided request. This uses a webhook tied to the interaction ID and


### PR DESCRIPTION
**Description:** Removes `createFollowUp#wait` parameter because it will not be taken into account.

**Justification:** 
According to the documentation: `wait is always true`
https://discord.com/developers/docs/interactions/slash-commands#create-followup-message