### PR TITLE
Add support for multiple embeds in a message

### DIFF
--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpec.java
@@ -55,7 +55,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
     @Nullable
     private String nonce;
     private boolean tts;
-    private EmbedData embed;
+    private List<EmbedData> embeds;
     private List<Tuple2<String, InputStream>> files;
     private AllowedMentionsData allowedMentionsData;
     private MessageReferenceData messageReferenceData;
@@ -96,14 +96,36 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
 
     /**
      * Sets rich content to the created {@link Message} in the form of an {@link Embed} object.
+     * <p>
+     * This method overrides any embeds added by {@link #addEmbed(Consumer)}.
+     *
+     * @param spec An {@link EmbedCreateSpec} consumer used to attach rich content when creating a message.
+     * @return This spec.
+     * @deprecated Use {@link #addEmbed(Consumer)}.
+     */
+    @Deprecated
+    public MessageCreateSpec setEmbed(Consumer<? super EmbedCreateSpec> spec) {
+        final EmbedCreateSpec mutatedSpec = new EmbedCreateSpec();
+        spec.accept(mutatedSpec);
+        embeds = Collections.singletonList(mutatedSpec.asRequest());
+        return this;
+    }
+
+    /**
+     * Adds an embed to the message.
+     * <p>
+     * A message may have up to 10 embeds.
      *
      * @param spec An {@link EmbedCreateSpec} consumer used to attach rich content when creating a message.
      * @return This spec.
      */
-    public MessageCreateSpec setEmbed(Consumer<? super EmbedCreateSpec> spec) {
+    public MessageCreateSpec addEmbed(Consumer<? super EmbedCreateSpec> spec) {
         final EmbedCreateSpec mutatedSpec = new EmbedCreateSpec();
         spec.accept(mutatedSpec);
-        embed = mutatedSpec.asRequest();
+        if (embeds == null) {
+            embeds = new ArrayList<>(1); // most common case is only 1 embed per message
+        }
+        embeds.add(mutatedSpec.asRequest());
         return this;
     }
 
@@ -186,7 +208,7 @@ public class MessageCreateSpec implements Spec<MultipartRequest> {
                 .content(content == null ? Possible.absent() : Possible.of(content))
                 .nonce(nonce == null ? Possible.absent() : Possible.of(nonce))
                 .tts(tts)
-                .embed(embed == null ? Possible.absent() : Possible.of(embed))
+                .embeds(embeds == null ? Possible.absent() : Possible.of(embeds))
                 .allowedMentions(allowedMentionsData == null ? Possible.absent() : Possible.of(allowedMentionsData))
                 .messageReference(messageReferenceData == null ? Possible.absent() : Possible.of(messageReferenceData))
                 .components(components == null ? Possible.absent() :

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpec.java
@@ -24,8 +24,7 @@ import discord4j.discordjson.possible.Possible;
 import discord4j.rest.util.AllowedMentions;
 import reactor.util.annotation.Nullable;
 
-import java.util.Arrays;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
@@ -36,7 +35,7 @@ import java.util.function.Consumer;
 public class MessageEditSpec implements Spec<MessageEditRequest> {
 
     private Possible<Optional<String>> content = Possible.absent();
-    private Possible<Optional<EmbedData>> embed = Possible.absent();
+    private Possible<Optional<List<EmbedData>>> embeds = Possible.absent();
     private Possible<Optional<AllowedMentionsData>> allowedMentions = Possible.absent();
     private Possible<Optional<Integer>> flags = Possible.absent();
 
@@ -56,16 +55,52 @@ public class MessageEditSpec implements Spec<MessageEditRequest> {
      *
      * @param spec An {@link EmbedCreateSpec} consumer used to attach rich content when creating a message.
      * @return This spec.
+     * @deprecated Use {@link #addEmbed(Consumer)} or {@link #removeEmbeds()}
      */
+    @Deprecated
     public MessageEditSpec setEmbed(@Nullable Consumer<? super EmbedCreateSpec> spec) {
         if (spec != null) {
             final EmbedCreateSpec mutatedSpec = new EmbedCreateSpec();
             spec.accept(mutatedSpec);
-            this.embed = Possible.of(Optional.of(mutatedSpec.asRequest()));
+            this.embeds = Possible.of(Optional.of(Collections.singletonList(mutatedSpec.asRequest())));
         } else {
-            this.embed = Possible.of(Optional.empty());
+            this.embeds = Possible.of(Optional.empty());
         }
 
+        return this;
+    }
+
+    /**
+     * Adds an embed to the edit request.
+     * <p>
+     * <b>Warning:</b> This method does <i>not</i> add an embed to the embeds already existing on the message. That is,
+     * if a message has embeds A and B, editing it with {@code addEmbed(C)} will result in the message having <i>only</i>
+     * embed C. To actually add embed C to the message, all embeds must be sent
+     * (i.e., do {@code addEmbed(A).addEmbed(B).addEmbed(C)}.
+     *
+     * @param spec An {@link EmbedCreateSpec} consumer used to attach rich content when creating a message.
+     * @return This spec.
+     */
+    public MessageEditSpec addEmbed(Consumer<? super EmbedCreateSpec> spec) {
+        final EmbedCreateSpec mutatedSpec = new EmbedCreateSpec();
+        spec.accept(mutatedSpec);
+
+        // if the Possible or the Optional is empty
+        if (this.embeds.isAbsent() || !this.embeds.get().isPresent()) {
+            this.embeds = Possible.of(Optional.of(new ArrayList<>(1)));
+        }
+
+        this.embeds.get().get().add(mutatedSpec.asRequest());
+        return this;
+    }
+
+    /**
+     * Removes all of the embeds on the message.
+     *
+     * @return This spec.
+     */
+    public MessageEditSpec removeEmbeds() {
+        this.embeds = Possible.of(Optional.empty());
         return this;
     }
 
@@ -101,7 +136,7 @@ public class MessageEditSpec implements Spec<MessageEditRequest> {
     public MessageEditRequest asRequest() {
         return MessageEditRequest.builder()
                 .content(content)
-                .embed(embed)
+                .embeds(embeds)
                 .allowedMentions(allowedMentions)
                 .flags(flags)
                 .build();

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.1.7-SNAPSHOT
 storesVersion=3.1.7
-discordJsonVersion=1.5.13
+discordJsonVersion=1.5.14-SNAPSHOT
 storesArtifact=com.discord4j:stores-jdk


### PR DESCRIPTION
**Description:**
* Deprecates `MessageCreateSpec#setEmbed(Consumer)`
* Adds `MessageCreateSpec#addEmbed(Consumer)`
* Deprecates `MessageEditSpec#setEmbed(Consumer)`
* Adds `MessageEditSpec#addEmbed(Consumer)`
  The docs of for carefully explain its potentially-counter-intuitive behavior.
* Adds `MessageEditSpec#removeEmbeds()`
  This is an alternative to `setEmbed(null)`.

I'm not entirely satisfied with the naming/behavior of `MessageEditSpec#addEmbed(Consumer)` or the existence of `MessageEditSpec#removeEmbeds()`, but I don't think it's worth trying to improve with new specs coming soon.

Depends on https://github.com/Discord4J/discord-json/pull/99

**Justification:**
https://github.com/discord/discord-api-docs/pull/3105