### PR TITLE
Add equals and hashcode to rest entities

### DIFF
--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -466,6 +467,19 @@ public class RestChannel {
 
     public Mono<Void> deleteGroupDMRecipient(Snowflake userId) {
         return restClient.getChannelService().deleteGroupDMRecipient(id, userId.asLong());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestChannel that = (RestChannel) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     public Flux<WebhookData> getWebhooks() {

--- a/rest/src/main/java/discord4j/rest/entity/RestEmoji.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestEmoji.java
@@ -25,6 +25,8 @@ import discord4j.rest.util.Permission;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Objects;
+
 /**
  * Represents a guild emoji entity in Discord.
  */
@@ -115,5 +117,18 @@ public class RestEmoji {
      */
     public Mono<Void> delete(@Nullable String reason) {
         return restClient.getEmojiService().deleteGuildEmoji(guildId, id, reason);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestEmoji restEmoji = (RestEmoji) o;
+        return guildId == restEmoji.guildId && id == restEmoji.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(guildId, id);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -29,6 +29,7 @@ import reactor.util.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -307,6 +308,19 @@ public class RestGuild {
 
     public Mono<GuildWidgetData> modifyWidget(GuildWidgetModifyRequest request) {
         return restClient.getGuildService().modifyGuildWidget(id, request);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestGuild restGuild = (RestGuild) o;
+        return id == restGuild.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     // TODO add Get Guild Vanity URL

--- a/rest/src/main/java/discord4j/rest/entity/RestGuildTemplate.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuildTemplate.java
@@ -20,6 +20,8 @@ import discord4j.discordjson.json.*;
 import discord4j.rest.RestClient;
 import reactor.core.publisher.Mono;
 
+import java.util.Objects;
+
 /**
  * Represents a guild template entity in Discord.
  */
@@ -71,5 +73,18 @@ public class RestGuildTemplate {
      */
     public Mono<GuildData> createGuild(TemplateCreateGuildRequest request) {
         return restClient.getTemplateService().createGuild(code, request);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestGuildTemplate that = (RestGuildTemplate) o;
+        return Objects.equals(code, that.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestInvite.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestInvite.java
@@ -22,6 +22,8 @@ import discord4j.rest.RestClient;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Objects;
+
 /**
  * Represents a code that can be used to add a user to a guild.
  */
@@ -63,4 +65,16 @@ public class RestInvite {
         return restClient.getInviteService().deleteInvite(code, reason);
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestInvite that = (RestInvite) o;
+        return code.equals(that.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code);
+    }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestMember.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMember.java
@@ -29,6 +29,7 @@ import reactor.math.MathFlux;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents a user (bot or normal) that is member of a specific guild.
@@ -220,5 +221,18 @@ public class RestMember {
 
                     return thisHighestRolePos.map(thisPos -> thisPos > otherHighestPos);
                 });
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestMember that = (RestMember) o;
+        return guildId == that.guildId && id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(guildId, id);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestMessage.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestMessage.java
@@ -25,6 +25,8 @@ import discord4j.rest.util.MultipartRequest;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Objects;
+
 /**
  * Represents a message within Discord.
  */
@@ -187,5 +189,18 @@ public class RestMessage {
      */
     public Mono<MessageData> publish() {
         return restClient.getChannelService().publishMessage(channelId, id);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestMessage that = (RestMessage) o;
+        return channelId == that.channelId && id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(channelId, id);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestRole.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestRole.java
@@ -26,6 +26,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Objects;
+
 /**
  * Roles represent a set of permissions, unique per guild, attached to a group of users.
  */
@@ -132,5 +134,18 @@ public class RestRole {
                 .getGuildRoles(guildId)
                 .filter(response -> Snowflake.asLong(response.id()) == id)
                 .singleOrEmpty();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestRole restRole = (RestRole) o;
+        return guildId == restRole.guildId && id == restRole.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(guildId, id);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestUser.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestUser.java
@@ -24,6 +24,8 @@ import discord4j.discordjson.json.UserData;
 import discord4j.rest.RestClient;
 import reactor.core.publisher.Mono;
 
+import java.util.Objects;
+
 /**
  * Represents a user (bot or normal) entity in Discord. Users can spawn across the entire platform, be members of
  * guilds, participate in text and voice chat, and much more.
@@ -80,5 +82,18 @@ public class RestUser {
      */
     public final Mono<ChannelData> getPrivateChannel() {
         return restClient.getUserService().createDM(DMCreateRequest.builder().recipientId(Snowflake.asString(id)).build());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestUser restUser = (RestUser) o;
+        return id == restUser.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/rest/src/main/java/discord4j/rest/entity/RestWebhook.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestWebhook.java
@@ -25,6 +25,8 @@ import discord4j.rest.util.Permission;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Objects;
+
 /**
  * Represents a webhook entity in Discord. Webhooks are a low-effort way to post messages to channels in Discord.
  */
@@ -95,5 +97,18 @@ public class RestWebhook {
      */
     public Mono<Void> delete(@Nullable String reason) {
         return restClient.getWebhookService().deleteWebhook(id, reason);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RestWebhook that = (RestWebhook) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }


### PR DESCRIPTION
**Description:** 
Add equals and hashCode to rest entities. 

**Justification:**
Instead of using 

`if (restMessage1.getId().equals(restMessage2.getId()))`

one can use 

`if (restMessage1.equals(restMessage2))` 

now!
