### PR TITLE
Fix performance issue when adding list elements to cached guilds

### DIFF
--- a/common/src/main/java/discord4j/common/store/impl/LocalStoreLayout.java
+++ b/common/src/main/java/discord4j/common/store/impl/LocalStoreLayout.java
@@ -43,9 +43,9 @@ import java.util.stream.Collectors;
 import static discord4j.common.store.impl.ImplUtils.*;
 
 /**
- * A {@link StoreLayout} that stores entities in the heap of the local JVM. This implementation is entirely
- * thread-safe: atomicity guarantees are made so that the cache won't be set in an inconsistent state if two events
- * are received concurrently. However, it is still up to the user to ensure that events are received in the right order.
+ * A {@link StoreLayout} that stores entities in the heap of the local JVM. This implementation is entirely thread-safe:
+ * atomicity guarantees are made so that the cache won't be set in an inconsistent state if two events are received
+ * concurrently. However, it is still up to the user to ensure that events are received in the right order.
  */
 public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataUpdater {
 
@@ -59,7 +59,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
     private final ConcurrentMap<Long, WithUser<ImmutableEmojiData>> emojis =
             new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Long, ImmutableGuildData> guilds = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, WrappedGuildData> guilds = new ConcurrentHashMap<>();
 
     private final ConcurrentMap<Long2, WithUser<ImmutableMemberData>> members =
             new ConcurrentHashMap<>();
@@ -240,12 +240,12 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
 
     @Override
     public Flux<GuildData> getGuilds() {
-        return Flux.fromIterable(guilds.values());
+        return Flux.fromIterable(guilds.values()).map(WrappedGuildData::unwrap);
     }
 
     @Override
     public Mono<GuildData> getGuildById(long guildId) {
-        return Mono.justOrEmpty(guilds.get(guildId));
+        return Mono.justOrEmpty(guilds.get(guildId)).map(WrappedGuildData::unwrap);
     }
 
     @Override
@@ -386,8 +386,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
                     GuildContent guildContent = computeGuildContent(guildId);
                     guildContent.channelIds.remove(channelId.asLong());
                     ifNonNullDo(contentByChannel.get(channelId.asLong()), ChannelContent::dispose);
-                    guilds.computeIfPresent(guildId, (k, guild) -> guild.withChannels(
-                            remove(guild.channels(), channelId)));
+                    ifNonNullDo(guilds.get(guildId), guild -> guild.getChannels().remove(channelId));
                 })).thenReturn(data);
     }
 
@@ -416,7 +415,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
                     .members(Collections.emptyList())
                     .channels(Collections.emptyList())
                     .build();
-            guilds.put(guildId, guild);
+            guilds.put(guildId, new WrappedGuildData(guild));
             roles.forEach(role -> saveRole(guildId, role));
             emojis.forEach(emoji -> saveEmoji(guildId, emoji));
             members.forEach(member -> saveMember(guildId, member));
@@ -443,8 +442,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
                     .map(WithUser::get)
                     .collect(Collectors.toSet());
             emojis.keySet().removeAll(content.emojiIds);
-            guilds.computeIfPresent(guildId, (k, guild) -> guild.withEmojis(
-                    removeAllIds(guild.emojis(), content.emojiIds)));
+            ifNonNullDo(guilds.get(guildId), guild -> guild.getEmojis().clear());
             content.emojiIds.clear();
             dispatch.emojis().forEach(emoji -> saveEmoji(guildId, emoji));
             return old;
@@ -464,8 +462,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
             Long2 memberId = new Long2(guildId, userId);
             GuildContent guildContent = computeGuildContent(guildId);
             guildContent.memberIds.remove(memberId);
-            guilds.computeIfPresent(guildId, (k, guild) -> guild.withMembers(
-                    remove(guild.members(), Id.of(memberId.b))));
+            ifNonNullDo(guilds.get(guildId), guild -> guild.getMembers().remove(Id.of(memberId.b)));
             return ifNonNullMap(members.remove(memberId), WithUser::get);
         });
     }
@@ -513,9 +510,9 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         return Mono.fromCallable(() -> {
             GuildContent guildContent = computeGuildContent(guildId);
             guildContent.roleIds.remove(roleId.asLong());
-            guilds.computeIfPresent(guildId, (k, guild) -> guild.withRoles(remove(guild.roles(), roleId)));
+            ifNonNullDo(guilds.get(guildId), guild -> guild.getRoles().remove(roleId));
             guildContent.memberIds.forEach(id2 -> members.computeIfPresent(id2,
-                            (k, member) -> member.update(m -> m.withRoles(remove(m.roles(), roleId)))));
+                    (k, member) -> member.update(m -> m.withRoles(remove(m.roles(), roleId)))));
             return roles.remove(roleId.asLong());
         });
     }
@@ -529,12 +526,12 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
     public Mono<GuildData> onGuildUpdate(int shardIndex, GuildUpdate dispatch) {
         long guildId = dispatch.guild().id().asLong();
         return Mono.fromCallable(() -> {
-            GuildData old = guilds.get(guildId);
-            guilds.computeIfPresent(guildId, (k, oldGuild) -> GuildData.builder()
-                    .from(oldGuild)
+            WrappedGuildData old = guilds.get(guildId);
+            guilds.computeIfPresent(guildId, (k, oldGuild) -> new WrappedGuildData(GuildData.builder()
+                    .from(oldGuild.unwrap())
                     .from(dispatch.guild())
-                    .build());
-            return old;
+                    .build()));
+            return ifNonNullMap(old, WrappedGuildData::unwrap);
         });
     }
 
@@ -562,7 +559,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         Long2 id = new Long2(channelId, messageId);
         return Mono.fromRunnable(() -> {
             ChannelContent channelContent = computeChannelContent(id.a);
-            channels.computeIfPresent(id.a, (k, channel) -> channel.withLastMessageId(id.b));
+            channels.computeIfPresent(id.a, (k, channel) -> channel.withLastMessageIdOrNull(id.b));
             channelContent.messageIds.add(id);
             AtomicReference<ImmutableUserData> userRef = computeUserRef(id.b, message,
                     (m, old) -> ImmutableUserData.copyOf(m.author()));
@@ -670,7 +667,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
     @Override
     public Mono<Void> onReady(Ready dispatch) {
         return Mono.fromRunnable(() -> {
-            int[] shardInfo = dispatch.shard().toOptional().orElseGet(() -> new int[] {0, 1});
+            int[] shardInfo = dispatch.shard().toOptional().orElseGet(() -> new int[]{0, 1});
             if (selfUser == null) {
                 ImmutableUserData userData = ImmutableUserData.copyOf(dispatch.user());
                 selfUser = new AtomicReference<>(userData);
@@ -723,26 +720,28 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         return contentByChannel.computeIfAbsent(channelId, ChannelContent::new);
     }
 
-    private @Nullable ChannelData saveChannel(long guildId, ChannelData channel) {
+    @Nullable
+    private ChannelData saveChannel(long guildId, ChannelData channel) {
         long channelId = channel.id().asLong();
         GuildContent guildContent = computeGuildContent(guildId);
         guildContent.channelIds.add(channelId);
-        guilds.computeIfPresent(guildId, (k, guild) -> guild.withChannels(add(guild.channels(), Id.of(channelId))));
+        ifNonNullDo(guilds.get(guildId), guild -> guild.getChannels().add(Id.of(channelId)));
         return channels.put(channelId, ImmutableChannelData.copyOf(channel).withGuildId(guildId));
     }
 
-    private @Nullable RoleData saveRole(long guildId, RoleData role) {
+    @Nullable
+    private RoleData saveRole(long guildId, RoleData role) {
         long roleId = role.id().asLong();
         GuildContent guildContent = computeGuildContent(guildId);
         guildContent.roleIds.add(roleId);
-        guilds.computeIfPresent(guildId, (k, guild) -> guild.withRoles(add(guild.roles(), Id.of(roleId))));
+        ifNonNullDo(guilds.get(guildId), guild -> guild.getRoles().add(Id.of(roleId)));
         return roles.put(roleId, ImmutableRoleData.copyOf(role));
     }
 
     private void saveEmoji(long guildId, EmojiData emoji) {
         emoji.id().map(Id::asLong).ifPresent(emojiId -> {
             computeGuildContent(guildId).emojiIds.add(emojiId);
-            guilds.computeIfPresent(guildId, (k, guild) -> guild.withEmojis(add(guild.emojis(), Id.of(emojiId))));
+            ifNonNullDo(guilds.get(guildId), guild -> guild.getEmojis().add(Id.of(emojiId)));
             AtomicReference<ImmutableUserData> userRef = ifNonNullMap(
                     emoji.user().toOptional().map(user -> user.id().asLong()).orElse(null),
                     userId -> computeUserRef(userId, emoji, (e, u) -> ImmutableUserData.copyOf(e.user().get())));
@@ -755,14 +754,15 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         Long2 memberId = new Long2(guildId, member.user().id().asLong());
         GuildContent guildContent = computeGuildContent(guildId);
         guildContent.memberIds.add(memberId);
-        guilds.computeIfPresent(guildId, (k, guild) -> guild.withMembers(add(guild.members(), Id.of(memberId.b))));
+        ifNonNullDo(guilds.get(guildId), guild -> guild.getMembers().add(Id.of(memberId.b)));
         AtomicReference<ImmutableUserData> userRef = computeUserRef(memberId.b, member,
                 (m, u) -> ImmutableUserData.copyOf(m.user()));
         members.put(memberId, new WithUser<>(ImmutableMemberData.copyOf(member).withUser(EmptyUser.INSTANCE), userRef,
                 ImmutableMemberData::withUser));
     }
 
-    private @Nullable PresenceAndUserData savePresence(long guildId, PresenceData presence) {
+    @Nullable
+    private PresenceAndUserData savePresence(long guildId, PresenceData presence) {
         Long2 presenceId = new Long2(guildId, presence.user().id().asLong());
         ImmutableUserData oldUser = ifNonNullMap(users.get(presenceId.b), AtomicReference::get);
         return ifNonNullMap(computeUserRef(presenceId.b, presence, LocalStoreLayout::userFromPresence), userRef -> {
@@ -783,8 +783,8 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         });
     }
 
-    private static @Nullable ImmutableUserData userFromPresence(PresenceData newPresence,
-                                                                @Nullable ImmutableUserData oldUser) {
+    @Nullable
+    private static ImmutableUserData userFromPresence(PresenceData newPresence, @Nullable ImmutableUserData oldUser) {
         if (oldUser == null) return null;
         ImmutablePartialUserData partialUserData = ImmutablePartialUserData.copyOf(newPresence.user());
         return UserData.builder()
@@ -792,12 +792,15 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
                 .username(partialUserData.usernameOrElse(oldUser.username()))
                 .discriminator(partialUserData.discriminatorOrElse(oldUser.discriminator()))
                 .avatar(or(Possible.flatOpt(partialUserData.avatar()), oldUser::avatar))
-                .banner(Possible.of(or(Possible.flatOpt(partialUserData.banner()), () -> Possible.flatOpt(oldUser.banner()))))
-                .accentColor(Possible.of(or(Possible.flatOpt(partialUserData.accentColor()), () -> Possible.flatOpt(oldUser.accentColor()))))
+                .banner(Possible.of(or(Possible.flatOpt(partialUserData.banner()),
+                        () -> Possible.flatOpt(oldUser.banner()))))
+                .accentColor(Possible.of(or(Possible.flatOpt(partialUserData.accentColor()),
+                        () -> Possible.flatOpt(oldUser.accentColor()))))
                 .build();
     }
 
-    private @Nullable VoiceStateData saveOrRemoveVoiceState(long guildId, VoiceStateData voiceState) {
+    @Nullable
+    private VoiceStateData saveOrRemoveVoiceState(long guildId, VoiceStateData voiceState) {
         Long2 voiceStateId = new Long2(guildId, voiceState.userId().asLong());
         GuildContent guildContent = computeGuildContent(guildId);
         if (voiceState.channelId().isPresent()) {
@@ -816,7 +819,8 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         }
     }
 
-    private @Nullable MessageData deleteMessage(long channelId, long messageId) {
+    @Nullable
+    private MessageData deleteMessage(long channelId, long messageId) {
         Long2 id = new Long2(channelId, messageId);
         ChannelContent channelContent = computeChannelContent(channelId);
         channelContent.messageIds.remove(id);
@@ -852,10 +856,11 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
                 .collect(Collectors.toList())));
     }
 
-    private @Nullable
-    <T> AtomicReference<ImmutableUserData> computeUserRef(long userId, T newData, BiFunction<T, ImmutableUserData,
-            ImmutableUserData> userUpdater) {
-        for (;;) {
+    @Nullable
+    private <T> AtomicReference<ImmutableUserData> computeUserRef(long userId, T newData,
+                                                                  BiFunction<T, ImmutableUserData, ImmutableUserData>
+                                                                         userUpdater) {
+        for (; ; ) {
             AtomicReference<ImmutableUserData> existing = users.get(userId);
             AtomicReference<ImmutableUserData> ref;
             if (existing == null) {
@@ -883,63 +888,6 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
     }
 
     // ------------ Internal classes ------------
-
-    private class GuildContent {
-
-        private final long guildId;
-        private final Set<Long> channelIds = new HashSet<>();
-        private final Set<Long> emojiIds = new HashSet<>();
-        private final Set<Long2> memberIds = new HashSet<>();
-        private final Set<Long2> presenceIds = new HashSet<>();
-        private final Set<Long> roleIds = new HashSet<>();
-        private final Set<Long2> voiceStateIds = new HashSet<>();
-        private volatile boolean memberListComplete;
-
-        public GuildContent(long guildId) {
-            this.guildId = guildId;
-        }
-
-        private void completeMemberList() {
-            memberListComplete = true;
-        }
-
-        private boolean isMemberListComplete() {
-            return memberListComplete;
-        }
-
-        private @Nullable GuildData dispose() {
-            ImmutableGuildData old = guilds.remove(guildId);
-            contentByGuild.remove(guildId);
-            contentByChannel.values().stream()
-                    .filter(content -> channelIds.contains(content.channelId))
-                    .collect(Collectors.toSet())
-                    .forEach(ChannelContent::dispose);
-            emojis.keySet().removeAll(emojiIds);
-            members.keySet().removeAll(memberIds);
-            presences.keySet().removeAll(presenceIds);
-            roles.keySet().removeAll(roleIds);
-            voiceStates.keySet().removeAll(voiceStateIds);
-            return old;
-        }
-    }
-
-    private class ChannelContent {
-
-        private final long channelId;
-        private final Set<Long2> messageIds = new HashSet<>();
-        private final Set<Long2> voiceStateIds = new HashSet<>();
-
-        public ChannelContent(long channelId) {
-            this.channelId = channelId;
-        }
-
-        private void dispose() {
-            channels.remove(channelId);
-            contentByChannel.remove(channelId);
-            messages.keySet().removeAll(messageIds);
-            voiceStates.keySet().removeAll(voiceStateIds);
-        }
-    }
 
     private static class Long2 {
         private final long a, b;
@@ -989,6 +937,64 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         @Override
         public int hashCode() {
             return id != -1 ? Long.hashCode(id) : Objects.hash(name);
+        }
+    }
+
+    private class GuildContent {
+
+        private final long guildId;
+        private final Set<Long> channelIds = new HashSet<>();
+        private final Set<Long> emojiIds = new HashSet<>();
+        private final Set<Long2> memberIds = new HashSet<>();
+        private final Set<Long2> presenceIds = new HashSet<>();
+        private final Set<Long> roleIds = new HashSet<>();
+        private final Set<Long2> voiceStateIds = new HashSet<>();
+        private volatile boolean memberListComplete;
+
+        public GuildContent(long guildId) {
+            this.guildId = guildId;
+        }
+
+        private void completeMemberList() {
+            memberListComplete = true;
+        }
+
+        private boolean isMemberListComplete() {
+            return memberListComplete;
+        }
+
+        @Nullable
+        private GuildData dispose() {
+            WrappedGuildData old = guilds.remove(guildId);
+            contentByGuild.remove(guildId);
+            contentByChannel.values().stream()
+                    .filter(content -> channelIds.contains(content.channelId))
+                    .collect(Collectors.toSet())
+                    .forEach(ChannelContent::dispose);
+            emojis.keySet().removeAll(emojiIds);
+            members.keySet().removeAll(memberIds);
+            presences.keySet().removeAll(presenceIds);
+            roles.keySet().removeAll(roleIds);
+            voiceStates.keySet().removeAll(voiceStateIds);
+            return ifNonNullMap(old, WrappedGuildData::unwrap);
+        }
+    }
+
+    private class ChannelContent {
+
+        private final long channelId;
+        private final Set<Long2> messageIds = new HashSet<>();
+        private final Set<Long2> voiceStateIds = new HashSet<>();
+
+        public ChannelContent(long channelId) {
+            this.channelId = channelId;
+        }
+
+        private void dispose() {
+            channels.remove(channelId);
+            contentByChannel.remove(channelId);
+            messages.keySet().removeAll(messageIds);
+            voiceStates.keySet().removeAll(voiceStateIds);
         }
     }
 }

--- a/common/src/main/java/discord4j/common/store/impl/WrappedGuildData.java
+++ b/common/src/main/java/discord4j/common/store/impl/WrappedGuildData.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.common.store.impl;
+
+import discord4j.discordjson.Id;
+import discord4j.discordjson.json.ImmutableGuildData;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class WrappedGuildData {
+
+    private final ImmutableGuildData guild;
+    private final List<Id> members;
+    private final List<Id> emojis;
+    private final List<Id> channels;
+    private final List<Id> roles;
+
+    WrappedGuildData(ImmutableGuildData guild) {
+        this.guild = ImmutableGuildData.builder()
+                .from(guild)
+                .members(Collections.emptyList())
+                .emojis(Collections.emptyList())
+                .channels(Collections.emptyList())
+                .roles(Collections.emptyList())
+                .build();
+        this.members = new ArrayList<>(guild.members());
+        this.emojis = new ArrayList<>(guild.emojis());
+        this.channels = new ArrayList<>(guild.channels());
+        this.roles = new ArrayList<>(guild.roles());
+    }
+
+    ImmutableGuildData unwrap() {
+        return ImmutableGuildData.builder()
+                .from(guild)
+                .members(members)
+                .emojis(emojis)
+                .channels(channels)
+                .roles(roles)
+                .build();
+    }
+
+    List<Id> getMembers() {
+        return members;
+    }
+
+    List<Id> getEmojis() {
+        return emojis;
+    }
+
+    List<Id> getChannels() {
+        return channels;
+    }
+
+    List<Id> getRoles() {
+        return roles;
+    }
+}


### PR DESCRIPTION
**Description:** Fix a performance issue in the store implementation that was caused by adding elements to large immutable list. It was more specifically affecting member list for large guilds.

**Justification:** store updates should run in constant time, especially since they are currently running on the same thread where gateway dispatches are emitted.

**Note:** this PR doesn't fix the requestMembers() never completing when a gateway error is received while processing chunks, that's a separate issue.