### PR TITLE
Add 'Get Original Interaction Response' endpoint

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/interaction/InteractionCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/InteractionCreateEvent.java
@@ -181,6 +181,12 @@ public class InteractionCreateEvent extends Event {
         }
 
         @Override
+        public Mono<MessageData> getInitialResponse() {
+            return restClient.getWebhookService()
+                    .getWebhookMessage(applicationId, interactionData.token(), "@original");
+        }
+
+        @Override
         public Mono<MessageData> editInitialResponse(WebhookMessageEditRequest request) {
             return restClient.getWebhookService()
                     .modifyWebhookMessage(applicationId, interactionData.token(), "@original", request);

--- a/rest/src/main/java/discord4j/rest/interaction/InteractionOperations.java
+++ b/rest/src/main/java/discord4j/rest/interaction/InteractionOperations.java
@@ -131,6 +131,12 @@ class InteractionOperations implements RestInteraction, InteractionResponse, Gui
     // InteractionResponse
 
     @Override
+    public Mono<MessageData> getInitialResponse() {
+        return restClient.getWebhookService()
+                .getWebhookMessage(applicationId, interactionData.token(), "@original");
+    }
+
+    @Override
     public Mono<MessageData> editInitialResponse(WebhookMessageEditRequest request) {
         return restClient.getWebhookService()
                 .modifyWebhookMessage(applicationId, interactionData.token(), "@original", request);

--- a/rest/src/main/java/discord4j/rest/interaction/InteractionResponse.java
+++ b/rest/src/main/java/discord4j/rest/interaction/InteractionResponse.java
@@ -31,6 +31,15 @@ import reactor.core.publisher.Mono;
 public interface InteractionResponse {
 
     /**
+     * Return a {@link Mono} that upon subscription, will retrieve the initial response sent when accepting this
+     * interaction.
+     *
+     * @return a {@link Mono} where, upon successful completion, emits the original message. If an error is received,
+     * it is emitted through the {@code Mono}.
+     */
+    Mono<MessageData> getInitialResponse();
+
+    /**
      * Return a {@link Mono} that upon subscription, will modify the initial response sent when accepting this
      * interaction with the given raw request content.
      *

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -1052,6 +1052,12 @@ public abstract class Routes {
     public static final Route WEBHOOK_EXECUTE_GITHUB = Route.post("/webhooks/{webhook.id}/{webhook.token}/github");
 
     /**
+     * @see <a href="https://discord.com/developers/docs/resources/webhook#get-webhook-message">
+     * https://discord.com/developers/docs/resources/webhook#get-webhook-message</a>
+     */
+    public static final Route WEBHOOK_MESSAGE_GET = Route.get("/webhooks/{webhook.id}/{webhook.token}/messages/{message.id}");
+
+    /**
      * @see <a href="https://discord.com/developers/docs/resources/webhook#edit-webhook-message">
      * https://discord.com/developers/docs/resources/webhook#edit-webhook-message</a>
      */

--- a/rest/src/main/java/discord4j/rest/service/WebhookService.java
+++ b/rest/src/main/java/discord4j/rest/service/WebhookService.java
@@ -103,6 +103,12 @@ public class WebhookService extends RestService {
         }
     }
 
+    public Mono<MessageData> getWebhookMessage(long webhookId, String webhookToken, String messageId) {
+        return Routes.WEBHOOK_MESSAGE_GET.newRequest(webhookId, webhookToken, messageId)
+            .exchange(getRouter())
+            .bodyToMono(MessageData.class);
+    }
+
     public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId, WebhookMessageEditRequest request) {
         return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
             .body(request)


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.0.x` or `3.1.x`
-->

**Description:** Adds the [Get Webhook Message](https://discord.com/developers/docs/resources/webhook#get-webhook-message) route, which is used to [get the initial response](https://discord.com/developers/docs/interactions/receiving-and-responding#get-original-interaction-response) for interactions. 

**Justification:** This is necessary to filter for component interactions that occurred on slash command responses, for instance, responding to a button press on a slash command response.

Sorry about opening two PR's, I didn't know that I was supposed to target the oldest relevant branch.