### PR TITLE
Add missing components field to new specs

### DIFF
--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
@@ -52,6 +52,7 @@
 package discord4j.core.spec;
 
 import discord4j.common.util.Snowflake;
+import discord4j.core.object.component.LayoutComponent;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.channel.MessageChannel;
 import discord4j.discordjson.json.MessageCreateRequest;
@@ -95,6 +96,8 @@ interface MessageCreateSpecGenerator extends Spec<MultipartRequest<MessageCreate
 
     Possible<Snowflake> messageReference();
 
+    Possible<List<LayoutComponent>> components();
+
     @Override
     default MultipartRequest<MessageCreateRequest> asRequest() {
         MessageCreateRequest json = MessageCreateRequest.builder()
@@ -109,6 +112,9 @@ interface MessageCreateSpecGenerator extends Spec<MultipartRequest<MessageCreate
                         ref -> MessageReferenceData.builder()
                                 .messageId(ref.asString())
                                 .build()))
+                .components(mapPossible(components(), components -> components.stream()
+                        .map(LayoutComponent::getData)
+                        .collect(Collectors.toList())))
                 .build();
         return MultipartRequest.ofRequestAndFiles(json, Stream.concat(files().stream(), fileSpoilers().stream())
                 .map(MessageCreateFields.File::asRequest)

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -17,6 +17,7 @@
 
 package discord4j.core.spec;
 
+import discord4j.core.object.component.LayoutComponent;
 import discord4j.core.object.entity.Message;
 import discord4j.discordjson.json.MessageEditRequest;
 import discord4j.discordjson.possible.Possible;
@@ -29,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static discord4j.core.spec.InternalSpecUtils.mapPossible;
 import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
 
 @Value.Immutable(singleton = true)
@@ -43,6 +43,8 @@ interface MessageEditSpecGenerator extends Spec<MessageEditRequest> {
 
     Possible<Optional<List<Message.Flag>>> flags();
 
+    Possible<Optional<List<LayoutComponent>>> components();
+
     @Override
     default MessageEditRequest asRequest() {
         return MessageEditRequest.builder()
@@ -54,6 +56,9 @@ interface MessageEditSpecGenerator extends Spec<MessageEditRequest> {
                 .flags(mapPossibleOptional(flags(), f -> f.stream()
                         .mapToInt(Message.Flag::getValue)
                         .reduce(0, (left, right) -> left | right)))
+                .components(mapPossibleOptional(components(), components -> components.stream()
+                        .map(LayoutComponent::getData)
+                        .collect(Collectors.toList())))
                 .build();
     }
 }


### PR DESCRIPTION
**Description:** Add components field to the new MessageCreateSpec and MessageEditSpec

**Justification:** They are only present in legacy specs currently