### PR TITLE
fix channel type in text channel request builder

### DIFF
--- a/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
@@ -53,7 +53,7 @@ interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
-                .type(Channel.Type.GUILD_NEWS.getValue())
+                .type(Channel.Type.GUILD_TEXT.getValue())
                 .name(name())
                 .topic(topic())
                 .rateLimitPerUser(rateLimitPerUser())


### PR DESCRIPTION
Description: Changes channel type in TextChannelCreateSpecGenerator.java from news to text

Justification: Fixes issue #969 