### PR TITLE
Fix message id usage as user cache key

### DIFF
--- a/common/src/main/java/discord4j/common/store/impl/LocalStoreLayout.java
+++ b/common/src/main/java/discord4j/common/store/impl/LocalStoreLayout.java
@@ -564,7 +564,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
             ChannelContent channelContent = computeChannelContent(id.a);
             channels.computeIfPresent(id.a, (k, channel) -> channel.withLastMessageId(id.b));
             channelContent.messageIds.add(id);
-            AtomicReference<ImmutableUserData> userRef = computeUserRef(id.b, message,
+            AtomicReference<ImmutableUserData> userRef = computeUserRef(message.author().id().asLong(), message,
                     (m, old) -> ImmutableUserData.copyOf(m.author()));
             messages.put(id, new WithUser<>(message.withAuthor(EmptyUser.INSTANCE), userRef,
                     ImmutableMessageData::withAuthor));


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

  **Description:** Fixes message id usage as user cache key

**Justification:** On message create events, the user cache is constantly replenished with new identical users, since the message id is used as key
