### PR TITLE
fixed wrong reference for User.getBannerUrl() method

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/User.java
+++ b/core/src/main/java/discord4j/core/object/entity/User.java
@@ -201,7 +201,7 @@ public class User implements Entity {
      */
     public final Optional<String> getBannerUrl() {
         final boolean animated = hasAnimatedBanner();
-        return getAvatarUrl(animated ? GIF : PNG);
+        return getBannerUrl(animated ? GIF : PNG);
     }
 
     /**


### PR DESCRIPTION
**Description:**
Fixed an reference error for getBannerUrl with no parameter returning the user avatar url instead of banner url.

**Justification:**
The changed corrects the getBannerUrl() to return the same url as getBannerUrl(Image.Format) instead o the user avatar as getUserAvatar() would also return the same url.