### PR TITLE
Fix component interaction edit being sent as reply

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
@@ -23,7 +23,7 @@ import discord4j.core.object.command.Interaction;
 import discord4j.core.object.component.Button;
 import discord4j.core.object.component.MessageComponent;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.InteractionApplicationCommandEditMono;
+import discord4j.core.spec.InteractionApplicationCommandCallbackEditMono;
 import discord4j.core.spec.InteractionApplicationCommandCallbackSpec;
 import discord4j.core.spec.legacy.LegacyInteractionApplicationCommandCallbackSpec;
 import discord4j.discordjson.json.InteractionApplicationCommandCallbackData;
@@ -112,14 +112,14 @@ public class ComponentInteractEvent extends InteractionCreateEvent {
     /**
      * Requests to respond to the interaction by immediately editing the message the button is on. Properties specifying
      * how to edit the message can be set via the {@code withXxx} methods of the returned
-     * {@link InteractionApplicationCommandEditMono}.
+     * {@link InteractionApplicationCommandCallbackEditMono}.
      *
-     * @return A {@link InteractionApplicationCommandEditMono} where, upon successful completion, emits nothing;
+     * @return A {@link InteractionApplicationCommandCallbackEditMono} where, upon successful completion, emits nothing;
      * indicating the interaction response has been sent. If an error is received, it is emitted through the {@code
      * InteractionApplicationCommandCallbackMono}.
      */
-    public InteractionApplicationCommandEditMono edit() {
-        return InteractionApplicationCommandEditMono.of(this);
+    public InteractionApplicationCommandCallbackEditMono edit() {
+        return InteractionApplicationCommandCallbackEditMono.of(this);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ComponentInteractEvent.java
@@ -23,7 +23,7 @@ import discord4j.core.object.command.Interaction;
 import discord4j.core.object.component.Button;
 import discord4j.core.object.component.MessageComponent;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.InteractionApplicationCommandCallbackMono;
+import discord4j.core.spec.InteractionApplicationCommandEditMono;
 import discord4j.core.spec.InteractionApplicationCommandCallbackSpec;
 import discord4j.core.spec.legacy.LegacyInteractionApplicationCommandCallbackSpec;
 import discord4j.discordjson.json.InteractionApplicationCommandCallbackData;
@@ -112,14 +112,14 @@ public class ComponentInteractEvent extends InteractionCreateEvent {
     /**
      * Requests to respond to the interaction by immediately editing the message the button is on. Properties specifying
      * how to edit the message can be set via the {@code withXxx} methods of the returned
-     * {@link InteractionApplicationCommandCallbackMono}.
+     * {@link InteractionApplicationCommandEditMono}.
      *
-     * @return A {@link InteractionApplicationCommandCallbackMono} where, upon successful completion, emits nothing;
+     * @return A {@link InteractionApplicationCommandEditMono} where, upon successful completion, emits nothing;
      * indicating the interaction response has been sent. If an error is received, it is emitted through the {@code
      * InteractionApplicationCommandCallbackMono}.
      */
-    public InteractionApplicationCommandCallbackMono edit() {
-        return InteractionApplicationCommandCallbackMono.of(this);
+    public InteractionApplicationCommandEditMono edit() {
+        return InteractionApplicationCommandEditMono.of(this);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/event/domain/interaction/InteractionCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/InteractionCreateEvent.java
@@ -22,7 +22,7 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.Event;
 import discord4j.core.object.command.Interaction;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.InteractionApplicationCommandCallbackMono;
+import discord4j.core.spec.InteractionApplicationCommandReplyMono;
 import discord4j.core.spec.InteractionApplicationCommandCallbackSpec;
 import discord4j.core.spec.legacy.LegacyInteractionApplicationCommandCallbackSpec;
 import discord4j.discordjson.json.*;
@@ -138,27 +138,27 @@ public class InteractionCreateEvent extends Event {
     /**
      * Requests to respond to the interaction with a message. Properties specifying how to build the reply message to
      * the interaction can be set via the {@code withXxx} methods of the returned {@link
-     * InteractionApplicationCommandCallbackMono}.
+     * InteractionApplicationCommandReplyMono}.
      *
-     * @return A {@link InteractionApplicationCommandCallbackMono} where, upon successful completion, emits nothing;
+     * @return A {@link InteractionApplicationCommandReplyMono} where, upon successful completion, emits nothing;
      * indicating the interaction response has been sent. If an error is received, it is emitted through the {@code
      * InteractionApplicationCommandCallbackMono}.
      */
-    public InteractionApplicationCommandCallbackMono reply() {
-        return InteractionApplicationCommandCallbackMono.of(this);
+    public InteractionApplicationCommandReplyMono reply() {
+        return InteractionApplicationCommandReplyMono.of(this);
     }
 
     /**
      * Requests to respond to the interaction with a message initialized with the specified content. Properties
      * specifying how to build the reply message to the interaction can be set via the {@code withXxx} methods of the
-     * returned {@link InteractionApplicationCommandCallbackMono}.
+     * returned {@link InteractionApplicationCommandReplyMono}.
      *
      * @param content a string to populate the message with
-     * @return A {@link InteractionApplicationCommandCallbackMono} where, upon successful completion, emits nothing;
+     * @return A {@link InteractionApplicationCommandReplyMono} where, upon successful completion, emits nothing;
      * indicating the interaction response has been sent. If an error is received, it is emitted through the {@code
      * InteractionApplicationCommandCallbackMono}.
      */
-    public InteractionApplicationCommandCallbackMono reply(final String content) {
+    public InteractionApplicationCommandReplyMono reply(final String content) {
         return reply().withContent(content);
     }
 

--- a/core/src/main/java/discord4j/core/event/domain/interaction/InteractionCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/InteractionCreateEvent.java
@@ -22,7 +22,7 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.Event;
 import discord4j.core.object.command.Interaction;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.InteractionApplicationCommandReplyMono;
+import discord4j.core.spec.InteractionApplicationCommandCallbackReplyMono;
 import discord4j.core.spec.InteractionApplicationCommandCallbackSpec;
 import discord4j.core.spec.legacy.LegacyInteractionApplicationCommandCallbackSpec;
 import discord4j.discordjson.json.*;
@@ -138,27 +138,27 @@ public class InteractionCreateEvent extends Event {
     /**
      * Requests to respond to the interaction with a message. Properties specifying how to build the reply message to
      * the interaction can be set via the {@code withXxx} methods of the returned {@link
-     * InteractionApplicationCommandReplyMono}.
+     * InteractionApplicationCommandCallbackReplyMono}.
      *
-     * @return A {@link InteractionApplicationCommandReplyMono} where, upon successful completion, emits nothing;
+     * @return A {@link InteractionApplicationCommandCallbackReplyMono} where, upon successful completion, emits nothing;
      * indicating the interaction response has been sent. If an error is received, it is emitted through the {@code
      * InteractionApplicationCommandCallbackMono}.
      */
-    public InteractionApplicationCommandReplyMono reply() {
-        return InteractionApplicationCommandReplyMono.of(this);
+    public InteractionApplicationCommandCallbackReplyMono reply() {
+        return InteractionApplicationCommandCallbackReplyMono.of(this);
     }
 
     /**
      * Requests to respond to the interaction with a message initialized with the specified content. Properties
      * specifying how to build the reply message to the interaction can be set via the {@code withXxx} methods of the
-     * returned {@link InteractionApplicationCommandReplyMono}.
+     * returned {@link InteractionApplicationCommandCallbackReplyMono}.
      *
      * @param content a string to populate the message with
-     * @return A {@link InteractionApplicationCommandReplyMono} where, upon successful completion, emits nothing;
+     * @return A {@link InteractionApplicationCommandCallbackReplyMono} where, upon successful completion, emits nothing;
      * indicating the interaction response has been sent. If an error is received, it is emitted through the {@code
      * InteractionApplicationCommandCallbackMono}.
      */
-    public InteractionApplicationCommandReplyMono reply(final String content) {
+    public InteractionApplicationCommandCallbackReplyMono reply(final String content) {
         return reply().withContent(content);
     }
 

--- a/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
@@ -17,6 +17,7 @@
 
 package discord4j.core.spec;
 
+import discord4j.core.event.domain.interaction.ComponentInteractEvent;
 import discord4j.core.event.domain.interaction.InteractionCreateEvent;
 import discord4j.core.object.component.LayoutComponent;
 import discord4j.core.object.entity.Message;
@@ -66,7 +67,7 @@ interface InteractionApplicationCommandCallbackSpecGenerator extends Spec<Intera
 
 @SuppressWarnings("immutables:subtype")
 @Value.Immutable(builder = false)
-abstract class InteractionApplicationCommandCallbackMonoGenerator extends Mono<Void>
+abstract class InteractionApplicationCommandReplyMonoGenerator extends Mono<Void>
         implements InteractionApplicationCommandCallbackSpecGenerator {
 
     abstract InteractionCreateEvent event();
@@ -74,6 +75,22 @@ abstract class InteractionApplicationCommandCallbackMonoGenerator extends Mono<V
     @Override
     public void subscribe(CoreSubscriber<? super Void> actual) {
         event().reply(InteractionApplicationCommandCallbackSpec.copyOf(this)).subscribe(actual);
+    }
+
+    @Override
+    public abstract String toString();
+}
+
+@SuppressWarnings("immutables:subtype")
+@Value.Immutable(builder = false)
+abstract class InteractionApplicationCommandEditMonoGenerator extends Mono<Void>
+        implements InteractionApplicationCommandCallbackSpecGenerator {
+
+    abstract ComponentInteractEvent event();
+
+    @Override
+    public void subscribe(CoreSubscriber<? super Void> actual) {
+        event().edit(InteractionApplicationCommandCallbackSpec.copyOf(this)).subscribe(actual);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
@@ -67,7 +67,7 @@ interface InteractionApplicationCommandCallbackSpecGenerator extends Spec<Intera
 
 @SuppressWarnings("immutables:subtype")
 @Value.Immutable(builder = false)
-abstract class InteractionApplicationCommandReplyMonoGenerator extends Mono<Void>
+abstract class InteractionApplicationCommandCallbackReplyMonoGenerator extends Mono<Void>
         implements InteractionApplicationCommandCallbackSpecGenerator {
 
     abstract InteractionCreateEvent event();
@@ -83,7 +83,7 @@ abstract class InteractionApplicationCommandReplyMonoGenerator extends Mono<Void
 
 @SuppressWarnings("immutables:subtype")
 @Value.Immutable(builder = false)
-abstract class InteractionApplicationCommandEditMonoGenerator extends Mono<Void>
+abstract class InteractionApplicationCommandCallbackEditMonoGenerator extends Mono<Void>
         implements InteractionApplicationCommandCallbackSpecGenerator {
 
     abstract ComponentInteractEvent event();


### PR DESCRIPTION
**Description:** 
Previously, `InteractionApplicationCommandCallbackMono` always used `InteractionCreateEvent#reply` when subscribed to. This meant that `ComponentInteractEvent#edit()` (which returned `InteractionApplicationCommandCallbackMono`) would actually reply to the interaction (use `CHANNEL_MESSAGE_WITH_SOURCE`) instead of editing (use `UPDATE_MESSAGE`). 

This PR solves this by
* Renaming `InteractionApplicationCommandCallbackMono` to `InteractionApplicationCommandCallbackReplyMono`
* Adding `InteractionApplicationCommandCallbackEditMono`

**Justification:**
Fixes #987 