### PR TITLE
Improve Region usage in specs

### DIFF
--- a/core/src/main/java/discord4j/core/object/Region.java
+++ b/core/src/main/java/discord4j/core/object/Region.java
@@ -18,6 +18,7 @@ package discord4j.core.object;
 
 import discord4j.discordjson.json.RegionData;
 import discord4j.core.GatewayDiscordClient;
+import reactor.util.annotation.Nullable;
 
 import java.util.Objects;
 
@@ -120,10 +121,12 @@ public final class Region implements DiscordObject {
                 '}';
     }
 
-    /** Represents the different region ids. */
+    /** Represents the different non-deprecated voice region ids. */
     public enum Id {
 
         UNKNOWN(null),
+
+        AUTOMATIC(null),
 
         US_WEST("us-west"),
 
@@ -179,7 +182,11 @@ public final class Region implements DiscordObject {
          * @param value The underlying value as represented by Discord.
          * @return The region id.
          */
-        public static Region.Id of(final String value) {
+        public static Region.Id of(@Nullable final String value) {
+            if(value == null) {
+                return AUTOMATIC;
+            }
+
             switch (value) {
                 case "us-west": return US_WEST;
                 case "us-east": return US_EAST;

--- a/core/src/main/java/discord4j/core/object/Region.java
+++ b/core/src/main/java/discord4j/core/object/Region.java
@@ -105,22 +105,6 @@ public final class Region implements DiscordObject {
         return data.deprecated();
     }
 
-    /**
-     * Gets if this is a custom voice region.
-     *
-     * @return {@code true} if this is a custom voice region, {@code false} otherwise.
-     */
-    public boolean isCustom() {
-        return data.custom();
-    }
-
-    @Override
-    public String toString() {
-        return "Region{" +
-                "data=" + data +
-                '}';
-    }
-
     /** Represents the different non-deprecated voice region ids. */
     public enum Id {
 

--- a/core/src/main/java/discord4j/core/object/Region.java
+++ b/core/src/main/java/discord4j/core/object/Region.java
@@ -119,4 +119,83 @@ public final class Region implements DiscordObject {
                 "data=" + data +
                 '}';
     }
+
+    /** Represents the different region ids. */
+    public enum Id {
+
+        UNKNOWN(null),
+
+        US_WEST("us-west"),
+
+        US_EAST("us-east"),
+
+        US_CENTRAL("us-central"),
+
+        US_SOUTH("us-south"),
+
+        SINGAPORE("singapore"),
+
+        SOUTHAFRICA("southafrica"),
+
+        SYDNEY("sydney"),
+
+        EUROPE("europe"),
+
+        BRAZIL("brazil"),
+
+        HONGKONG("hongkong"),
+
+        RUSSIA("russia"),
+
+        JAPAN("japan"),
+
+        INDIA("india");
+
+        /** The underlying value as represented by Discord. */
+        private final String value;
+
+        /**
+         * Constructs a {@code Region.Id}.
+         *
+         * @param value The underlying value as represented by Discord.
+         */
+        Id(final String value) {
+            this.value = value;
+        }
+
+        /**
+         * Gets the underlying value as represented by Discord.
+         *
+         * @return The underlying value as represented by Discord.
+         */
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Gets the enum associated with the value. It is guaranteed that invoking {@link #getValue()} from the returned
+         * enum will equal ({@code ==}) the supplied {@code value}.
+         *
+         * @param value The underlying value as represented by Discord.
+         * @return The region id.
+         */
+        public static Region.Id of(final String value) {
+            switch (value) {
+                case "us-west": return US_WEST;
+                case "us-east": return US_EAST;
+                case "us-central": return US_CENTRAL;
+                case "us-south": return US_SOUTH;
+                case "singapore": return SINGAPORE;
+                case "southafrica": return SOUTHAFRICA;
+                case "sydney": return SYDNEY;
+                case "europe": return EUROPE;
+                case "brazil": return BRAZIL;
+                case "hongkong": return HONGKONG;
+                case "russia": return RUSSIA;
+                case "japan": return JAPAN;
+                case "india": return INDIA;
+                default: return UNKNOWN;
+            }
+        }
+    }
 }

--- a/core/src/main/java/discord4j/core/object/Region.java
+++ b/core/src/main/java/discord4j/core/object/Region.java
@@ -105,6 +105,22 @@ public final class Region implements DiscordObject {
         return data.deprecated();
     }
 
+    /**
+     * Gets if this is a custom voice region.
+     *
+     * @return {@code true} if this is a custom voice region, {@code false} otherwise.
+     */
+    public boolean isCustom() {
+        return data.custom();
+    }
+
+    @Override
+    public String toString() {
+        return "Region{" +
+                "data=" + data +
+                '}';
+    }
+
     /** Represents the different non-deprecated voice region ids. */
     public enum Id {
 

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -228,7 +228,9 @@ public final class Guild implements Entity {
      * Gets the voice region ID for the guild.
      *
      * @return The voice region ID for the guild.
+     * @deprecated Voice region are now specific to voice channels. Use {@code VoiceChannel#getRtcRegion} instead.
      */
+    @Deprecated
     public Region.Id getRegionId() {
         return Region.Id.of(data.region());
     }
@@ -238,7 +240,9 @@ public final class Guild implements Entity {
      *
      * @return A {@link Mono} where, upon successful completion, emits the voice {@link Region region} for the guild. If
      * an error is received, it is emitted through the {@code Mono}.
+     * @deprecated Voice regions are now specific to voice channels. Use {@code VoiceChannel#getRtcRegion} instead.
      */
+    @Deprecated
     public Mono<Region> getRegion() {
         return getRegions().filter(response -> response.getId().equals(getRegionId().getValue())).single();
     }

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -229,8 +229,8 @@ public final class Guild implements Entity {
      *
      * @return The voice region ID for the guild.
      */
-    public String getRegionId() {
-        return data.region();
+    public Region.Id getRegionId() {
+        return Region.Id.of(data.region());
     }
 
     /**
@@ -240,7 +240,7 @@ public final class Guild implements Entity {
      * an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Region> getRegion() {
-        return getRegions().filter(response -> response.getId().equals(getRegionId())).single();
+        return getRegions().filter(response -> response.getId().equals(getRegionId().getValue())).single();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -72,23 +72,12 @@ public final class VoiceChannel extends BaseCategorizableChannel {
     }
 
     /**
-     * Gets the voice region id for the voice channel, automatic if not present.
+     * Gets the voice region id for the voice channel.
      *
-     * @return The voice region id for the voice channel, automatic if not present.
+     * @return The voice region id for the voice channel.
      */
-    public Optional<Region.Id> getRtcRegion() {
-        return Possible.flatOpt(getData().rtcRegion()).map(Region.Id::of);
-    }
-
-    /**
-     * Requests to retrieve the voice region for the voice channel.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the voice {@link Region region} for the guild. If
-     * an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Region> getRegion() {
-        return getClient().getRegions().filter(response -> getRtcRegion().map(Region.Id::getValue)
-                .map(response.getId()::equals).orElse(false)).single();
+    public Region.Id getRtcRegion() {
+        return Possible.flatOpt(getData().rtcRegion()).map(Region.Id::of).orElse(Region.Id.AUTOMATIC);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -19,6 +19,7 @@ package discord4j.core.object.entity.channel;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.Embed;
+import discord4j.core.object.Region;
 import discord4j.core.object.VoiceState;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.spec.VoiceChannelEditSpec;
@@ -75,8 +76,19 @@ public final class VoiceChannel extends BaseCategorizableChannel {
      *
      * @return The voice region id for the voice channel, automatic if not present.
      */
-    public Optional<String> getRtcRegion() {
-        return Possible.flatOpt(getData().rtcRegion());
+    public Optional<Region.Id> getRtcRegion() {
+        return Possible.flatOpt(getData().rtcRegion()).map(Region.Id::of);
+    }
+
+    /**
+     * Requests to retrieve the voice region for the voice channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the voice {@link Region region} for the guild. If
+     * an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Region> getRegion() {
+        return getClient().getRegions().filter(response -> getRtcRegion().map(Region.Id::getValue)
+                .map(response.getId()::equals).orElse(false)).single();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildCreateSpec.java
@@ -65,11 +65,11 @@ public class GuildCreateSpec implements Spec<GuildCreateRequest> {
     /**
      * Sets the voice region for the created {@link Guild}.
      *
-     * @param region The voice region for the guild.
+     * @param regionId The voice region for the guild.
      * @return This spec.
      */
-    public GuildCreateSpec setRegion(Region region) {
-        this.region = region.getId();
+    public GuildCreateSpec setRegion(Region.Id regionId) {
+        this.region = regionId.getValue();
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
@@ -52,13 +52,13 @@ public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
     }
 
     /**
-     * Sets the voice region for the modified {@link Guild}, automatic if null.
+     * Sets the voice region for the modified {@link Guild}.
      *
-     * @param regionId The voice region for the guild, automatic if null.
+     * @param regionId The voice region for the guild.
      * @return This spec.
      */
-    public GuildEditSpec setRegion(@Nullable Region.Id regionId) {
-        requestBuilder.region(Possible.of(Optional.ofNullable(regionId).map(Region.Id::getValue)));
+    public GuildEditSpec setRegion(Region.Id regionId) {
+        requestBuilder.region(Possible.of(Optional.of(regionId).map(Region.Id::getValue)));
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
@@ -52,13 +52,24 @@ public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
     }
 
     /**
-     * Sets the voice region for the modified {@link Guild}.
+     * Sets the voice region for the modified {@link Guild}, automatic if null.
      *
-     * @param regionId The voice region for the guild.
+     * @param regionId The voice region for the guild, automatic if null.
      * @return This spec.
      */
     public GuildEditSpec setRegion(@Nullable Region.Id regionId) {
         requestBuilder.region(Possible.of(Optional.ofNullable(regionId).map(Region.Id::getValue)));
+        return this;
+    }
+
+    /**
+     * Sets the voice region for the modified {@link Guild}, automatic if null.
+     *
+     * @param regionId The voice region for the guild, automatic if null.
+     * @return This spec.
+     */
+    public GuildEditSpec setRegion(@Nullable String regionId) {
+        requestBuilder.region(Possible.of(Optional.ofNullable(regionId)));
         return this;
     }
 

--- a/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEditSpec.java
@@ -25,7 +25,6 @@ import discord4j.rest.util.Image;
 import discord4j.common.util.Snowflake;
 import reactor.util.annotation.Nullable;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
@@ -55,11 +54,11 @@ public class GuildEditSpec implements AuditSpec<GuildModifyRequest> {
     /**
      * Sets the voice region for the modified {@link Guild}.
      *
-     * @param region The voice region for the guild.
+     * @param regionId The voice region for the guild.
      * @return This spec.
      */
-    public GuildEditSpec setRegion(@Nullable Region region) {
-        requestBuilder.region(Possible.of(Optional.ofNullable(region).map(Region::getId)));
+    public GuildEditSpec setRegion(@Nullable Region.Id regionId) {
+        requestBuilder.region(Possible.of(Optional.ofNullable(regionId).map(Region.Id::getValue)));
         return this;
     }
 


### PR DESCRIPTION
**Description:**

- Some regions are marked as `deprecated` by Discord, should they be included in the enum?
- Is it ok to return `null` for `UNKNOWN` enum?
- The solution does not seem really future proof, if Discord releases a new region, we will have to update the enum. Maybe we can change the `setRegion` to take a String instead? But it will probably be confusing.
- `rtc_region` can be  empty when set to `automatic`, is it ok to return an empty mono in this case for `public Mono<Region> getRegion()`?
- Should these change be ported to `3.1.x`?

**Justification:** Fix https://github.com/Discord4J/Discord4J/issues/910