### PR TITLE
Conserve order for Message#getAttachments

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -316,14 +316,14 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets any attached files.
+     * Gets any attached files, with the same order as in the message.
      *
-     * @return Any attached files.
+     * @return Any attached files, with the same order as in the message.
      */
     public Set<Attachment> getAttachments() {
         return data.attachments().stream()
                 .map(data -> new Attachment(gateway, data))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**


### PR DESCRIPTION
**Description:** Conserve order for `Message#getAttachments`.

**Justification:** Fix https://github.com/Discord4J/Discord4J/issues/928