### PR TITLE
Properly terminate RequestSubscriber when a RequestStream is evicted

### DIFF
--- a/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
@@ -119,6 +119,10 @@ public class DefaultRouter implements Router {
                     return null;
                 }
                 if (stream.getResetAt().isBefore(now) && stream.countRequestsInFlight() < 1) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("Evicting RequestStream with bucket ID {}", bucketKey);
+                    }
+                    stream.stop();
                     return null;
                 }
                 return stream;

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -210,7 +210,6 @@ class RequestStream {
                     .retryWhen(serverErrorRetryFactory())
                     .doFinally(this::next)
                     .checkpoint("Request to " + clientRequest.getDescription() + " [RequestStream]")
-                    .takeUntilOther(stopCallback.asMono())
                     .subscribe(
                             response -> callback.emitValue(response, FAIL_FAST),
                             t -> {
@@ -244,7 +243,7 @@ class RequestStream {
 
         @Override
         protected void hookOnComplete() {
-            log.debug("[B:{}] RequestStream completed");
+            log.debug("[B:{}] RequestStream completed", id.toString());
         }
     }
 }


### PR DESCRIPTION
**Description:**

* When evicting a RequestStream, call a `.stop()` method that will trigger a callback terminating the underlying `RequestSubscriber`
* Fix race condition where the in-flight request counter could be zero when there could be actually one.

**Justification:**

#924 introduces eviction of unused request streams, but when using it in my bot I came across an issue where an in-flight request would be stuck forever. After some testing I realized the `RequestSubscriber` subscription was still alive for evicted request streams, so each eviction-recreation would spawn a new subscription and would end up creating congestion / thread starvation on the scheduler, which explains why my requests ended up hanging.