### PR TITLE
Conserve order and improve usability of Message#getAttachments

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -315,14 +315,14 @@ public final class Message implements Entity {
     }
 
     /**
-     * Gets any attached files.
+     * Gets any attached files, with the same order as in the message.
      *
-     * @return Any attached files.
+     * @return Any attached files, with the same order as in the message.
      */
-    public Set<Attachment> getAttachments() {
+    public List<Attachment> getAttachments() {
         return data.attachments().stream()
                 .map(data -> new Attachment(gateway, data))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
**Description:** Conserve order and improve usability of `Message#getAttachments`

**Justification:** Same as https://github.com/Discord4J/Discord4J/pull/858