### PR TITLE
Add ApplicationCommandOptionType#NUMBER, ApplicationCommandInteractionOptionValue#asDouble() and ApplicationCommandOptionChoice#asDouble()

### DIFF
--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionOptionValue.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionOptionValue.java
@@ -72,6 +72,13 @@ public class ApplicationCommandInteractionOptionValue implements DiscordObject {
         return Long.parseLong(value);
     }
 
+    public double asDouble() {
+        if (type != ApplicationCommandOptionType.NUMBER.getValue()) {
+            throw new IllegalArgumentException("Option value cannot be converted as double");
+        }
+        return Double.parseDouble(value);
+    }
+
     public Snowflake asSnowflake() {
         if (type != ApplicationCommandOptionType.USER.getValue()
                 && type != ApplicationCommandOptionType.ROLE.getValue()

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandOptionChoice.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandOptionChoice.java
@@ -69,7 +69,7 @@ public class ApplicationCommandOptionChoice implements DiscordObject {
     /**
      * Gets the value of this choice.
      *
-     * @return The name of this choice.
+     * @return The value of this choice.
      */
     public Object getValue() {
         return data.value();
@@ -94,6 +94,19 @@ public class ApplicationCommandOptionChoice implements DiscordObject {
             return Long.parseLong(asString());
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Choice value cannot be converted to long", e);
+        }
+    }
+
+    /**
+     * Gets the value of this choice as a double.
+     *
+     * @return The value of this choice as a double.
+     */
+    public double asDouble() {
+        try {
+            return Double.parseDouble(asString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Choice value cannot be converted to double", e);
         }
     }
 

--- a/rest/src/main/java/discord4j/rest/util/ApplicationCommandOptionType.java
+++ b/rest/src/main/java/discord4j/rest/util/ApplicationCommandOptionType.java
@@ -31,7 +31,8 @@ public enum ApplicationCommandOptionType {
     USER(6),
     CHANNEL(7),
     ROLE(8),
-    MENTIONABLE(9);
+    MENTIONABLE(9),
+    NUMBER(10);
 
     /**
      * The underlying value as represented by Discord.
@@ -75,6 +76,7 @@ public enum ApplicationCommandOptionType {
             case 7: return CHANNEL;
             case 8: return ROLE;
             case 9: return MENTIONABLE;
+            case 10: return NUMBER;
             default: return UNKNOWN;
         }
     }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.0.x` or `3.1.x`
-->

**Description:** Adds `ApplicationCommandOptionType#NUMBER`, `ApplicationCommandInteractionOptionValue#asDouble()` and `ApplicationCommandOptionChoice#asDouble()` to support floating point numbers as an option for Slash Commands.

**Justification:** https://github.com/discord/discord-api-docs/pull/3455