### PR TITLE
Implement thread channel caching and accessor methods

### DIFF
--- a/common/src/main/java/discord4j/common/store/Store.java
+++ b/common/src/main/java/discord4j/common/store/Store.java
@@ -245,6 +245,18 @@ public final class Store {
                         .onVoiceStateUpdateDispatch(action.getShardIndex(), action.getVoiceStateUpdateDispatch()))
                 .map(CompleteGuildMembersAction.class, action -> gatewayDataUpdater
                         .onGuildMembersCompletion(action.getGuildId()))
+                .map(ThreadCreateAction.class, action -> gatewayDataUpdater
+                        .onThreadCreate(action.getShardIndex(), action.getThreadCreate()))
+                .map(ThreadUpdateAction.class, action -> gatewayDataUpdater
+                        .onThreadUpdate(action.getShardIndex(), action.getThreadUpdate()))
+                .map(ThreadDeleteAction.class, action -> gatewayDataUpdater
+                        .onThreadDelete(action.getShardIndex(), action.getThreadDelete()))
+                .map(ThreadListSyncAction.class, action -> gatewayDataUpdater
+                        .onThreadListSync(action.getShardIndex(), action.getThreadListSync()))
+                .map(ThreadMemberUpdateAction.class, action -> gatewayDataUpdater
+                        .onThreadMemberUpdate(action.getShardIndex(), action.getThreadMemberUpdate()))
+                .map(ThreadMembersUpdateAction.class, action -> gatewayDataUpdater
+                        .onThreadMembersUpdate(action.getShardIndex(), action.getThreadMembersUpdate()))
                 .build();
     }
 

--- a/common/src/main/java/discord4j/common/store/Store.java
+++ b/common/src/main/java/discord4j/common/store/Store.java
@@ -176,6 +176,10 @@ public final class Store {
                         .getVoiceStateById(action.getGuildId(), action.getUserId()))
                 .map(GetStageInstanceByChannelIdAction.class, action -> dataAccessor
                         .getStageInstanceByChannelId(action.getChannelId()))
+                .map(GetThreadMemberByIdAction.class, action -> dataAccessor
+                        .getThreadMemberById(action.getThreadId(), action.getUserId()))
+                .map(GetMembersInThreadAction.class, action -> dataAccessor
+                        .getMembersInThread(action.getThreadId()))
                 .build();
     }
 

--- a/common/src/main/java/discord4j/common/store/action/gateway/GatewayActions.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/GatewayActions.java
@@ -350,4 +350,70 @@ public class GatewayActions {
     public static CompleteGuildMembersAction completeGuildMembers(long guildId) {
         return new CompleteGuildMembersAction(guildId);
     }
+
+    /**
+     * Creates an action to execute when a {@link ThreadCreate} is received from the gateway.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a new {@link ThreadCreateAction}
+     */
+    public static ThreadCreateAction threadCreate(int shardIndex, ThreadCreate dispatch) {
+        return new ThreadCreateAction(shardIndex, dispatch);
+    }
+
+    /**
+     * Creates an action to execute when a {@link ThreadUpdate} is received from the gateway.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a new {@link ThreadUpdateAction}
+     */
+    public static ThreadUpdateAction threadUpdate(int shardIndex, ThreadUpdate dispatch) {
+        return new ThreadUpdateAction(shardIndex, dispatch);
+    }
+
+    /**
+     * Creates an action to execute when a {@link ThreadDelete} is received from the gateway.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a new {@link ThreadDeleteAction}
+     */
+    public static ThreadDeleteAction threadDelete(int shardIndex, ThreadDelete dispatch) {
+        return new ThreadDeleteAction(shardIndex, dispatch);
+    }
+
+    /**
+     * Creates an action to execute when a {@link ThreadListSync} is received from the gateway.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a new {@link ThreadListSyncAction}
+     */
+    public static ThreadListSyncAction threadListSync(int shardIndex, ThreadListSync dispatch) {
+        return new ThreadListSyncAction(shardIndex, dispatch);
+    }
+
+    /**
+     * Creates an action to execute when a {@link ThreadMemberUpdate} is received from the gateway.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a new {@link ThreadMemberUpdateAction}
+     */
+    public static ThreadMemberUpdateAction threadMemberUpdate(int shardIndex, ThreadMemberUpdate dispatch) {
+        return new ThreadMemberUpdateAction(shardIndex, dispatch);
+    }
+
+    /**
+     * Creates an action to execute when a {@link ThreadMembersUpdate} is received from the gateway.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a new {@link ThreadMembersUpdateAction}
+     */
+    public static ThreadMembersUpdateAction threadMembersUpdate(int shardIndex, ThreadMembersUpdate dispatch) {
+        return new ThreadMembersUpdateAction(shardIndex, dispatch);
+    }
 }

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadCreateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadCreateAction.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.common.store.action.gateway;
 
 import discord4j.discordjson.json.gateway.ThreadCreate;

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadCreateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadCreateAction.java
@@ -1,0 +1,16 @@
+package discord4j.common.store.action.gateway;
+
+import discord4j.discordjson.json.gateway.ThreadCreate;
+
+public class ThreadCreateAction extends ShardAwareAction<Void> {
+    private final ThreadCreate threadCreate;
+
+    ThreadCreateAction(int shardIndex, ThreadCreate threadCreate) {
+        super(shardIndex);
+        this.threadCreate = threadCreate;
+    }
+
+    public ThreadCreate getThreadCreate() {
+        return threadCreate;
+    }
+}

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadDeleteAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadDeleteAction.java
@@ -1,9 +1,25 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.common.store.action.gateway;
 
-import discord4j.discordjson.json.ChannelData;
 import discord4j.discordjson.json.gateway.ThreadDelete;
 
-public class ThreadDeleteAction extends ShardAwareAction<ChannelData> {
+public class ThreadDeleteAction extends ShardAwareAction<Void> {
     private final ThreadDelete threadDelete;
 
     ThreadDeleteAction(int shardIndex, ThreadDelete threadDelete) {

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadDeleteAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadDeleteAction.java
@@ -1,0 +1,17 @@
+package discord4j.common.store.action.gateway;
+
+import discord4j.discordjson.json.ChannelData;
+import discord4j.discordjson.json.gateway.ThreadDelete;
+
+public class ThreadDeleteAction extends ShardAwareAction<ChannelData> {
+    private final ThreadDelete threadDelete;
+
+    ThreadDeleteAction(int shardIndex, ThreadDelete threadDelete) {
+        super(shardIndex);
+        this.threadDelete = threadDelete;
+    }
+
+    public ThreadDelete getThreadDelete() {
+        return threadDelete;
+    }
+}

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadListSyncAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadListSyncAction.java
@@ -1,0 +1,16 @@
+package discord4j.common.store.action.gateway;
+
+import discord4j.discordjson.json.gateway.ThreadListSync;
+
+public class ThreadListSyncAction extends ShardAwareAction<Void> {
+    private final ThreadListSync threadListSync;
+
+    ThreadListSyncAction(int shardIndex, ThreadListSync threadListSync) {
+        super(shardIndex);
+        this.threadListSync = threadListSync;
+    }
+
+    public ThreadListSync getThreadListSync() {
+        return threadListSync;
+    }
+}

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadListSyncAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadListSyncAction.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.common.store.action.gateway;
 
 import discord4j.discordjson.json.gateway.ThreadListSync;

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadMemberUpdateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadMemberUpdateAction.java
@@ -1,0 +1,17 @@
+package discord4j.common.store.action.gateway;
+
+import discord4j.discordjson.json.ThreadMemberData;
+import discord4j.discordjson.json.gateway.ThreadMemberUpdate;
+
+public class ThreadMemberUpdateAction extends ShardAwareAction<ThreadMemberData> {
+    private final ThreadMemberUpdate threadMemberUpdate;
+
+    ThreadMemberUpdateAction(int shardIndex, ThreadMemberUpdate threadMemberUpdate) {
+        super(shardIndex);
+        this.threadMemberUpdate = threadMemberUpdate;
+    }
+
+    public ThreadMemberUpdate getThreadMemberUpdate() {
+        return threadMemberUpdate;
+    }
+}

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadMembersUpdateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadMembersUpdateAction.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.common.store.action.gateway;
 
 import discord4j.discordjson.json.ThreadMemberData;

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadMembersUpdateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadMembersUpdateAction.java
@@ -1,0 +1,19 @@
+package discord4j.common.store.action.gateway;
+
+import discord4j.discordjson.json.ThreadMemberData;
+import discord4j.discordjson.json.gateway.ThreadMembersUpdate;
+
+import java.util.List;
+
+public class ThreadMembersUpdateAction extends ShardAwareAction<List<ThreadMemberData>> {
+    private final ThreadMembersUpdate threadMembersUpdate;
+
+    ThreadMembersUpdateAction(int shardIndex, ThreadMembersUpdate threadMembersUpdate) {
+        super(shardIndex);
+        this.threadMembersUpdate = threadMembersUpdate;
+    }
+
+    public ThreadMembersUpdate getThreadMembersUpdate() {
+        return threadMembersUpdate;
+    }
+}

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadUpdateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadUpdateAction.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package discord4j.common.store.action.gateway;
 
 import discord4j.discordjson.json.ChannelData;

--- a/common/src/main/java/discord4j/common/store/action/gateway/ThreadUpdateAction.java
+++ b/common/src/main/java/discord4j/common/store/action/gateway/ThreadUpdateAction.java
@@ -1,0 +1,17 @@
+package discord4j.common.store.action.gateway;
+
+import discord4j.discordjson.json.ChannelData;
+import discord4j.discordjson.json.gateway.ThreadUpdate;
+
+public class ThreadUpdateAction extends ShardAwareAction<ChannelData> {
+    private final ThreadUpdate threadUpdate;
+
+    ThreadUpdateAction(int shardIndex, ThreadUpdate threadUpdate) {
+        super(shardIndex);
+        this.threadUpdate = threadUpdate;
+    }
+
+    public ThreadUpdate getThreadUpdate() {
+        return threadUpdate;
+    }
+}

--- a/common/src/main/java/discord4j/common/store/action/read/GetMembersInThreadAction.java
+++ b/common/src/main/java/discord4j/common/store/action/read/GetMembersInThreadAction.java
@@ -15,20 +15,19 @@
  * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package discord4j.common.store.action.gateway;
+package discord4j.common.store.action.read;
 
+import discord4j.common.store.api.StoreAction;
 import discord4j.discordjson.json.ThreadMemberData;
-import discord4j.discordjson.json.gateway.ThreadMemberUpdate;
 
-public class ThreadMemberUpdateAction extends ShardAwareAction<ThreadMemberData> {
-    private final ThreadMemberUpdate threadMemberUpdate;
+public class GetMembersInThreadAction implements StoreAction<ThreadMemberData> {
+    private final long threadId;
 
-    ThreadMemberUpdateAction(int shardIndex, ThreadMemberUpdate threadMemberUpdate) {
-        super(shardIndex);
-        this.threadMemberUpdate = threadMemberUpdate;
+    GetMembersInThreadAction(long threadId) {
+        this.threadId = threadId;
     }
 
-    public ThreadMemberUpdate getThreadMemberUpdate() {
-        return threadMemberUpdate;
+    public long getThreadId() {
+        return threadId;
     }
 }

--- a/common/src/main/java/discord4j/common/store/action/read/GetThreadMemberByIdAction.java
+++ b/common/src/main/java/discord4j/common/store/action/read/GetThreadMemberByIdAction.java
@@ -15,20 +15,25 @@
  * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package discord4j.common.store.action.gateway;
+package discord4j.common.store.action.read;
 
+import discord4j.common.store.api.StoreAction;
 import discord4j.discordjson.json.ThreadMemberData;
-import discord4j.discordjson.json.gateway.ThreadMemberUpdate;
 
-public class ThreadMemberUpdateAction extends ShardAwareAction<ThreadMemberData> {
-    private final ThreadMemberUpdate threadMemberUpdate;
+public class GetThreadMemberByIdAction implements StoreAction<ThreadMemberData> {
+    private final long threadId;
+    private final long userId;
 
-    ThreadMemberUpdateAction(int shardIndex, ThreadMemberUpdate threadMemberUpdate) {
-        super(shardIndex);
-        this.threadMemberUpdate = threadMemberUpdate;
+    GetThreadMemberByIdAction(long threadId, long userId) {
+        this.threadId = threadId;
+        this.userId = userId;
     }
 
-    public ThreadMemberUpdate getThreadMemberUpdate() {
-        return threadMemberUpdate;
+    public long getThreadId() {
+        return threadId;
+    }
+
+    public long getUserId() {
+        return userId;
     }
 }

--- a/common/src/main/java/discord4j/common/store/action/read/ReadActions.java
+++ b/common/src/main/java/discord4j/common/store/action/read/ReadActions.java
@@ -505,4 +505,25 @@ public class ReadActions {
     public static GetStageInstanceByChannelIdAction getStageInstanceByChannelId(long channelId) {
         return new GetStageInstanceByChannelIdAction(channelId);
     }
+
+    /**
+     * Creates an action to retrieve data for the thread member corresponding to the given thread ID and user ID.
+     *
+     * @param threadId the thread ID
+     * @param userId the user ID
+     * @return a new {@link GetThreadMemberByIdAction}
+     */
+    public static GetThreadMemberByIdAction getThreadMemberById(long threadId, long userId) {
+        return new GetThreadMemberByIdAction(threadId, userId);
+    }
+
+    /**
+     * Creates an action to retrieve data for all thread members present in a store for the given thread ID.
+     *
+     * @param threadId the thread ID
+     * @return a new {@link GetMembersInThreadAction}
+     */
+    public static GetMembersInThreadAction getMembersInThread(long threadId) {
+        return new GetMembersInThreadAction(threadId);
+    }
 }

--- a/common/src/main/java/discord4j/common/store/api/layout/DataAccessor.java
+++ b/common/src/main/java/discord4j/common/store/api/layout/DataAccessor.java
@@ -431,4 +431,21 @@ public interface DataAccessor {
      * @return A {@link Mono} emitting the stage instance data, or empty if not found
      */
     Mono<StageInstanceData> getStageInstanceByChannelId(long channelId);
+
+    /**
+     * Retrieves data for the thread member corresponding to the given thread ID and user ID.
+     *
+     * @param threadId the thread ID
+     * @param userId the user ID
+     * @return A {@link Mono} emitting the thread member data, or empty if not found
+     */
+    Mono<ThreadMemberData> getThreadMemberById(long threadId, long userId);
+
+    /**
+     * Retrieves data for all thread members present in the store for the given thread ID.
+     *
+     * @param threadId the thread ID
+     * @return A {@link Flux} emitting the thread members, or empty if none is present
+     */
+    Flux<ThreadMemberData> getMembersInThread(long threadId);
 }

--- a/common/src/main/java/discord4j/common/store/api/layout/DataAccessor.java
+++ b/common/src/main/java/discord4j/common/store/api/layout/DataAccessor.java
@@ -438,14 +438,20 @@ public interface DataAccessor {
      * @param threadId the thread ID
      * @param userId the user ID
      * @return A {@link Mono} emitting the thread member data, or empty if not found
+     * @since 3.3.0
      */
-    Mono<ThreadMemberData> getThreadMemberById(long threadId, long userId);
+    default Mono<ThreadMemberData> getThreadMemberById(long threadId, long userId) {
+        return Mono.empty();
+    }
 
     /**
      * Retrieves data for all thread members present in the store for the given thread ID.
      *
      * @param threadId the thread ID
      * @return A {@link Flux} emitting the thread members, or empty if none is present
+     * @since 3.3.0
      */
-    Flux<ThreadMemberData> getMembersInThread(long threadId);
+    default Flux<ThreadMemberData> getMembersInThread(long threadId) {
+        return Flux.empty();
+    }
 }

--- a/common/src/main/java/discord4j/common/store/api/layout/GatewayDataUpdater.java
+++ b/common/src/main/java/discord4j/common/store/api/layout/GatewayDataUpdater.java
@@ -400,7 +400,7 @@ public interface GatewayDataUpdater {
 
     Mono<ChannelData> onThreadUpdate(int shardIndex, ThreadUpdate dispatch);
 
-    Mono<ChannelData> onThreadDelete(int shardIndex, ThreadDelete dispatch);
+    Mono<Void> onThreadDelete(int shardIndex, ThreadDelete dispatch);
 
     Mono<Void> onThreadListSync(int shardIndex, ThreadListSync dispatch);
 

--- a/common/src/main/java/discord4j/common/store/api/layout/GatewayDataUpdater.java
+++ b/common/src/main/java/discord4j/common/store/api/layout/GatewayDataUpdater.java
@@ -21,7 +21,6 @@ import discord4j.common.store.api.object.InvalidationCause;
 import discord4j.common.store.api.object.PresenceAndUserData;
 import discord4j.discordjson.json.*;
 import discord4j.discordjson.json.gateway.*;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -396,15 +395,66 @@ public interface GatewayDataUpdater {
      */
     Mono<Void> onGuildMembersCompletion(long guildId);
 
+    /**
+     * Updates the internal state of the store according to the given {@link ThreadCreate} gateway dispatch. This
+     * will typically perform an insert operation on the related {@link ChannelData}.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a {@link Mono} completing when the operation is done
+     */
     Mono<Void> onThreadCreate(int shardIndex, ThreadCreate dispatch);
 
+    /**
+     * Updates the internal state of the store according to the given {@link ThreadUpdate} gateway dispatch. This
+     * will typically perform an update operation on a related {@link ChannelData} that is already present in the store.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a {@link Mono} completing when the operation is done, optionally returning the old state of the
+     * {@link ChannelData} before the update
+     */
     Mono<ChannelData> onThreadUpdate(int shardIndex, ThreadUpdate dispatch);
 
+    /**
+     * Updates the internal state of the store according to the given {@link ThreadDelete} gateway dispatch. This
+     * will typically perform a delete operation on a related {@link ChannelData} that is already present in the store.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a {@link Mono} completing when the operation is done
+     */
     Mono<Void> onThreadDelete(int shardIndex, ThreadDelete dispatch);
 
+    /**
+     * Updates the internal state of the store according to the given {@link ThreadListSync} gateway dispatch. This
+     * will typically perform an update and delete operation on the related {@link ChannelData} and {@link ThreadMemberData}.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a {@link Mono} completing when the operation is done
+     */
     Mono<Void> onThreadListSync(int shardIndex, ThreadListSync dispatch);
 
+    /**
+     * Updates the internal state of the store according to the given {@link ThreadMemberUpdate} gateway dispatch. This
+     * will typically perform a delete operation on a related {@link ThreadMemberData} that is already present in the store.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a {@link Mono} completing when the operation is done, optionally returning the old state of the
+     * {@link ThreadMemberUpdate} before the deletion
+     */
     Mono<ThreadMemberData> onThreadMemberUpdate(int shardIndex, ThreadMemberUpdate dispatch);
 
+    /**
+     * Updates the internal state of the store according to the given {@link ThreadMembersUpdate} gateway dispatch. This
+     * will typically perform a delete operation on a related {@link ThreadMemberData} that is already present in the store.
+     *
+     * @param shardIndex the index of the shard where the dispatch comes from
+     * @param dispatch   the dispatch data coming from Discord gateway
+     * @return a {@link Mono} completing when the operation is done, optionally returning the old state of the
+     * list of {@link ThreadMemberData} before the deletion
+     */
     Mono<List<ThreadMemberData>> onThreadMembersUpdate(int shardIndex, ThreadMembersUpdate dispatch);
 }

--- a/common/src/main/java/discord4j/common/store/api/layout/GatewayDataUpdater.java
+++ b/common/src/main/java/discord4j/common/store/api/layout/GatewayDataUpdater.java
@@ -21,8 +21,10 @@ import discord4j.common.store.api.object.InvalidationCause;
 import discord4j.common.store.api.object.PresenceAndUserData;
 import discord4j.discordjson.json.*;
 import discord4j.discordjson.json.gateway.*;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -393,4 +395,16 @@ public interface GatewayDataUpdater {
      * @return a {@link Mono} completing when the operation is done
      */
     Mono<Void> onGuildMembersCompletion(long guildId);
+
+    Mono<Void> onThreadCreate(int shardIndex, ThreadCreate dispatch);
+
+    Mono<ChannelData> onThreadUpdate(int shardIndex, ThreadUpdate dispatch);
+
+    Mono<ChannelData> onThreadDelete(int shardIndex, ThreadDelete dispatch);
+
+    Mono<Void> onThreadListSync(int shardIndex, ThreadListSync dispatch);
+
+    Mono<ThreadMemberData> onThreadMemberUpdate(int shardIndex, ThreadMemberUpdate dispatch);
+
+    Mono<List<ThreadMemberData>> onThreadMembersUpdate(int shardIndex, ThreadMembersUpdate dispatch);
 }

--- a/common/src/main/java/discord4j/common/store/impl/LocalStoreLayout.java
+++ b/common/src/main/java/discord4j/common/store/impl/LocalStoreLayout.java
@@ -82,6 +82,9 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
     private final ConcurrentMap<Long2, ImmutableVoiceStateData> voiceStates =
             new ConcurrentHashMap<>();
 
+    private final ConcurrentMap<Long2, ImmutableThreadMemberData> threadMembers =
+            new ConcurrentHashMap<>();
+
     private final Set<Integer> shardsConnected = new HashSet<>();
     private volatile AtomicReference<ImmutableUserData> selfUser;
     private volatile int shardCount;
@@ -439,6 +442,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
             List<EmojiData> emojis = createData.emojis();
             List<MemberData> members = createData.members();
             List<ChannelData> channels = createData.channels();
+            List<ChannelData> threads = createData.threads();
             List<PresenceData> presences = createData.presences();
             List<VoiceStateData> voiceStates = createData.voiceStates();
             ImmutableGuildData guild = ImmutableGuildData.builder()
@@ -453,6 +457,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
             emojis.forEach(emoji -> saveEmoji(guildId, emoji));
             members.forEach(member -> saveMember(guildId, member));
             channels.forEach(channel -> saveChannel(guildId, channel));
+            threads.forEach(channel -> saveChannel(guildId, channel));
             presences.forEach(presence -> savePresence(guildId, presence));
             voiceStates.forEach(voiceState -> saveOrRemoveVoiceState(guildId, voiceState));
         });
@@ -771,6 +776,73 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
     }
 
     @Override
+    public Mono<Void> onThreadCreate(int shardIndex, ThreadCreate dispatch) {
+        return Mono.fromRunnable(() -> dispatch.thread().guildId().toOptional()
+                .ifPresent(guildId -> saveChannel(guildId.asLong(), dispatch.thread())));
+    }
+
+    @Override
+    public Mono<ChannelData> onThreadUpdate(int shardIndex, ThreadUpdate dispatch) {
+        return Mono.fromCallable(() -> dispatch.thread().guildId().toOptional()
+                .map(guildId -> saveChannel(guildId.asLong(), dispatch.thread()))
+                .orElse(null));
+    }
+
+    @Override
+    public Mono<ChannelData> onThreadDelete(int shardIndex, ThreadDelete dispatch) {
+        ChannelData data = dispatch.thread();
+        return Mono.fromRunnable(() -> data.guildId().toOptional()
+                .map(Id::asLong)
+                .ifPresent(guildId -> {
+                    Id channelId = data.id();
+                    GuildContent guildContent = computeGuildContent(guildId);
+                    guildContent.channelIds.remove(channelId.asLong());
+                    ifNonNullDo(contentByChannel.get(channelId.asLong()), ChannelContent::dispose);
+                    ifNonNullDo(guilds.get(guildId), guild -> guild.getChannels().remove(channelId));
+                })).thenReturn(data);
+    }
+
+    @Override
+    public Mono<Void> onThreadListSync(int shardIndex, ThreadListSync dispatch) {
+        return Mono.fromRunnable(() -> {
+            long guildId = dispatch.guildId().asLong();
+            dispatch.threads().forEach(thread -> saveChannel(guildId, thread));
+            dispatch.members().forEach(member -> saveThreadMember(member));
+        });
+    }
+
+    @Override
+    public Mono<ThreadMemberData> onThreadMemberUpdate(int shardIndex, ThreadMemberUpdate dispatch) {
+        return Mono.fromCallable(() -> saveThreadMember(dispatch.member()));
+    }
+
+    @Override
+    public Mono<List<ThreadMemberData>> onThreadMembersUpdate(int shardIndex, ThreadMembersUpdate dispatch) {
+        long threadId = dispatch.id().asLong();
+        return Mono.fromCallable(() -> {
+            ChannelContent content = computeChannelContent(threadId);
+            List<ThreadMemberData> old = content.threadMembersIds.stream()
+                    .map(threadMembers::get)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+            dispatch.addedMembers().forEach(threadMember -> {
+                Long2 id = new Long2(threadId, threadMember.userId().get().asLong());
+                content.threadMembersIds.add(id);
+                threadMembers.put(id, ImmutableThreadMemberData.copyOf(threadMember));
+            });
+
+            dispatch.removedMemberIds().forEach(id -> {
+                Long2 key = new Long2(threadId, id.asLong());
+                content.threadMembersIds.remove(key);
+                threadMembers.remove(key);
+            });
+
+            return old;
+        });
+    }
+
+    @Override
     public DataAccessor getDataAccessor() {
         return this;
     }
@@ -836,6 +908,15 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
                 (m, u) -> ImmutableUserData.copyOf(m.user()));
         members.put(memberId, new WithUser<>(ImmutableMemberData.copyOf(member).withUser(EmptyUser.INSTANCE), userRef,
                 ImmutableMemberData::withUser));
+    }
+
+    @Nullable
+    private ThreadMemberData saveThreadMember(ThreadMemberData threadMember) {
+        long threadId = threadMember.id().get().asLong();
+        ChannelContent content = computeChannelContent(threadId);
+        Long2 id = new Long2(threadId, threadMember.userId().get().asLong());
+        content.threadMembersIds.add(id);
+        return threadMembers.put(id, ImmutableThreadMemberData.copyOf(threadMember));
     }
 
     @Nullable
@@ -1063,6 +1144,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
 
         private final long channelId;
         private final Set<Long2> messageIds = new HashSet<>();
+        private final Set<Long2> threadMembersIds = new HashSet<>();
         private final Set<Long2> voiceStateIds = new HashSet<>();
 
         public ChannelContent(long channelId) {
@@ -1072,6 +1154,7 @@ public class LocalStoreLayout implements StoreLayout, DataAccessor, GatewayDataU
         private void dispose() {
             channels.remove(channelId);
             contentByChannel.remove(channelId);
+            threadMembers.keySet().removeAll(threadMembersIds);
             messages.keySet().removeAll(messageIds);
         }
     }

--- a/common/src/main/java/discord4j/common/store/legacy/StateHolder.java
+++ b/common/src/main/java/discord4j/common/store/legacy/StateHolder.java
@@ -42,8 +42,10 @@ import java.util.Collections;
  * <li>Message store: {@code long} keys and {@link MessageData} values.</li>
  * <li>Presence store: {@code long} pair keys and {@link PresenceUpdate} values.</li>
  * <li>Role store: {@code long} keys and {@link RoleData} values.</li>
+ * <li>Stage instance store: {@code long} keys and {@link StageInstanceData} values.</li>
  * <li>User store: {@code long} keys and {@link UserData} values.</li>
  * <li>Voice state store: {@code long} pair keys and {@link VoiceStateData} values.</li>
+ * <li>Thread member store: {@code long} pair keys and {@link ThreadMemberData} values.</li>
  * </ul>
  */
 public final class StateHolder {
@@ -62,6 +64,7 @@ public final class StateHolder {
     private final LongObjStore<StageInstanceData> stageInstanceStore;
     private final LongObjStore<UserData> userStore;
     private final Store<LongLongTuple2, VoiceStateData> voiceStateStore;
+    private final Store<LongLongTuple2, ThreadMemberData> threadMemberStore;
 
     public StateHolder(final StoreService service) {
         storeService = service;
@@ -96,10 +99,13 @@ public final class StateHolder {
         log.debug("StageInstance storage        : {}", stageInstanceStore);
 
         userStore = service.provideLongObjStore(UserData.class);
-        log.debug("User storage        : {}", userStore);
+        log.debug("User storage          : {}", userStore);
 
         voiceStateStore = service.provideGenericStore(LongLongTuple2.class, VoiceStateData.class);
-        log.debug("Voice state storage : {}", voiceStateStore);
+        log.debug("Voice state storage   : {}", voiceStateStore);
+
+        threadMemberStore = service.provideGenericStore(LongLongTuple2.class, ThreadMemberData.class);
+        log.debug("Thread member storage : {}", voiceStateStore);
     }
 
     public StoreService getStoreService() {
@@ -150,6 +156,10 @@ public final class StateHolder {
         return voiceStateStore;
     }
 
+    public Store<LongLongTuple2, ThreadMemberData> getThreadMemberStore() {
+        return threadMemberStore;
+    }
+
     public Mono<Void> invalidateStores() {
         return channelStore.invalidate()
                 .and(guildStore.invalidate())
@@ -160,6 +170,7 @@ public final class StateHolder {
                 .and(roleStore.invalidate())
                 .and(stageInstanceStore.invalidate())
                 .and(userStore.invalidate())
-                .and(voiceStateStore.invalidate());
+                .and(voiceStateStore.invalidate())
+                .and(threadMemberStore.invalidate());
     }
 }

--- a/core/src/main/java/discord4j/core/GatewayDiscordClient.java
+++ b/core/src/main/java/discord4j/core/GatewayDiscordClient.java
@@ -827,4 +827,14 @@ public class GatewayDiscordClient implements EntityRetriever {
     public Flux<GuildSticker> getGuildStickers(Snowflake guildId) {
         return entityRetriever.getGuildStickers(guildId);
     }
+
+    @Override
+    public Mono<ThreadMember> getThreadMemberById(Snowflake threadId, Snowflake userId) {
+        return entityRetriever.getThreadMemberById(threadId, userId);
+    }
+
+    @Override
+    public Flux<ThreadMember> getThreadMembers(Snowflake threadId) {
+        return entityRetriever.getThreadMembers(threadId);
+    }
 }

--- a/core/src/main/java/discord4j/core/event/ReactiveEventAdapter.java
+++ b/core/src/main/java/discord4j/core/event/ReactiveEventAdapter.java
@@ -32,6 +32,7 @@ import discord4j.core.event.domain.message.*;
 import discord4j.core.event.domain.role.RoleCreateEvent;
 import discord4j.core.event.domain.role.RoleDeleteEvent;
 import discord4j.core.event.domain.role.RoleUpdateEvent;
+import discord4j.core.event.domain.thread.*;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -530,6 +531,76 @@ public abstract class ReactiveEventAdapter {
     }
 
     /**
+     * Invoked when a thread is created, relevant to the current user, or when the current user is added to a thread.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onThreadChannelCreateEvent(ThreadChannelCreateEvent event) {
+        return Mono.empty();
+    }
+
+    /**
+     * Invoked when a thread relevant to the current user is deleted.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onThreadChannelDeleteEvent(ThreadChannelDeleteEvent event) {
+        return Mono.empty();
+    }
+
+    /**
+     * Invoked when a thread relevant to the current user is updated.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onThreadChannelUpdateEvent(ThreadChannelUpdateEvent event) {
+        return Mono.empty();
+    }
+
+    /**
+     * Invoked when the current user gains access to a thread channel.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onThreadListSyncEvent(ThreadListSyncEvent event) {
+        return Mono.empty();
+    }
+
+    /**
+     * Invoked when anyone is added to or removed from a thread. If the current user does not have the
+     * {@link discord4j.gateway.intent.Intent#GUILD_MEMBERS} Gateway Intent, then this event will only be sent if the
+     * current user was added to or removed from the thread.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onThreadMembersUpdateEvent(ThreadMembersUpdateEvent event) {
+        return Mono.empty();
+    }
+
+    /**
+     * Invoked when the thread member object for the current user is updated. This event is documented for completeness,
+     * but unlikely to be used by most bots. For bots, this event largely is just a signal that you are a member of the
+     * thread.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onThreadMemberUpdateEvent(ThreadMemberUpdateEvent event) {
+        return Mono.empty();
+    }
+
+    /**
      * Invoked when a guild channel is created, but its {@link discord4j.core.object.entity.channel.Channel.Type type}
      * is not supported or implemented.
      *
@@ -983,6 +1054,12 @@ public abstract class ReactiveEventAdapter {
         if (event instanceof StoreChannelCreateEvent) compatibleHooks.add(onStoreChannelCreate((StoreChannelCreateEvent) event));
         if (event instanceof StoreChannelDeleteEvent) compatibleHooks.add(onStoreChannelDelete((StoreChannelDeleteEvent) event));
         if (event instanceof StoreChannelUpdateEvent) compatibleHooks.add(onStoreChannelUpdate((StoreChannelUpdateEvent) event));
+        if (event instanceof ThreadChannelCreateEvent) compatibleHooks.add(onThreadChannelCreateEvent((ThreadChannelCreateEvent) event));
+        if (event instanceof ThreadChannelDeleteEvent) compatibleHooks.add(onThreadChannelDeleteEvent((ThreadChannelDeleteEvent) event));
+        if (event instanceof ThreadChannelUpdateEvent) compatibleHooks.add(onThreadChannelUpdateEvent((ThreadChannelUpdateEvent) event));
+        if (event instanceof ThreadListSyncEvent) compatibleHooks.add(onThreadListSyncEvent((ThreadListSyncEvent) event));
+        if (event instanceof ThreadMembersUpdateEvent) compatibleHooks.add(onThreadMembersUpdateEvent((ThreadMembersUpdateEvent) event));
+        if (event instanceof ThreadMemberUpdateEvent) compatibleHooks.add(onThreadMemberUpdateEvent((ThreadMemberUpdateEvent) event));
         if (event instanceof UnknownChannelCreateEvent) compatibleHooks.add(onUnknownChannelCreate((UnknownChannelCreateEvent) event));
         if (event instanceof UnknownChannelDeleteEvent) compatibleHooks.add(onUnknownChannelDelete((UnknownChannelDeleteEvent) event));
         if (event instanceof UnknownChannelUpdateEvent) compatibleHooks.add(onUnknownChannelUpdate((UnknownChannelUpdateEvent) event));

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelCreateEvent.java
@@ -17,12 +17,15 @@
 
 package discord4j.core.event.domain.thread;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.channel.ThreadChannel;
 import discord4j.gateway.ShardInfo;
 
-@Experimental
+/**
+ * Sent when a thread is created, relevant to the current user, or when the current user is added to a thread.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-create">Discord Docs</a>
+ */
 public class ThreadChannelCreateEvent extends ThreadEvent {
 
     private final ThreadChannel channel;

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelDeleteEvent.java
@@ -21,6 +21,7 @@ import discord4j.common.annotations.Experimental;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.channel.ThreadChannel;
 import discord4j.gateway.ShardInfo;
+import reactor.util.annotation.Nullable;
 
 @Experimental
 public class ThreadChannelDeleteEvent extends ThreadEvent {

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelDeleteEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelDeleteEvent.java
@@ -17,13 +17,15 @@
 
 package discord4j.core.event.domain.thread;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.channel.ThreadChannel;
 import discord4j.gateway.ShardInfo;
-import reactor.util.annotation.Nullable;
 
-@Experimental
+/**
+ * Sent when a thread relevant to the current user is deleted.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-delete">Discord Docs</a>
+ */
 public class ThreadChannelDeleteEvent extends ThreadEvent {
 
     private final ThreadChannel channel;

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelUpdateEvent.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.event.domain.thread;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.channel.ThreadChannel;
 import discord4j.gateway.ShardInfo;
@@ -25,7 +24,11 @@ import reactor.util.annotation.Nullable;
 
 import java.util.Optional;
 
-@Experimental
+/**
+ * Sent when a thread is updated. This is not sent when the channel field last_message_id is altered.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-member-update">Discord Docs</a>
+ */
 public class ThreadChannelUpdateEvent extends ThreadEvent {
 
     private final ThreadChannel channel;

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadListSyncEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadListSyncEvent.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.event.domain.thread;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.ThreadMember;
@@ -29,7 +28,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Experimental
+/**
+ * Sent when the current user gains access to a channel.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-list-sync">Discord Docs</a>
+ */
 public class ThreadListSyncEvent extends ThreadEvent {
 
     private final ThreadListSync dispatch;

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadMemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadMemberUpdateEvent.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.event.domain.thread;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.ThreadMember;
 import discord4j.gateway.ShardInfo;
@@ -25,7 +24,12 @@ import reactor.util.annotation.Nullable;
 
 import java.util.Optional;
 
-@Experimental
+/**
+ * Sent when the thread member object for the current user is updated. This event is documented for completeness, but
+ * unlikely to be used by most bots. For bots, this event largely is just a signal that you are a member of the thread.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-member-update>Discord Docs</a>
+ */
 public class ThreadMemberUpdateEvent extends ThreadEvent {
 
     private final ThreadMember member;

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadMemberUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadMemberUpdateEvent.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * Sent when the thread member object for the current user is updated. This event is documented for completeness, but
  * unlikely to be used by most bots. For bots, this event largely is just a signal that you are a member of the thread.
  *
- * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-member-update>Discord Docs</a>
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-member-update">Discord Docs</a>
  */
 public class ThreadMemberUpdateEvent extends ThreadEvent {
 

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadMembersUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadMembersUpdateEvent.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.event.domain.thread;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.ThreadMember;
@@ -33,8 +32,9 @@ import java.util.stream.Collectors;
  * Sent when anyone is added to or removed from a thread. If the current user does not have the
  * {@link discord4j.gateway.intent.Intent#GUILD_MEMBERS} Gateway Intent, then this event will only be sent if the
  * current user was added to or removed from the thread.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#thread-members-update">Discord Docs</a>
  */
-@Experimental
 public class ThreadMembersUpdateEvent extends ThreadEvent {
 
     private final ThreadMembersUpdate dispatch;

--- a/core/src/main/java/discord4j/core/object/ThreadListPart.java
+++ b/core/src/main/java/discord4j/core/object/ThreadListPart.java
@@ -1,0 +1,69 @@
+package discord4j.core.object;
+
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.ThreadMember;
+import discord4j.core.object.entity.channel.ThreadChannel;
+import discord4j.core.util.EntityUtil;
+import discord4j.discordjson.json.ListThreadsData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** A part of thread channels list which contains channels and thread members. */
+public class ThreadListPart {
+    private final List<ThreadChannel> threads;
+
+    private final List<ThreadMember> members;
+
+    public ThreadListPart(GatewayDiscordClient client, ListThreadsData data) {
+        this.threads = data.threads().stream()
+                .map(channelData -> (ThreadChannel) EntityUtil.getChannel(client, channelData))
+                .collect(Collectors.toList());
+
+        this.members = data.members().stream()
+                .map(threadMemberData -> new ThreadMember(client, threadMemberData))
+                .collect(Collectors.toList());
+    }
+
+    private ThreadListPart(List<ThreadChannel> threads, List<ThreadMember> members) {
+        this.threads = threads;
+        this.members = members;
+    }
+
+    /**
+     * Gets the thread channels in this portion of the threads list.
+     *
+     * @return The thread channels in this portion of the threads list.
+     */
+    public List<ThreadChannel> getThreads() {
+        return threads;
+    }
+
+    /**
+     * Gets the thread members in this portion of the threads list.
+     *
+     * @return The thread members in this portion of the threads list.
+     */
+    public List<ThreadMember> getMembers() {
+        return members;
+    }
+
+    /**
+     * Combines this portion of the threads list with another portion.
+     *
+     * @param other The other portion to combine with.
+     * @return A new {@link ThreadListPart} with both parts.
+     */
+    public ThreadListPart combine(ThreadListPart other) {
+        List<ThreadChannel> combineThreads = new ArrayList<>(threads.size() + other.threads.size());
+        combineThreads.addAll(threads);
+        combineThreads.addAll(other.threads);
+
+        List<ThreadMember> combineMembers = new ArrayList<>(members.size() + other.members.size());
+        combineMembers.addAll(members);
+        combineMembers.addAll(other.members);
+
+        return new ThreadListPart(combineThreads, combineMembers);
+    }
+}

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -1869,6 +1869,27 @@ public final class Guild implements Entity {
         return gateway.getVoiceConnectionRegistry().getVoiceConnection(getId());
     }
 
+    /**
+     * Requests to retrieve the active threads of the guild.
+     * <p>
+     * The audit log parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * guild.getActiveThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually emits the {@link ThreadListPart threads} of the guild. If an error is
+     * received, it is emitted through the {@code Flux}.
+     */
+    public Mono<ThreadListPart> getActiveThreads() {
+        return gateway.getRestClient().getGuildService()
+                .listActiveGuildThreads(data.id().asLong())
+                .map(data -> new ThreadListPart(gateway, data));
+    }
+
     @Override
     public boolean equals(@Nullable final Object obj) {
         return EntityUtil.equals(this, obj);

--- a/core/src/main/java/discord4j/core/object/entity/ThreadMember.java
+++ b/core/src/main/java/discord4j/core/object/entity/ThreadMember.java
@@ -63,7 +63,7 @@ public final class ThreadMember {
      */
     public Snowflake getThreadId() {
         // ThreadMemberData#id is absent in GUILD_CREATE (threads self is part of)
-        // D4J should be able to include the missing value with the outer thread id when creating ThreadMember
+        // TODO D4J should be able to include the missing value with the outer thread id when creating ThreadMember
         return Snowflake.of(data.id().toOptional().orElseThrow(IllegalStateException::new));
     }
 
@@ -74,7 +74,7 @@ public final class ThreadMember {
      */
     public Snowflake getUserId() {
         // ThreadMemberData#userId is absent in GUILD_CREATE (threads self is part of)
-        // D4J should be able to include the missing value with the self id when creating ThreadMember
+        // TODO D4J should be able to include the missing value with the self id when creating ThreadMember
         return Snowflake.of(data.userId().toOptional().orElseThrow(IllegalStateException::new));
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/ThreadMember.java
+++ b/core/src/main/java/discord4j/core/object/entity/ThreadMember.java
@@ -47,18 +47,42 @@ public final class ThreadMember {
         this.data = Objects.requireNonNull(data);
     }
 
+    /**
+     * Gets the data of the thread member.
+     *
+     * @return The data of the thread member.
+     */
+    public ThreadMemberData getData() {
+        return data;
+    }
+
+    /**
+     * Gets the ID of thread which member is associated.
+     *
+     * @return The ID of thread channel.
+     */
     public Snowflake getThreadId() {
         // ThreadMemberData#id is absent in GUILD_CREATE (threads self is part of)
         // D4J should be able to include the missing value with the outer thread id when creating ThreadMember
         return Snowflake.of(data.id().toOptional().orElseThrow(IllegalStateException::new));
     }
 
+    /**
+     * Gets the ID of user.
+     *
+     * @return The ID of user.
+     */
     public Snowflake getUserId() {
         // ThreadMemberData#userId is absent in GUILD_CREATE (threads self is part of)
         // D4J should be able to include the missing value with the self id when creating ThreadMember
         return Snowflake.of(data.userId().toOptional().orElseThrow(IllegalStateException::new));
     }
 
+    /**
+     * Gets when the user joined the thread.
+     *
+     * @return When the user joined the thread.
+     */
     public Instant getJoinTimestamp() {
         return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(data.joinTimestamp(), Instant::from);
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -20,6 +20,7 @@ import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.Member;
+import discord4j.core.object.entity.ThreadMember;
 import discord4j.core.object.entity.User;
 import discord4j.core.retriever.EntityRetrievalStrategy;
 import discord4j.core.spec.ThreadChannelEditMono;
@@ -28,6 +29,7 @@ import discord4j.core.util.EntityUtil;
 import discord4j.discordjson.json.ChannelData;
 import discord4j.discordjson.json.ThreadMetadata;
 import discord4j.rest.util.PermissionSet;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -75,6 +77,50 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
         return Mono.justOrEmpty(getParentId())
                 .flatMap(getClient().withRetrievalStrategy(retrievalStrategy)::getChannelById)
                 .cast(TopLevelGuildMessageChannel.class);
+    }
+
+    /**
+     * Requests to retrieve the member of this thread.
+     *
+     * @param userId The ID of the user.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link ThreadMember member} of this thread. If
+     * an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<ThreadMember> getMember(Snowflake userId) {
+        return getClient().getThreadMemberById(getId(), userId);
+    }
+
+    /**
+     * Requests to retrieve the member of this thread, using the given retrieval strategy.
+     *
+     * @param userId The ID of the user.
+     * @param retrievalStrategy the strategy to use to get the thread member
+     * @return A {@link Mono} where, upon successful completion, emits the {@link ThreadMember member} of this thread. If
+     * an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<ThreadMember> getMember(Snowflake userId, EntityRetrievalStrategy retrievalStrategy) {
+        return getClient().withRetrievalStrategy(retrievalStrategy)
+                .getThreadMemberById(getId(), userId);
+    }
+
+    /**
+     * Returns all members of this thread.
+     *
+     * @return A {@link Flux} that continually emits all {@link ThreadMember members} of this thread.
+     */
+    public Flux<ThreadMember> getThreadMembers() {
+        return getClient().getThreadMembers(getId());
+    }
+
+    /**
+     * Returns all members of this thread, using the given retrieval strategy.
+     *
+     * @param retrievalStrategy the strategy to use to get the thread members
+     * @return A {@link Flux} that continually emits all {@link ThreadMember members} of this thread.
+     */
+    public Flux<ThreadMember> getThreadMembers(EntityRetrievalStrategy retrievalStrategy) {
+        return getClient().withRetrievalStrategy(retrievalStrategy)
+                .getThreadMembers(getId());
     }
 
     public int getApproximateMessageCount() {

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
@@ -16,6 +16,7 @@
  */
 package discord4j.core.object.entity.channel;
 
+import discord4j.core.object.ThreadListPart;
 import discord4j.core.object.entity.Webhook;
 import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.WebhookCreateMono;
@@ -110,5 +111,65 @@ public interface TopLevelGuildMessageChannel extends CategorizableChannel, Guild
         return getClient().getRestClient().getChannelService()
                 .startThreadWithoutMessage(getId().asLong(), spec.asRequest())
                 .map(data -> new ThreadChannel(getClient(), data));
+    }
+
+    /**
+     * Requests to retrieve the public archived threads for this channel.
+     * <p>
+     * The audit log parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getPublicArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    default Flux<ThreadListPart> getPublicArchivedThreads() {
+        return getRestChannel().getPublicArchivedThreads()
+                .map(data -> new ThreadListPart(getClient(), data));
+    }
+
+    /**
+     * Requests to retrieve the private archived threads for this channel.
+     * <p>
+     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getPrivateArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    default Flux<ThreadListPart> getPrivateArchivedThreads() {
+        return getRestChannel().getPrivateArchivedThreads()
+                .map(data -> new ThreadListPart(getClient(), data));
+    }
+
+    /**
+     * Requests to retrieve the joined private archived threads for this channel.
+     * <p>
+     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getJoinedPrivateArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    default Flux<ThreadListPart> getJoinedPrivateArchivedThreads() {
+        return getRestChannel().getJoinedPrivateArchivedThreads()
+                .map(data -> new ThreadListPart(getClient(), data));
     }
 }

--- a/core/src/main/java/discord4j/core/retriever/EntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/EntityRetriever.java
@@ -16,14 +16,7 @@
  */
 package discord4j.core.retriever;
 
-import discord4j.core.object.entity.Guild;
-import discord4j.core.object.entity.GuildEmoji;
-import discord4j.core.object.entity.GuildSticker;
-import discord4j.core.object.entity.Member;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.Role;
-import discord4j.core.object.entity.StageInstance;
-import discord4j.core.object.entity.User;
+import discord4j.core.object.entity.*;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.GuildChannel;
 import discord4j.core.util.OrderUtil;
@@ -165,6 +158,7 @@ public interface EntityRetriever {
      * The order of items emitted by the returned {@code Flux} is unspecified. Use {@link OrderUtil#orderRoles(Flux)}
      * to consistently order roles.
      *
+     * @param guildId The ID of the guild.
      * @return A {@link Flux} that continually emits the guild's {@link Role roles}. If an error is received, it is
      * emitted through the {@code Flux}.
      */
@@ -173,6 +167,7 @@ public interface EntityRetriever {
     /**
      * Requests to retrieve the guild's emojis.
      *
+     * @param guildId The ID of the guild.
      * @return A {@link Flux} that continually emits the guild's {@link GuildEmoji emojis}. If an error is received,
      * it is emitted through the {@code Flux}.
      */
@@ -190,8 +185,28 @@ public interface EntityRetriever {
     /**
      * Requests to retrieve the guild's stickers.
      *
+     * @param guildId The ID of the guild.
      * @return A {@link Flux} that continually emits the guild's {@link GuildSticker stickers}. If an error is received,
      * it is emitted through the {@code Flux}.
      */
     Flux<GuildSticker> getGuildStickers(Snowflake guildId);
+
+    /**
+     * Requests to retrieve the thread member associated to the supplied thread ID and user ID.
+     *
+     * @param threadId The ID of the thread.
+     * @param userId The ID of the user.
+     * @return A {@link Mono} where, upon successful completion, emits the {@link ThreadMember} associated to the supplied
+     *         thread ID and user ID. If an error is received, it is emitted through the {@code Mono}.
+     */
+    Mono<ThreadMember> getThreadMemberById(Snowflake threadId, Snowflake userId);
+
+    /**
+     * Requests to retrieve the thread's members.
+     *
+     * @param threadId The ID of the thread.
+     * @return A {@link Flux} that continually emits the thread's {@link ThreadMember members}. If an error is received,
+     * it is emitted through the {@code Flux}.
+     */
+    Flux<ThreadMember> getThreadMembers(Snowflake threadId);
 }

--- a/core/src/main/java/discord4j/core/retriever/FallbackEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/FallbackEntityRetriever.java
@@ -16,14 +16,7 @@
  */
 package discord4j.core.retriever;
 
-import discord4j.core.object.entity.Guild;
-import discord4j.core.object.entity.GuildEmoji;
-import discord4j.core.object.entity.GuildSticker;
-import discord4j.core.object.entity.Member;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.Role;
-import discord4j.core.object.entity.StageInstance;
-import discord4j.core.object.entity.User;
+import discord4j.core.object.entity.*;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.GuildChannel;
 import discord4j.common.util.Snowflake;
@@ -120,9 +113,18 @@ public class FallbackEntityRetriever implements EntityRetriever {
         return first.getStageInstanceByChannelId(channelId).switchIfEmpty(fallback.getStageInstanceByChannelId(channelId));
     }
 
-
     @Override
     public Flux<GuildSticker> getGuildStickers(Snowflake guildId) {
         return first.getGuildStickers(guildId).switchIfEmpty(fallback.getGuildStickers(guildId));
+    }
+
+    @Override
+    public Mono<ThreadMember> getThreadMemberById(Snowflake threadId, Snowflake userId) {
+        return first.getThreadMemberById(threadId, userId).switchIfEmpty(fallback.getThreadMemberById(threadId, userId));
+    }
+
+    @Override
+    public Flux<ThreadMember> getThreadMembers(Snowflake threadId) {
+        return first.getThreadMembers(threadId).switchIfEmpty(fallback.getThreadMembers(threadId));
     }
 }

--- a/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
@@ -167,6 +167,18 @@ public class RestEntityRetriever implements EntityRetriever {
             .map(data -> new GuildSticker(gateway, data, guildId.asLong()));
     }
 
+    @Override
+    public Mono<ThreadMember> getThreadMemberById(Snowflake threadId, Snowflake userId) {
+        return rest.getChannelService().getThreadMember(threadId.asLong(), userId.asLong())
+                .map(data -> new ThreadMember(gateway, data));
+    }
+
+    @Override
+    public Flux<ThreadMember> getThreadMembers(Snowflake threadId) {
+        return rest.getChannelService().listThreadMembers(threadId.asLong())
+                .map(data -> new ThreadMember(gateway, data));
+    }
+
     private GuildData toGuildData(GuildUpdateData guild) {
         return GuildData.builder()
                 .from(guild)

--- a/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/StoreEntityRetriever.java
@@ -143,6 +143,18 @@ public class StoreEntityRetriever implements EntityRetriever {
     @Override
     public Flux<GuildSticker> getGuildStickers(Snowflake guildId) {
         return Flux.from(store.execute(ReadActions.getStickersInGuild(guildId.asLong())))
-            .map(data -> new GuildSticker(gateway, data, guildId.asLong()));
+                .map(data -> new GuildSticker(gateway, data, guildId.asLong()));
+    }
+
+    @Override
+    public Mono<ThreadMember> getThreadMemberById(Snowflake threadId, Snowflake userId) {
+        return Mono.from(store.execute(ReadActions.getThreadMemberById(threadId.asLong(), userId.asLong())))
+                .map(data -> new ThreadMember(gateway, data));
+    }
+
+    @Override
+    public Flux<ThreadMember> getThreadMembers(Snowflake threadId) {
+        return Flux.from(store.execute(ReadActions.getMembersInThread(threadId.asLong())))
+                .map(data -> new ThreadMember(gateway, data));
     }
 }

--- a/core/src/test/java/discord4j/core/ExampleThread.java
+++ b/core/src/test/java/discord4j/core/ExampleThread.java
@@ -20,6 +20,7 @@ package discord4j.core;
 import discord4j.common.util.Snowflake;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.event.domain.interaction.MessageInteractionEvent;
+import discord4j.core.event.domain.thread.ThreadEvent;
 import discord4j.core.object.command.ApplicationCommand;
 import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.command.ApplicationCommandInteractionOptionValue;
@@ -35,6 +36,8 @@ import discord4j.discordjson.json.ApplicationCommandOptionData;
 import discord4j.discordjson.json.ApplicationCommandRequest;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -46,6 +49,8 @@ import static reactor.function.TupleUtils.function;
  * Showcase some thread operations under a given test guild. Requires TOKEN and GUILD_ID environment variables.
  */
 public class ExampleThread {
+
+    private static final Logger log = Loggers.getLogger(ExampleThread.class);
 
     private static final String TOKEN = System.getenv("TOKEN");
     private static final long GUILD_ID = Long.parseLong(System.getenv("GUILD_ID"));
@@ -277,7 +282,13 @@ public class ExampleThread {
                         return Mono.empty();
                     });
 
-                    return createCommands.then(Mono.when(onChatInput, onMessage));
+                    // Listen to new thread events
+                    Publisher<?> listenThreadEvents = client.on(ThreadEvent.class, event -> {
+                        log.info("Thread event: {}", event);
+                        return Mono.empty();
+                    });
+
+                    return createCommands.then(Mono.when(onChatInput, onMessage, listenThreadEvents));
                 })
                 .block();
     }

--- a/gateway/src/main/java/discord4j/gateway/state/DispatchStoreLayer.java
+++ b/gateway/src/main/java/discord4j/gateway/state/DispatchStoreLayer.java
@@ -62,6 +62,12 @@ public class DispatchStoreLayer {
         add(GuildRoleDelete.class::isInstance, GatewayActions::guildRoleDelete);
         add(GuildRoleUpdate.class::isInstance, GatewayActions::guildRoleUpdate);
         add(GuildUpdate.class::isInstance, GatewayActions::guildUpdate);
+        add(ThreadCreate.class::isInstance, GatewayActions::threadCreate);
+        add(ThreadUpdate.class::isInstance, GatewayActions::threadUpdate);
+        add(ThreadDelete.class::isInstance, GatewayActions::threadDelete);
+        add(ThreadListSync.class::isInstance, GatewayActions::threadListSync);
+        add(ThreadMemberUpdate.class::isInstance, GatewayActions::threadMemberUpdate);
+        add(ThreadMembersUpdate.class::isInstance, GatewayActions::threadMembersUpdate);
         add(MessageCreate.class::isInstance, GatewayActions::messageCreate);
         add(MessageDelete.class::isInstance, GatewayActions::messageDelete);
         add(MessageDeleteBulk.class::isInstance, GatewayActions::messageDeleteBulk);

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -329,6 +329,10 @@ public class RestGuild {
         return restClient.getTemplateService().getTemplates(id);
     }
 
+    public Mono<ListThreadsData> getActiveThreads() {
+        return restClient.getGuildService().listActiveGuildThreads(id);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -376,8 +376,6 @@ public abstract class Routes {
 
     public static final Route LIST_THREAD_MEMBERS = Route.get("/channels/{channel.id}/thread-members");
 
-    public static final Route LIST_ACTIVE_THREADS = Route.get("/channels/{channel.id}/threads/active");
-
     public static final Route LIST_PUBLIC_ARCHIVED_THREADS = Route.get("/channels/{channel.id}/threads/archived/public");
 
     public static final Route LIST_PRIVATE_ARCHIVED_THREADS = Route.get("/channels/{channel.id}/threads/archived/private");

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -831,6 +831,8 @@ public abstract class Routes {
      */
     public static final Route OTHERS_VOICE_STATE_MODIFY = Route.patch("/guilds/{guild.id}/voice-states/{user.id}");
 
+    public static final Route LIST_ACTIVE_GUILD_THREADS = Route.get("/guilds/{guild.id}/threads/active");
+
     /////////////////////////////////////////////
     ////////////// Invite Resource //////////////
     /////////////////////////////////////////////

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -372,6 +372,8 @@ public abstract class Routes {
 
     public static final Route REMOVE_THREAD_MEMBER = Route.delete("/channels/{channel.id}/thread-members/{user.id}");
 
+    public static final Route GET_THREAD_MEMBER = Route.get("/channels/{channel.id}/thread-members/{user.id}");
+
     public static final Route LIST_THREAD_MEMBERS = Route.get("/channels/{channel.id}/thread-members");
 
     public static final Route LIST_ACTIVE_THREADS = Route.get("/channels/{channel.id}/threads/active");
@@ -1183,5 +1185,4 @@ public abstract class Routes {
     public static final Route MODIFY_STAGE_INSTANCE = Route.patch("/stage-instances/{channel.id}");
 
     public static final Route DELETE_STAGE_INSTANCE = Route.delete("/stage-instances/{channel.id}");
-
 }

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -288,13 +288,6 @@ public class ChannelService extends RestService {
                 .flatMapMany(Flux::fromArray);
     }
 
-    // TODO is this not paginated?
-    public Mono<ListThreadsData> listActiveThreads(long channelId) {
-        return Routes.LIST_ACTIVE_THREADS.newRequest(channelId)
-                .exchange(getRouter())
-                .bodyToMono(ListThreadsData.class);
-    }
-
     public Mono<ListThreadsData> listPublicArchivedThreads(long channelId, Map<String, Object> queryParams) {
         return Routes.LIST_PUBLIC_ARCHIVED_THREADS.newRequest(channelId)
                 .query(queryParams)

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -275,6 +275,12 @@ public class ChannelService extends RestService {
                 .bodyToMono(Void.class);
     }
 
+    public Mono<ThreadMemberData> getThreadMember(long channelId, long userId) {
+        return Routes.GET_THREAD_MEMBER.newRequest(channelId, userId)
+                .exchange(getRouter())
+                .bodyToMono(ThreadMemberData.class);
+    }
+
     public Flux<ThreadMemberData> listThreadMembers(long channelId) {
         return Routes.LIST_THREAD_MEMBERS.newRequest(channelId)
                 .exchange(getRouter())

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -332,4 +332,9 @@ public class GuildService extends RestService {
             .bodyToMono(Void.class);
     }
 
+    public Mono<ListThreadsData> listActiveGuildThreads(long guildId) {
+        return Routes.LIST_ACTIVE_GUILD_THREADS.newRequest(guildId)
+                .exchange(getRouter())
+                .bodyToMono(ListThreadsData.class);
+    }
 }


### PR DESCRIPTION
**Description:**
Depends on Discord4J/discord-json#127
- Added methods for saving and accessing thread and thread's members. But I want to know whether or not to add `countThreads()`/`countMembersInThread()` methods
- Exposed methods to `EntityRetreiver` and `ThreadChannel`, `Guild`, updated  `RestChannel`, `RestGuild`
- Created new object `ThreadListPart` object which is used for the result in listing methods

**Justification:** Implement full support of threads for persisting

# API Changes
- Remove ChannelService#listActiveThreads: instead use GuildService#listActiveGuildThreads
