### PR TITLE
Deserialize interaction message on demand

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.event.domain.interaction;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.command.ApplicationCommandInteraction;
 import discord4j.core.object.command.Interaction;
@@ -31,6 +32,7 @@ import discord4j.rest.util.InteractionResponseType;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -61,12 +63,23 @@ public class ComponentInteractEvent extends InteractionCreateEvent {
 
     /**
      * Gets the message the component is on.
+     * <p>
+     * For ephemeral messages, only the ID is present. Use {@link #getMessageId()}
      *
      * @return The message the component is on.
      */
-    public Message getMessage() {
-        return getInteraction().getMessage()
-                .orElseThrow(IllegalStateException::new); // components are always on messages
+    public Optional<Message> getMessage() {
+        return getInteraction().getMessage();
+    }
+
+    /**
+     * Gets the ID of the message the component is on.
+     *
+     * @return The ID of the message the component is on.
+     */
+    public Snowflake getMessageId() {
+        return getInteraction().getMessageId()
+                .orElseThrow(IllegalStateException::new); // at least the ID is always present for component interactions
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.2.0-SNAPSHOT
-discordJsonVersion=1.6.6
+discordJsonVersion=1.6.7-SNAPSHOT
 storesVersion=3.2.1


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.0.x` or `3.1.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Makes `Interaction#getMessage()` filter out ephemeral messages, because Discord doesn't send a full message object. This also means `ComponentInteractEvent#getMessage()` is now `Optional`. `getMessageId()` has been added to both, and is always present for component interactions.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
Fixes #963

Depends on https://github.com/Discord4J/discord-json/pull/101