### PR TITLE
Change implemenetations of `getX(id/name)` methods in application commands objects

### DIFF
--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommand.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommand.java
@@ -178,9 +178,10 @@ public class ApplicationCommand implements DiscordObject {
      * @return The option corresponding to the provided name, if present.
      */
     public Optional<ApplicationCommandOption> getOption(final String name) {
-        return getOptions().stream()
-                .filter(option -> option.getName().equals(name))
-                .findFirst();
+        return data.options().toOptional().orElse(Collections.emptyList()).stream()
+                .filter(option -> option.name().equals(name))
+                .findFirst()
+                .map(data -> new ApplicationCommandOption(gateway, data));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteraction.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteraction.java
@@ -131,9 +131,11 @@ public class ApplicationCommandInteraction implements DiscordObject {
      * @return The option corresponding to the provided name, if present.
      */
     public Optional<ApplicationCommandInteractionOption> getOption(final String name) {
-        return getOptions().stream()
-                .filter(option -> option.getName().equals(name))
-                .findFirst();
+        return data.options().toOptional().orElse(Collections.emptyList()).stream()
+                .filter(option -> option.name().equals(name))
+                .findFirst()
+                .map(data -> new ApplicationCommandInteractionOption(gateway, data, guildId,
+                        this.data.resolved().toOptional().orElse(null)));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionOption.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionOption.java
@@ -111,9 +111,10 @@ public class ApplicationCommandInteractionOption implements DiscordObject {
      * @return The option corresponding to the provided name, if present.
      */
     public Optional<ApplicationCommandInteractionOption> getOption(final String name) {
-        return getOptions().stream()
-                .filter(data -> data.getName().equals(name))
-                .findFirst();
+        return data.options().toOptional().orElse(Collections.emptyList()).stream()
+                .filter(data -> data.name().equals(name))
+                .findFirst()
+                .map(data -> new ApplicationCommandInteractionOption(gateway, data, guildId, resolved));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionResolved.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteractionResolved.java
@@ -84,7 +84,9 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
      * @return the resolved channel, if present
      */
     public Optional<ResolvedChannel> getChannel(Snowflake channelId) {
-        return Optional.ofNullable(getChannels().get(channelId));
+        return data.channels().toOptional()
+                .map(channels -> channels.get(channelId.asString()))
+                .map(data -> new ResolvedChannel(gateway, data));
     }
 
     /**
@@ -110,7 +112,9 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
      * @return the resolved user, if present
      */
     public Optional<User> getUser(Snowflake userId) {
-        return Optional.ofNullable(getUsers().get(userId));
+        return data.users().toOptional()
+                .map(users -> users.get(userId.asString()))
+                .map(data -> new User(gateway, data));
     }
 
     /**
@@ -135,7 +139,11 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
      * @return the resolved member, if present
      */
     public Optional<ResolvedMember> getMember(Snowflake memberId) {
-        return Optional.ofNullable(getMembers().get(memberId));
+        return data.members().toOptional()
+                .map(members -> members.get(memberId.asString()))
+                .map(memberData -> new ResolvedMember(gateway, memberData,
+                        getUser(memberId).map(User::getUserData).orElseThrow(IllegalStateException::new),
+                        Objects.requireNonNull(guildId)));
     }
 
     /**
@@ -150,7 +158,7 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
                             final Snowflake id = Snowflake.of(entry.getKey());
                             return Tuples.of(id, new ResolvedMember(gateway, entry.getValue(),
                                     getUser(id).map(User::getUserData).orElseThrow(IllegalStateException::new),
-                                    Optional.ofNullable(guildId).orElseThrow(IllegalStateException::new)));
+                                    Objects.requireNonNull(guildId)));
                         })
                         .collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2)))
                 .orElseGet(Collections::emptyMap);
@@ -163,7 +171,9 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
      * @return the resolved role, if present
      */
     public Optional<Role> getRole(Snowflake roleId) {
-        return Optional.ofNullable(getRoles().get(roleId));
+        return data.roles().toOptional()
+                .map(roles -> roles.get(roleId.asString()))
+                .map(data -> new Role(gateway, data, Objects.requireNonNull(guildId)));
     }
 
     /**
@@ -175,7 +185,7 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
         return data.roles().toOptional()
                 .map(map -> map.entrySet().stream()
                         .map(entry -> Tuples.of(Snowflake.of(entry.getKey()), new Role(gateway, entry.getValue(),
-                                Optional.ofNullable(guildId).orElseThrow(IllegalStateException::new))))
+                                Objects.requireNonNull(guildId))))
                         .collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2)))
                 .orElseGet(Collections::emptyMap);
     }
@@ -187,7 +197,9 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
      * @return the resolved message, if present
      */
     public Optional<Message> getMessage(Snowflake messageId) {
-        return Optional.ofNullable(getMessages().get(messageId));
+        return data.messages().toOptional()
+                .map(messages -> messages.get(messageId.asString()))
+                .map(data -> new Message(gateway, data));
     }
 
     /**
@@ -211,7 +223,9 @@ public class ApplicationCommandInteractionResolved implements DiscordObject {
      * @return the resolved attachment, if present
      */
     public Optional<Attachment> getAttachment(Snowflake attachmentId) {
-        return Optional.ofNullable(getAttachments().get(attachmentId));
+        return data.attachments().toOptional()
+                .map(attachments -> attachments.get(attachmentId.asString()))
+                .map(data -> new Attachment(gateway, data));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandOption.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandOption.java
@@ -139,9 +139,10 @@ public class ApplicationCommandOption implements DiscordObject {
      * @return The choice corresponding to the provided name, if present.
      */
     public Optional<ApplicationCommandOptionChoice> getChoice(final String name) {
-        return getChoices().stream()
-                .filter(choice -> choice.getName().equals(name))
-                .findFirst();
+        return data.choices().toOptional().orElse(Collections.emptyList()).stream()
+                .filter(choice -> choice.name().equals(name))
+                .findFirst()
+                .map(data -> new ApplicationCommandOptionChoice(gateway, data));
     }
 
     /**
@@ -165,9 +166,10 @@ public class ApplicationCommandOption implements DiscordObject {
      * subcommand group type.
      */
     public Optional<ApplicationCommandOption> getOption(final String name) {
-        return getOptions().stream()
-                .filter(option -> option.getName().equals(name))
-                .findFirst();
+        return data.options().toOptional().orElse(Collections.emptyList()).stream()
+                .filter(option -> option.name().equals(name))
+                .findFirst()
+                .map(data -> new ApplicationCommandOption(gateway, data));
     }
 
     /**


### PR DESCRIPTION
**Description:** Replace current variants of the `getX(id/name)` methods in application commands objects to faster and creating less garbage

**Justification:** Current implementations recollect lists and maps which is often redundant, especially in `ApplicationCommandInteractionResolved`
