### PR TITLE
Region value can be null

### DIFF
--- a/core/src/main/java/discord4j/core/object/Region.java
+++ b/core/src/main/java/discord4j/core/object/Region.java
@@ -162,7 +162,7 @@ public final class Region implements DiscordObject {
          *
          * @param value The underlying value as represented by Discord.
          */
-        Id(final String value) {
+        Id(@Nullable final String value) {
             this.value = value;
         }
 
@@ -171,6 +171,7 @@ public final class Region implements DiscordObject {
          *
          * @return The underlying value as represented by Discord.
          */
+        @Nullable
         public String getValue() {
             return value;
         }


### PR DESCRIPTION
**Description:**
Add nullability annotations for the value in the Region enum.

**Justification:**

The `UNKNOWN` and `AUTOMATIC` regions have a null value. 