### PR TITLE
Add #getData to PermissionOverwrite object

### DIFF
--- a/core/src/main/java/discord4j/core/object/PermissionOverwrite.java
+++ b/core/src/main/java/discord4j/core/object/PermissionOverwrite.java
@@ -16,10 +16,11 @@
  */
 package discord4j.core.object;
 
+import discord4j.common.util.Snowflake;
 import discord4j.core.object.entity.Member;
 import discord4j.core.object.entity.Role;
+import discord4j.discordjson.json.OverwriteData;
 import discord4j.rest.util.PermissionSet;
-import discord4j.common.util.Snowflake;
 
 import java.util.Optional;
 
@@ -59,6 +60,20 @@ public class PermissionOverwrite {
         this.denied = denied;
         this.targetId = targetId;
         this.type = type;
+    }
+
+    /**
+     * Map this {@link PermissionOverwrite} object to a {@link OverwriteData} JSON.
+     *
+     * @return JSON object.
+     */
+    public OverwriteData getData() {
+        return OverwriteData.builder()
+                .id(targetId)
+                .type(type.getValue())
+                .allow(allowed)
+                .deny(denied)
+                .build();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/spec/CategoryCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/CategoryCreateSpecGenerator.java
@@ -27,6 +27,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.*;
 
@@ -44,7 +45,9 @@ interface CategoryCreateSpecGenerator extends AuditSpec<ChannelCreateRequest> {
         return ChannelCreateRequest.builder()
                 .name(name())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/CategoryEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/CategoryEditSpecGenerator.java
@@ -26,8 +26,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
+import java.util.stream.Collectors;
 
 @Value.Immutable(singleton = true)
 interface CategoryEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
@@ -43,7 +42,9 @@ interface CategoryEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
         return ChannelModifyRequest.builder()
                 .name(name())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
@@ -58,8 +58,8 @@ interface InteractionApplicationCommandCallbackSpecGenerator extends Spec<Intera
                         .map(EmbedCreateSpec::asRequest)
                         .collect(Collectors.toList())))
                 .components(mapPossible(components(), components -> components.stream()
-                    .map(LayoutComponent::getData)
-                    .collect(Collectors.toList())))
+                        .map(LayoutComponent::getData)
+                        .collect(Collectors.toList())))
                 .allowedMentions(mapPossible(allowedMentions(), AllowedMentions::toData))
                 .build();
     }

--- a/core/src/main/java/discord4j/core/spec/InteractionFollowupCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionFollowupCreateSpecGenerator.java
@@ -80,8 +80,8 @@ interface InteractionFollowupCreateSpecGenerator extends Spec<MultipartRequest<F
                 .embeds(embeds().stream().map(EmbedCreateSpec::asRequest).collect(Collectors.toList()))
                 .allowedMentions(mapPossible(allowedMentions(), AllowedMentions::toData))
                 .components(mapPossible(components(), components -> components.stream()
-                    .map(LayoutComponent::getData)
-                    .collect(Collectors.toList())))
+                        .map(LayoutComponent::getData)
+                        .collect(Collectors.toList())))
                 .flags(mapPossible(ephemeral(), eph -> eph ? Message.Flag.EPHEMERAL.getFlag() : 0))
                 .build();
         return MultipartRequest.ofRequestAndFiles(request, Stream.concat(files().stream(), fileSpoilers().stream())

--- a/core/src/main/java/discord4j/core/spec/InternalSpecUtils.java
+++ b/core/src/main/java/discord4j/core/spec/InternalSpecUtils.java
@@ -16,8 +16,6 @@
  */
 package discord4j.core.spec;
 
-import discord4j.core.object.PermissionOverwrite;
-import discord4j.discordjson.json.OverwriteData;
 import discord4j.discordjson.possible.Possible;
 import discord4j.rest.util.Multimap;
 import reactor.util.annotation.Nullable;
@@ -26,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 final class InternalSpecUtils {
 
@@ -42,7 +39,7 @@ final class InternalSpecUtils {
     static <T, R> R mapNullable(@Nullable T value, Function<? super T, ? extends R> mapper) {
         return value != null ? mapper.apply(value) : null;
     }
-    
+
     static void putIfNotNull(Map<String, Object> map, String key, @Nullable Object value) {
         if (value != null) {
             map.put(key, value);
@@ -68,16 +65,5 @@ final class InternalSpecUtils {
     static <T, R> Possible<Optional<R>> mapPossibleOptional(Possible<Optional<T>> value,
                                                            Function<? super T, ? extends R> mapper) {
         return value.isAbsent() ? Possible.absent() : Possible.of(value.get().map(mapper));
-    }
-
-    static Possible<List<OverwriteData>> mapPossibleOverwrites(Possible<List<PermissionOverwrite>> possible) {
-        return mapPossible(possible, po -> po.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
-                .collect(Collectors.toList()));
     }
 }

--- a/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
@@ -29,9 +29,9 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.mapPossible;
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
 
 @Value.Immutable
 interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest> {
@@ -55,7 +55,9 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
                 .name(name())
                 .topic(topic())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .nsfw(nsfw())
                 .build();

--- a/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
@@ -28,9 +28,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
 
 @Value.Immutable(singleton = true)
 interface NewsChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
@@ -54,7 +54,9 @@ interface NewsChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
                 .position(position())
                 .topic(topic())
                 .nsfw(nsfw())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .build();
     }

--- a/core/src/main/java/discord4j/core/spec/StoreChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StoreChannelEditSpecGenerator.java
@@ -28,9 +28,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
 
 @Value.Immutable(singleton = true)
 interface StoreChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
@@ -48,7 +48,9 @@ interface StoreChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
         return ChannelModifyRequest.builder()
                 .name(name())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .build();
     }

--- a/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
@@ -29,9 +29,9 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.mapPossible;
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
 
 @Value.Immutable
 interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest> {
@@ -58,7 +58,9 @@ interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
                 .topic(topic())
                 .rateLimitPerUser(rateLimitPerUser())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .nsfw(nsfw())
                 .build();

--- a/core/src/main/java/discord4j/core/spec/TextChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelEditSpecGenerator.java
@@ -28,9 +28,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
 
 @Value.Immutable(singleton = true)
 interface TextChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
@@ -57,7 +57,9 @@ interface TextChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
                 .topic(topic())
                 .rateLimitPerUser(rateLimitPerUser())
                 .nsfw(nsfw())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .build();
     }

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
@@ -29,9 +29,9 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.mapPossible;
-import static discord4j.core.spec.InternalSpecUtils.mapPossibleOverwrites;
 
 @Value.Immutable
 interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest> {
@@ -56,7 +56,9 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
                 .bitrate(bitrate())
                 .userLimit(userLimit())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .build();
     }

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static discord4j.core.spec.InternalSpecUtils.*;
 
@@ -57,7 +58,9 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
                 .bitrate(bitrate())
                 .userLimit(userLimit())
                 .position(position())
-                .permissionOverwrites(mapPossibleOverwrites(permissionOverwrites()))
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .rtcRegion(rtcRegion())
                 .videoQualityMode(mapPossibleOptional(videoQualityMode(), VoiceChannel.Mode::getValue))

--- a/core/src/main/java/discord4j/core/spec/WebhookExecuteSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookExecuteSpecGenerator.java
@@ -78,8 +78,8 @@ interface WebhookExecuteSpecGenerator extends Spec<MultipartRequest<WebhookExecu
                 .embeds(embeds().stream().map(EmbedCreateSpec::asRequest).collect(Collectors.toList()))
                 .allowedMentions(mapPossible(allowedMentions(), AllowedMentions::toData))
                 .components(mapPossible(components(), components -> components.stream()
-                    .map(LayoutComponent::getData)
-                    .collect(Collectors.toList())))
+                        .map(LayoutComponent::getData)
+                        .collect(Collectors.toList())))
                 .build();
         return MultipartRequest.ofRequestAndFiles(request, Stream.concat(files().stream(), fileSpoilers().stream())
                 .map(MessageCreateFields.File::asRequest)

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyCategoryCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyCategoryCreateSpec.java
@@ -66,12 +66,7 @@ public class LegacyCategoryCreateSpec implements LegacyAuditSpec<ChannelCreateRe
      */
     public LegacyCategoryCreateSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyCategoryEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyCategoryEditSpec.java
@@ -64,12 +64,7 @@ public class LegacyCategoryEditSpec implements LegacyAuditSpec<ChannelModifyRequ
      */
     public LegacyCategoryEditSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyNewsChannelCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyNewsChannelCreateSpec.java
@@ -83,12 +83,7 @@ public class LegacyNewsChannelCreateSpec implements LegacyAuditSpec<ChannelCreat
      */
     public LegacyNewsChannelCreateSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyNewsChannelEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyNewsChannelEditSpec.java
@@ -93,12 +93,7 @@ public class LegacyNewsChannelEditSpec implements LegacyAuditSpec<ChannelModifyR
      */
     public LegacyNewsChannelEditSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyStoreChannelEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyStoreChannelEditSpec.java
@@ -68,12 +68,7 @@ public class LegacyStoreChannelEditSpec implements LegacyAuditSpec<ChannelModify
      */
     public LegacyStoreChannelEditSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyTextChannelCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyTextChannelCreateSpec.java
@@ -97,12 +97,7 @@ public class LegacyTextChannelCreateSpec implements LegacyAuditSpec<ChannelCreat
      */
     public LegacyTextChannelCreateSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyTextChannelEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyTextChannelEditSpec.java
@@ -94,12 +94,7 @@ public class LegacyTextChannelEditSpec implements LegacyAuditSpec<ChannelModifyR
      */
     public LegacyTextChannelEditSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyVoiceChannelCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyVoiceChannelCreateSpec.java
@@ -96,12 +96,7 @@ public class LegacyVoiceChannelCreateSpec implements LegacyAuditSpec<ChannelCrea
      */
     public LegacyVoiceChannelCreateSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyVoiceChannelEditSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyVoiceChannelEditSpec.java
@@ -73,12 +73,7 @@ public class LegacyVoiceChannelEditSpec implements LegacyAuditSpec<ChannelModify
      */
     public LegacyVoiceChannelEditSpec setPermissionOverwrites(Set<? extends PermissionOverwrite> permissionOverwrites) {
         List<OverwriteData> raw = permissionOverwrites.stream()
-                .map(o -> OverwriteData.builder()
-                        .id(o.getTargetId().asString())
-                        .type(o.getType().getValue())
-                        .allow(o.getAllowed().getRawValue())
-                        .deny(o.getDenied().getRawValue())
-                        .build())
+                .map(PermissionOverwrite::getData)
                 .collect(Collectors.toList());
 
         requestBuilder.permissionOverwrites(raw);


### PR DESCRIPTION
**Description:** Adds missing `#getData` method to `PermissionOverwrite` and replace manual mapping of the object to json data with method usage.

**Justification:** There are a lot of places where this method would be useful.