### PR TITLE
Allow for ephemeral followup messages

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/InteractionCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/InteractionCreateEvent.java
@@ -211,7 +211,7 @@ public class InteractionCreateEvent extends Event {
 
         @Override
         public Mono<MessageData> createFollowupMessage(String content) {
-            WebhookExecuteRequest body = WebhookExecuteRequest.builder().content(content).build();
+            FollowupMessageRequest body = FollowupMessageRequest.builder().content(content).build();
             WebhookMultipartRequest request = new WebhookMultipartRequest(body);
             return restClient.getWebhookService()
                     .executeWebhook(applicationId, interactionData.token(), true, request);
@@ -221,6 +221,29 @@ public class InteractionCreateEvent extends Event {
         public Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request) {
             return restClient.getWebhookService()
                     .executeWebhook(applicationId, interactionData.token(), true, request);
+        }
+
+        @Override
+        public Mono<MessageData> createFollowupMessageEphemeral(String content) {
+            FollowupMessageRequest body = FollowupMessageRequest.builder()
+                    .content(content)
+                    .flags(Message.Flag.EPHEMERAL.getFlag())
+                    .build();
+            WebhookMultipartRequest request = new WebhookMultipartRequest(body);
+            return restClient.getWebhookService()
+                    .executeWebhook(applicationId, interactionData.token(), true, request);
+        }
+
+        @Override
+        public Mono<MessageData> createFollowupMessageEphemeral(WebhookMultipartRequest request) {
+            FollowupMessageRequest newBody = FollowupMessageRequest.builder()
+                    .from(request.getExecuteRequest())
+                    .flags(Message.Flag.EPHEMERAL.getFlag())
+                    .build();
+            WebhookMultipartRequest newRequest = new WebhookMultipartRequest(newBody, request.getFiles());
+
+            return restClient.getWebhookService()
+                    .executeWebhook(applicationId, interactionData.token(), true, newRequest);
         }
 
         @Override

--- a/rest/src/main/java/discord4j/rest/interaction/InteractionOperations.java
+++ b/rest/src/main/java/discord4j/rest/interaction/InteractionOperations.java
@@ -144,7 +144,7 @@ class InteractionOperations implements RestInteraction, InteractionResponse, Gui
 
     @Override
     public Mono<MessageData> createFollowupMessage(String content) {
-        WebhookExecuteRequest body = WebhookExecuteRequest.builder().content(content).build();
+        FollowupMessageRequest body = FollowupMessageRequest.builder().content(content).build();
         WebhookMultipartRequest request = new WebhookMultipartRequest(body);
         return restClient.getWebhookService()
                 .executeWebhook(applicationId, interactionData.token(), true, request);
@@ -154,6 +154,29 @@ class InteractionOperations implements RestInteraction, InteractionResponse, Gui
     public Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request) {
         return restClient.getWebhookService()
                 .executeWebhook(applicationId, interactionData.token(), true, request);
+    }
+
+    @Override
+    public Mono<MessageData> createFollowupMessageEphemeral(String content) {
+        FollowupMessageRequest body = FollowupMessageRequest.builder()
+                .content(content)
+                .flags(1 << 6)
+                .build();
+        WebhookMultipartRequest request = new WebhookMultipartRequest(body);
+        return restClient.getWebhookService()
+                .executeWebhook(applicationId, interactionData.token(), true, request);
+    }
+
+    @Override
+    public Mono<MessageData> createFollowupMessageEphemeral(WebhookMultipartRequest request) {
+        FollowupMessageRequest newBody = FollowupMessageRequest.builder()
+                .from(request.getExecuteRequest())
+                .flags(1 << 6)
+                .build();
+        WebhookMultipartRequest newRequest = new WebhookMultipartRequest(newBody, request.getFiles());
+
+        return restClient.getWebhookService()
+                .executeWebhook(applicationId, interactionData.token(), true, newRequest);
     }
 
     @Override

--- a/rest/src/main/java/discord4j/rest/interaction/InteractionResponse.java
+++ b/rest/src/main/java/discord4j/rest/interaction/InteractionResponse.java
@@ -69,6 +69,26 @@ public interface InteractionResponse {
     Mono<MessageData> createFollowupMessage(WebhookMultipartRequest request);
 
     /**
+     * Create a new ephemeral followup message with the given content. This uses a webhook tied to the interaction ID
+     * and token.
+     *
+     * @param content the text content included in the followup
+     * @return a {@link Mono} where, upon successful completion, emits the sent message. If an error is received,
+     * it is emitted through the {@code Mono}.
+     */
+    Mono<MessageData> createFollowupMessageEphemeral(String content);
+
+    /**
+     * Create a new ephemeral followup message using the provided request. This uses a webhook tied to the interaction
+     * ID and token.
+     *
+     * @param request the message request to be sent as followup
+     * @return a {@link Mono} where, upon successful completion, emits the sent message. If an error is received,
+     * it is emitted through the {@code Mono}.
+     */
+    Mono<MessageData> createFollowupMessageEphemeral(WebhookMultipartRequest request);
+
+    /**
      * Modify the given message by ID using the provided request. This uses a webhook tied to the interaction ID and
      * token.
      *


### PR DESCRIPTION
**Description:**
Adds the ability to send ephemeral followup messages for interactions.

**Justification:**
#905 

This depends on https://github.com/Discord4J/discord-json/pull/85