### PR TITLE
Send empty activities array instead of null for status update

### DIFF
--- a/core/src/main/java/discord4j/core/object/presence/ClientPresence.java
+++ b/core/src/main/java/discord4j/core/object/presence/ClientPresence.java
@@ -67,9 +67,10 @@ public class ClientPresence {
     }
 
     public static ClientPresence of(Status status, @Nullable ClientActivity activity) {
-        Optional<List<ActivityUpdateRequest>> activities = Optional.ofNullable(activity)
+        List<ActivityUpdateRequest> activities = Optional.ofNullable(activity)
                 .map(ClientActivity::getActivityUpdateRequest)
-                .map(Collections::singletonList);
+                .map(Collections::singletonList)
+                .orElse(Collections.emptyList());
 
         return new ClientPresence(StatusUpdate.builder()
                 .status(status.getValue())


### PR DESCRIPTION
**Description:**
When using the `ClientPresence` factory methods that don't accept a `ClientActivity`, build a `StatusUpdate` with `activities: []` instead of `activities: null`.

**Justification:**
Sending null results in an invalid session. https://github.com/Discord4J/discord-json/pull/96 makes the field no longer nullable, but this PR is not blocked by that one. Fixes https://github.com/Discord4J/Discord4J/issues/932