### PR TITLE
Fix #911

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -165,7 +165,8 @@ public final class Message implements Entity {
      * @return The author of this message, if present.
      */
     public Optional<User> getAuthor() {
-        return data.webhookId().isAbsent() ? Optional.of(new User(gateway, data.author())) : Optional.empty();
+        return data.webhookId().isAbsent() || !data.interaction().isAbsent() ?
+                Optional.of(new User(gateway, data.author())) : Optional.empty();
     }
 
     /**


### PR DESCRIPTION
**Description:** Fixes https://github.com/Discord4J/Discord4J/issues/911

**Justification:** We can use `data#author` if the message comes from an interaction.