### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,26 @@
 version: 2
 updates:
 
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees: []
-    reviewers: []
-    commit-message:
-      prefix: "gradle"
-      include: "scope"
+    -   package-ecosystem: "gradle"
+        directory: "/"
+        schedule:
+            interval: "daily"
+        reviewers:
+            - "quanticc"
+            - "austinv11"
+            - "darichey"
+        commit-message:
+            prefix: "gradle"
+            include: "scope"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees: []
-    reviewers: []
-    commit-message:
-      prefix: "github-actions"
-      include: "scope"
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: "daily"
+        reviewers:
+            - "quanticc"
+            - "austinv11"
+            - "darichey"
+        commit-message:
+            prefix: "github-actions"
+            include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
         reviewers:
             - "quanticc"
             - "austinv11"
-            - "darichey"
         commit-message:
             prefix: "gradle"
             include: "scope"
@@ -20,7 +19,6 @@ updates:
         reviewers:
             - "quanticc"
             - "austinv11"
-            - "darichey"
         commit-message:
             prefix: "github-actions"
             include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees: []
+    reviewers: []
+    commit-message:
+      prefix: "gradle"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees: []
+    reviewers: []
+    commit-message:
+      prefix: "github-actions"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
         reviewers:
             - "quanticc"
             - "austinv11"
+            - "darichey"
         commit-message:
             prefix: "gradle"
             include: "scope"
@@ -19,6 +20,7 @@ updates:
         reviewers:
             - "quanticc"
             - "austinv11"
+            - "darichey"
         commit-message:
             prefix: "github-actions"
             include: "scope"


### PR DESCRIPTION
**Description:**
This PR adds a dependabot configuration for gradle and github-actions dependencies.

**Justification:**
Dependabot automates the task of checking dependencies for new releases.
When testing dependabot with the Discord4J project, it [found](https://github.com/nothub/Discord4J/pulls) several dependencies that are using outdated versions. Configuring dependabot seemed a better choice then opening pull requests for updates of these dependencies.

I defined these ~~top 3~~ committers to be assigned as reviewers of these pull requests:
- quanticc
- austinv11
