### PR TITLE
Added GUILD_JOIN_REQUEST_DELETE event to explicitly ignored events

### DIFF
--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
@@ -65,5 +65,6 @@ public abstract class EventNames {
     public static final String INTEGRATION_CREATE = "INTEGRATION_CREATE";
     public static final String INTEGRATION_UPDATE = "INTEGRATION_UPDATE";
     public static final String INTEGRATION_DELETE = "INTEGRATION_DELETE";
+    public static final String GUILD_JOIN_REQUEST_DELETE = "GUILD_JOIN_REQUEST_DELETE";
 
 }

--- a/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
+++ b/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
@@ -86,6 +86,7 @@ public class PayloadDeserializer extends StdDeserializer<GatewayPayload<?>> {
         dispatchTypes.put(EventNames.INTEGRATION_CREATE, null);
         dispatchTypes.put(EventNames.INTEGRATION_UPDATE, null);
         dispatchTypes.put(EventNames.INTEGRATION_DELETE, null);
+        dispatchTypes.put(EventNames.GUILD_JOIN_REQUEST_DELETE, null);
     }
 
     public PayloadDeserializer() {


### PR DESCRIPTION
Closes #967

**Description:** Add the "GUILD_JOIN_REQUEST_DELETE" event to explicitly ignored events

**Justification:** As mentionned on #967, "has existed for a while, but Discord hasn't documented it"