### PR TITLE
Evict stale `RequestStream`s to reduce memory usage over time

### DIFF
--- a/rest/src/main/java/discord4j/rest/request/ResponseHeaderStrategy.java
+++ b/rest/src/main/java/discord4j/rest/request/ResponseHeaderStrategy.java
@@ -29,8 +29,8 @@ public class ResponseHeaderStrategy implements RateLimitStrategy {
         HttpHeaders headers = response.responseHeaders();
         int remaining = headers.getInt("X-RateLimit-Remaining", -1);
         if (remaining == 0) {
-            long resetAt = (long) (Double.parseDouble(headers.get("X-RateLimit-Reset-After")) * 1000);
-            return Duration.ofMillis(resetAt);
+            long resetAfter = (long) (Double.parseDouble(headers.get("X-RateLimit-Reset-After")) * 1000);
+            return Duration.ofMillis(resetAfter);
         }
         return Duration.ZERO;
     }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.
-->

**Description:** <!-- A description of the changes made in this pull request. -->
This adds a housekeeping mechanic for ratelimit buckets.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
The `DefaultRouter` has a Map of `RequestStream` (ratelimit buckets) that only ever grows.
On a large enough bot, the map can take up several hundred MBs of memory after a few days.
We don't need to hold the ratelimit information in memory forever, once a bucket has no pending requests and is not ratelimited, we can safely get rid of it.

Implementation notes:
- housekeeping is done on the threads of the callers that send requests
- the first thread to send a request past a certain housekeeping period is assigned housekeeping duties
- both the housekeeping and the creation of new buckets take advantage of `ConcurrentHashMap#compute` to keep the changes to the map concurrent and thread-safe

I'm keeping this PR WIP initially, as I just deployed it, and want to run it for a few days first to verify that it is working as expected and not having a measurable negative impact, but please do feel free to code review it already.