### PR TITLE
Add ComponentInteractEvent#getMessage()

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
@@ -57,6 +57,16 @@ public class ComponentInteractEvent extends InteractionCreateEvent {
     }
 
     /**
+     * Gets the message the component is on.
+     *
+     * @return The message the component is on.
+     */
+    public Message getMessage() {
+        return getInteraction().getMessage()
+                .orElseThrow(IllegalStateException::new); // components are always on messages
+    }
+
+    /**
      * Requests to respond to the interaction by immediately editing the message the button is on.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link InteractionApplicationCommandCallbackSpec} to be


### PR DESCRIPTION
**Description:** <!-- A description of the changes made in this pull request. -->
Add `ComponentInteractEvent#getMessage()`.

This is a convenience method like those in `SlashCommandEvent` which simply unwraps an `Optional` that should always be present. In this case, `Interaction#getMessage()` is always present for component interactions.

**Justification:**
User convenience. 