### PR TITLE
Add Missing Flags and Types of Message

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -912,6 +912,7 @@ public final class Message implements Entity {
         **/
         THREAD_STARTER_MESSAGE(21),
 
+        /** A message created for notice the servers owners about invite new users (only in new servers) **/
         GUILD_INVITE_REMINDER(22),
 
         CONTEXT_MENU_COMMAND(23);

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -888,15 +888,21 @@ public final class Message implements Entity {
         /** A message created when the Guild is requalified for Discovery Feature **/
         GUILD_DISCOVERY_REQUALIFIED(15),
 
+        /** A message created for warning about the grace period of Guild Discovery **/
         GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING(16),
 
+        /** A message created for last warning about the grace period of Guild Discovery **/
         GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING(17),
 
+        /**
+         * A message created when a Thread is started ( <a href="https://support.discord.com/hc/es/articles/4403205878423-Threads">Threads</a> )
+         */
         THREAD_CREATED(18),
 
         /** A message created with a reply */
         REPLY(19),
 
+        /** A message created using an application (like slash commands) **/
         APPLICATION_COMMAND(20),
 
         THREAD_STARTER_MESSAGE(21),

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -905,6 +905,11 @@ public final class Message implements Entity {
         /** A message created using an application (like slash commands) **/
         APPLICATION_COMMAND(20),
 
+        /**
+         * The first message in a thread pointing to a related message in the parent channel from which the thread was started
+         * <br>
+         * <b>Note: </b> Only supported from v9 of API
+        **/
         THREAD_STARTER_MESSAGE(21),
 
         GUILD_INVITE_REMINDER(22),

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -742,6 +742,9 @@ public final class Message implements Entity {
         /** This message came from the urgent message system. */
         URGENT(4),
 
+        /** This message has an associated thread, with the same id as the message. */
+        HAS_THREAD(5),
+
         /** This message is an ephemeral interaction response. */
         EPHEMERAL(6),
 
@@ -889,12 +892,18 @@ public final class Message implements Entity {
 
         GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING(17),
 
+        THREAD_CREATED(18),
+
         /** A message created with a reply */
         REPLY(19),
 
         APPLICATION_COMMAND(20),
 
-        GUILD_INVITE_REMINDER(22);
+        THREAD_STARTER_MESSAGE(21),
+
+        GUILD_INVITE_REMINDER(22),
+
+        CONTEXT_MENU_COMMAND(23);
 
         /**
          * The underlying value as represented by Discord.
@@ -945,9 +954,12 @@ public final class Message implements Entity {
                 case 15: return GUILD_DISCOVERY_REQUALIFIED;
                 case 16: return GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING;
                 case 17: return GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING;
+                case 18: return THREAD_CREATED;
                 case 19: return REPLY;
                 case 20: return APPLICATION_COMMAND;
+                case 21: return THREAD_STARTER_MESSAGE;
                 case 22: return GUILD_INVITE_REMINDER;
+                case 23: return CONTEXT_MENU_COMMAND;
                 default: return UNKNOWN;
             }
         }


### PR DESCRIPTION
**Description:** This PR add Missings Flags (HAS_THREAD) and Types (THREAD_CREATED,THREAD_STARTER_MESSAGE and CONTEXT_MENU_COMMAND)

**Justification:** N/A

**Others:** This PR is for 3.2.x but this version is only for API v8 then dont know if need include THREAD_STARTER_MESSAGE because this only work in the v9 API (3.3.x)
