### PR TITLE
Update Integration#isEnabled for Optional data.

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Integration.java
+++ b/core/src/main/java/discord4j/core/object/entity/Integration.java
@@ -111,7 +111,7 @@ public class Integration implements Entity {
      * @return Whether the integration is enabled.
      */
     public boolean isEnabled() {
-        return data.enabled();
+        return data.enabled().toOptional().orElse(true);
     }
 
     /**


### PR DESCRIPTION
**Description:** This PR use the optional return based in another PR in discord-json for enabled field in Integration for AuditLogs, the only case where is field not show is for bots added... then by logic the default return can be true?

**Justification:** https://github.com/Discord4J/discord-json/pull/119
