### PR TITLE
Add ApplicationCommandInteraction::getResolved

### DIFF
--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteraction.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteraction.java
@@ -134,8 +134,26 @@ public class ApplicationCommandInteraction implements DiscordObject {
         return data.values().toOptional();
     }
 
+    /**
+     * Gets the converted users + roles + channels.
+     *
+     * @return The converted users + roles + channels.
+     */
+    public Optional<ApplicationCommandInteractionResolved> getResolved() {
+        return data.resolved().toOptional()
+                .map(data -> new ApplicationCommandInteractionResolved(gateway, data, guildId));
+    }
+
     @Override
     public GatewayDiscordClient getClient() {
         return gateway;
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationCommandInteraction{" +
+                "data=" + data +
+                ", guildId=" + guildId +
+                '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionResolved.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionResolved.java
@@ -1,0 +1,188 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.object.command;
+
+import discord4j.common.annotations.Experimental;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.DiscordObject;
+import discord4j.core.object.entity.Role;
+import discord4j.core.object.entity.User;
+import discord4j.discordjson.json.ApplicationCommandInteractionResolvedData;
+import reactor.util.annotation.Nullable;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * An object containing resolved objects from a Discord application command interaction.
+ *
+ * @see
+ * <a href="https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondata">
+ * Application Command Interaction Object</a>
+ */
+@Experimental
+public class ApplicationCommandInteractionResolved implements DiscordObject {
+
+    /** The gateway associated to this object. */
+    private final GatewayDiscordClient gateway;
+
+    /** The raw data as represented by Discord. */
+    private final ApplicationCommandInteractionResolvedData data;
+
+    @Nullable
+    private final Long guildId;
+
+    public ApplicationCommandInteractionResolved(GatewayDiscordClient gateway,
+                                                 ApplicationCommandInteractionResolvedData data,
+                                                 @Nullable Long guildId) {
+        this.gateway = Objects.requireNonNull(gateway);
+        this.data = Objects.requireNonNull(data);
+        this.guildId = guildId;
+    }
+
+    @Override
+    public GatewayDiscordClient getClient() {
+        return gateway;
+    }
+
+    /**
+     * Gets the raw data as represented by Discord.
+     *
+     * @return The raw data as represented by Discord.
+     */
+    public ApplicationCommandInteractionResolvedData getData() {
+        return data;
+    }
+
+    /**
+     * Gets the resolved channel with the given ID, if present.
+     *
+     * @param channelId the ID of the channel to get
+     * @return the resolved channel, if present
+     */
+    public Optional<ResolvedChannel> getChannel(Snowflake channelId) {
+        return Optional.ofNullable(getChannels().get(channelId));
+    }
+
+    /**
+     * Gets a map containing the resolved channels associated by their IDs
+     *
+     * @return the resolved channels
+     */
+    public Map<Snowflake, ResolvedChannel> getChannels() {
+        return data.channels().toOptional()
+                .map(map -> map.entrySet().stream()
+                        .map(entry -> Tuples.of(
+                                Snowflake.of(entry.getKey()),
+                                new ResolvedChannel(gateway, entry.getValue())))
+                        .collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2)))
+                .orElseGet(Collections::emptyMap);
+    }
+
+
+    /**
+     * Gets the resolved user with the given ID, if present.
+     *
+     * @param userId the ID of the user to get
+     * @return the resolved user, if present
+     */
+    public Optional<User> getUser(Snowflake userId) {
+        return Optional.ofNullable(getUsers().get(userId));
+    }
+
+    /**
+     * Gets a map containing the resolved users associated by their IDs
+     *
+     * @return the resolved users
+     */
+    public Map<Snowflake, User> getUsers() {
+        return data.users().toOptional()
+                .map(map -> map.entrySet().stream()
+                        .map(entry -> Tuples.of(
+                                Snowflake.of(entry.getKey()),
+                                new User(gateway, entry.getValue())))
+                        .collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2)))
+                .orElseGet(Collections::emptyMap);
+    }
+
+    /**
+     * Gets the resolved member with the given ID, if present.
+     *
+     * @param memberId the ID of the member to get
+     * @return the resolved member, if present
+     */
+    public Optional<ResolvedMember> getMember(Snowflake memberId) {
+        return Optional.ofNullable(getMembers().get(memberId));
+    }
+
+    /**
+     * Gets a map containing the resolved members associated by their IDs
+     *
+     * @return the resolved members
+     */
+    public Map<Snowflake, ResolvedMember> getMembers() {
+        return data.members().toOptional()
+                .map(map -> map.entrySet().stream()
+                        .map(entry -> {
+                            final Snowflake id = Snowflake.of(entry.getKey());
+                            return Tuples.of(id, new ResolvedMember(gateway, entry.getValue(),
+                                    getUser(id).map(User::getUserData).orElseThrow(IllegalStateException::new),
+                                    Optional.ofNullable(guildId).orElseThrow(IllegalStateException::new)));
+                        })
+                        .collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2)))
+                .orElseGet(Collections::emptyMap);
+    }
+
+    /**
+     * Gets the resolved role with the given ID, if present.
+     *
+     * @param roleId the ID of the role to get
+     * @return the resolved role, if present
+     */
+    public Optional<Role> getRole(Snowflake roleId) {
+        return Optional.ofNullable(getRoles().get(roleId));
+    }
+
+    /**
+     * Gets a map containing the resolved roles associated by their IDs
+     *
+     * @return the resolved roles
+     */
+    public Map<Snowflake, Role> getRoles() {
+        return data.roles().toOptional()
+                .map(map -> map.entrySet().stream()
+                        .map(entry -> Tuples.of(Snowflake.of(entry.getKey()), new Role(gateway, entry.getValue(),
+                                Optional.ofNullable(guildId).orElseThrow(IllegalStateException::new))))
+                        .collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2)))
+                .orElseGet(Collections::emptyMap);
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationCommandInteractionResolved{" +
+                "data=" + data +
+                ", guildId=" + guildId +
+                '}';
+    }
+}

--- a/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.object.command;
+
+import discord4j.common.annotations.Experimental;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.DiscordObject;
+import discord4j.core.object.entity.channel.Channel;
+import discord4j.core.retriever.EntityRetrievalStrategy;
+import discord4j.discordjson.json.ResolvedChannelData;
+import discord4j.rest.util.PermissionSet;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+/**
+ * A Discord channel that was resolved in a command.
+ *
+ * @see
+ * <a href="https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure">
+ * Application Command Interaction Data Resolved Object
+ * </a>
+ */
+@Experimental
+public class ResolvedChannel implements DiscordObject {
+
+    /** The gateway associated to this object. */
+    private final GatewayDiscordClient gateway;
+
+    /** The raw data as represented by Discord. */
+    private final ResolvedChannelData data;
+
+    /**
+     * Constructs a {@code ResolvedChannel} with an associated {@link GatewayDiscordClient} and Discord data.
+     *
+     * @param gateway The {@link GatewayDiscordClient} associated to this object, must be non-null.
+     * @param data The raw data as represented by Discord, must be non-null.
+     */
+    public ResolvedChannel(final GatewayDiscordClient gateway, final ResolvedChannelData data) {
+        this.gateway = Objects.requireNonNull(gateway);
+        this.data = Objects.requireNonNull(data);
+    }
+
+    public ResolvedChannelData getData() {
+        return data;
+    }
+
+    /**
+     * Gets the id of the channel.
+     *
+     * @return The id of the channel.
+     */
+    public Snowflake getId() {
+        return Snowflake.of(data.id());
+    }
+
+    /**
+     * Gets the name of the channel.
+     *
+     * @return The name of the channel.
+     */
+    public String getName() {
+        return data.name();
+    }
+
+    /**
+     * Gets the type of the channel.
+     *
+     * @return The type of the channel.
+     */
+    public Channel.Type getType() {
+        return Channel.Type.of(data.type());
+    }
+
+    /**
+     * Gets the computed permissions for the invoking user in the channel, including overwrites.
+     *
+     * @return The permissions of the channel.
+     */
+    public PermissionSet getEffectivePermissions() {
+        return PermissionSet.of(data.permissions());
+    }
+
+    /**
+     * Retrieves the full {@link Channel} instance corresponding to this resolved channel.
+     *
+     * @return a {@link Mono} where, upon successful completion, emits the full {@link Channel} instance corresponding
+     * to this resolved channel. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Channel> asChannel() {
+        return gateway.getChannelById(getId());
+    }
+
+    /**
+     * Retrieves the full {@link Channel} instance corresponding to this resolved channel, using the given retrieval
+     * strategy.
+     *
+     * @return a {@link Mono} where, upon successful completion, emits the full {@link Channel} instance corresponding
+     * to this resolved channel. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Channel> asChannel(EntityRetrievalStrategy retrievalStrategy) {
+        return gateway.withRetrievalStrategy(retrievalStrategy).getChannelById(getId());
+    }
+
+    @Override
+    public GatewayDiscordClient getClient() {
+        return gateway;
+    }
+
+    @Override
+    public String toString() {
+        return "ResolvedChannel{" +
+                "data=" + data +
+                '}';
+    }
+}

--- a/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
@@ -40,23 +40,32 @@ import java.util.Objects;
 @Experimental
 public class ResolvedChannel implements DiscordObject {
 
-    /** The gateway associated to this object. */
+    /**
+     * The gateway associated to this object.
+     */
     private final GatewayDiscordClient gateway;
 
-    /** The raw data as represented by Discord. */
+    /**
+     * The raw data as represented by Discord.
+     */
     private final ResolvedChannelData data;
 
     /**
      * Constructs a {@code ResolvedChannel} with an associated {@link GatewayDiscordClient} and Discord data.
      *
      * @param gateway The {@link GatewayDiscordClient} associated to this object, must be non-null.
-     * @param data The raw data as represented by Discord, must be non-null.
+     * @param data    The raw data as represented by Discord, must be non-null.
      */
     public ResolvedChannel(final GatewayDiscordClient gateway, final ResolvedChannelData data) {
         this.gateway = Objects.requireNonNull(gateway);
         this.data = Objects.requireNonNull(data);
     }
 
+    /**
+     * Returns the raw data as represented by Discord.
+     *
+     * @return the raw data
+     */
     public ResolvedChannelData getData() {
         return data;
     }
@@ -103,7 +112,7 @@ public class ResolvedChannel implements DiscordObject {
      * @return a {@link Mono} where, upon successful completion, emits the full {@link Channel} instance corresponding
      * to this resolved channel. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Channel> asChannel() {
+    public Mono<Channel> asFullChannel() {
         return gateway.getChannelById(getId());
     }
 
@@ -114,7 +123,7 @@ public class ResolvedChannel implements DiscordObject {
      * @return a {@link Mono} where, upon successful completion, emits the full {@link Channel} instance corresponding
      * to this resolved channel. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Channel> asChannel(EntityRetrievalStrategy retrievalStrategy) {
+    public Mono<Channel> asFullChannel(EntityRetrievalStrategy retrievalStrategy) {
         return gateway.withRetrievalStrategy(retrievalStrategy).getChannelById(getId());
     }
 

--- a/core/src/main/java/discord4j/core/object/command/ResolvedMember.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedMember.java
@@ -1,0 +1,195 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.object.command;
+
+import discord4j.common.annotations.Experimental;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.DiscordObject;
+import discord4j.core.object.entity.Member;
+import discord4j.core.retriever.EntityRetrievalStrategy;
+import discord4j.discordjson.json.ResolvedMemberData;
+import discord4j.discordjson.json.UserData;
+import discord4j.discordjson.possible.Possible;
+import discord4j.rest.util.PermissionSet;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A Discord member that was resolved in a command.
+ *
+ * @see
+ * <a href="https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure">
+ * Application Command Interaction Data Resolved Object
+ * </a>
+ */
+@Experimental
+public class ResolvedMember implements DiscordObject {
+
+    /** The gateway associated to this object. */
+    private final GatewayDiscordClient gateway;
+
+    /** The raw data as represented by Discord. */
+    private final ResolvedMemberData data;
+    private final UserData user;
+    private final long guildId;
+
+    /**
+     * Constructs a {@code ResolvedMember} with an associated {@link GatewayDiscordClient} and Discord data.
+     *  @param gateway The {@link GatewayDiscordClient} associated to this object, must be non-null.
+     * @param data The raw data as represented by Discord, must be non-null.
+     * @param user The raw user associated to the member, must be non-null.
+     * @param guildId
+     */
+    public ResolvedMember(final GatewayDiscordClient gateway, final ResolvedMemberData data, final UserData user,
+                          long guildId) {
+        this.gateway = Objects.requireNonNull(gateway);
+        this.data = Objects.requireNonNull(data);
+        this.user = Objects.requireNonNull(user);
+        this.guildId = guildId;
+    }
+
+    public ResolvedMemberData getData() {
+        return data;
+    }
+
+    /**
+     * Gets the ID of this member.
+     *
+     * @return The ID of this member;
+     */
+    public Snowflake getId() {
+        return Snowflake.of(user.id());
+    }
+
+    /**
+     * Gets the ID of the guild this user is associated to.
+     *
+     * @return The ID of the guild this user is associated to.
+     */
+    public Snowflake getGuildId() {
+        return Snowflake.of(guildId);
+    }
+
+    /**
+     * Gets the user's guild roles' IDs.
+     *
+     * @return The user's guild roles' IDs.
+     */
+    public Set<Snowflake> getRoleIds() {
+        return data.roles().stream()
+                .map(Snowflake::of)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Gets when the user joined the guild.
+     *
+     * @return When the user joined the guild.
+     */
+    public Instant getJoinTime() {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(data.joinedAt(), Instant::from);
+    }
+
+    /**
+     * Gets when the user started boosting the server, if present.
+     *
+     * @return When the user started boosting the server, if present.
+     */
+    public Optional<Instant> getPremiumTime() {
+        return Possible.flatOpt(data.premiumSince())
+                .map(timestamp -> DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(timestamp, Instant::from));
+    }
+
+    /**
+     * Gets the name that is displayed in client.
+     *
+     * @return The name that is displayed in client.
+     */
+    public String getDisplayName() {
+        return getNickname().orElse(user.username());
+    }
+
+    /**
+     * Gets the user's guild nickname (if one is set).
+     *
+     * @return The user's guild nickname (if one is set).
+     */
+    public Optional<String> getNickname() {
+        return Possible.flatOpt(data.nick());
+    }
+
+    /**
+     * Gets the <i>raw</i> nickname mention. This is the format utilized to directly mention another user (assuming the
+     * user exists in context of the mention).
+     *
+     * @return The <i>raw</i> nickname mention.
+     */
+    public String getNicknameMention() {
+        return "<@!" + getId().asString() + ">";
+    }
+
+    /**
+     * Gets the total permissions of the member in the channel, including overwrites.
+     *
+     * @return The permissions of the member.
+     */
+    public PermissionSet getEffectivePermissions() {
+        return PermissionSet.of(data.permissions().toOptional().orElseThrow(IllegalStateException::new));
+    }
+
+    /**
+     * Retrieves the full {@link Member} instance corresponding to this resolved member.
+     *
+     * @return a {@link Mono} where, upon successful completion, emits the full {@link Member} instance corresponding
+     * to this resolved member. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Member> asMember(Snowflake guildId) {
+        return gateway.getMemberById(guildId, getId());
+    }
+
+    /**
+     * Retrieves the full {@link Member} instance corresponding to this resolved member, using the given retrieval
+     * strategy.
+     *
+     * @return a {@link Mono} where, upon successful completion, emits the full {@link Member} instance corresponding to
+     * this resolved member. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Member> asMember(Snowflake guildId, EntityRetrievalStrategy retrievalStrategy) {
+        return gateway.withRetrievalStrategy(retrievalStrategy).getMemberById(guildId, getId());
+    }
+
+    @Override
+    public GatewayDiscordClient getClient() {
+        return gateway;
+    }
+
+    @Override
+    public String toString() {
+        return "ResolvedMember{" +
+                "data=" + data +
+                ", user=" + user +
+                '}';
+    }
+}

--- a/core/src/main/java/discord4j/core/object/command/ResolvedMember.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedMember.java
@@ -47,20 +47,25 @@ import java.util.stream.Collectors;
 @Experimental
 public class ResolvedMember implements DiscordObject {
 
-    /** The gateway associated to this object. */
+    /**
+     * The gateway associated to this object.
+     */
     private final GatewayDiscordClient gateway;
 
-    /** The raw data as represented by Discord. */
+    /**
+     * The raw data as represented by Discord.
+     */
     private final ResolvedMemberData data;
     private final UserData user;
     private final long guildId;
 
     /**
      * Constructs a {@code ResolvedMember} with an associated {@link GatewayDiscordClient} and Discord data.
-     *  @param gateway The {@link GatewayDiscordClient} associated to this object, must be non-null.
-     * @param data The raw data as represented by Discord, must be non-null.
-     * @param user The raw user associated to the member, must be non-null.
-     * @param guildId
+     *
+     * @param gateway The {@link GatewayDiscordClient} associated to this object, must be non-null.
+     * @param data    The raw data as represented by Discord, must be non-null.
+     * @param user    The raw user associated to the member, must be non-null.
+     * @param guildId the ID of the guild the user is member of
      */
     public ResolvedMember(final GatewayDiscordClient gateway, final ResolvedMemberData data, final UserData user,
                           long guildId) {
@@ -70,6 +75,11 @@ public class ResolvedMember implements DiscordObject {
         this.guildId = guildId;
     }
 
+    /**
+     * Returns the raw data as represented by Discord.
+     *
+     * @return the raw data
+     */
     public ResolvedMemberData getData() {
         return data;
     }
@@ -162,11 +172,11 @@ public class ResolvedMember implements DiscordObject {
     /**
      * Retrieves the full {@link Member} instance corresponding to this resolved member.
      *
-     * @return a {@link Mono} where, upon successful completion, emits the full {@link Member} instance corresponding
-     * to this resolved member. If an error is received, it is emitted through the {@code Mono}.
+     * @return a {@link Mono} where, upon successful completion, emits the full {@link Member} instance corresponding to
+     * this resolved member. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Member> asMember(Snowflake guildId) {
-        return gateway.getMemberById(guildId, getId());
+    public Mono<Member> asFullMember() {
+        return gateway.getMemberById(getGuildId(), getId());
     }
 
     /**
@@ -176,8 +186,8 @@ public class ResolvedMember implements DiscordObject {
      * @return a {@link Mono} where, upon successful completion, emits the full {@link Member} instance corresponding to
      * this resolved member. If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<Member> asMember(Snowflake guildId, EntityRetrievalStrategy retrievalStrategy) {
-        return gateway.withRetrievalStrategy(retrievalStrategy).getMemberById(guildId, getId());
+    public Mono<Member> asFullMember(EntityRetrievalStrategy retrievalStrategy) {
+        return gateway.withRetrievalStrategy(retrievalStrategy).getMemberById(getGuildId(), getId());
     }
 
     @Override
@@ -190,6 +200,7 @@ public class ResolvedMember implements DiscordObject {
         return "ResolvedMember{" +
                 "data=" + data +
                 ", user=" + user +
+                ", guildId=" + guildId +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:** Add `ApplicationCommandInteraction::getResolved` so we can access the users, channels and roles that are resolved by Discord from the user input when receiving a command interaction

**Justification:** `ApplicationCommandInteractionData::resolved` currently does not have an equivalent in d4j-core. The only way to get a channel, role or user from a command option value is to use the getters available in `ApplicationCommandInteractionOptionValue`, but those return a `Mono`, however by accessing the `resolved` field we can access those values without having to make additional requests.