### PR TITLE
Add missed channel thread types to #getChannel

### DIFF
--- a/core/src/main/java/discord4j/core/util/EntityUtil.java
+++ b/core/src/main/java/discord4j/core/util/EntityUtil.java
@@ -62,6 +62,10 @@ public final class EntityUtil {
             case GUILD_CATEGORY: return new Category(gateway, data);
             case GUILD_NEWS: return new NewsChannel(gateway, data);
             case GUILD_STORE: return new StoreChannel(gateway, data);
+            case GUILD_NEWS_THREAD:
+            case GUILD_PUBLIC_THREAD:
+            case GUILD_PRIVATE_THREAD:
+                return new ThreadChannel(gateway, data);
             default: return throwUnsupportedDiscordValue(data);
         }
     }


### PR DESCRIPTION
**Description:** Adds missed switch branches to `#getChannel` factory method.

**Justification:** If send message in the channel thread throws `java.lang.UnsupportedOperationException` exception.
