### PR TITLE
fixed ExtendedInvite.getExpiration falsely depending on temporary membership

### DIFF
--- a/core/src/main/java/discord4j/core/object/ExtendedInvite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedInvite.java
@@ -69,10 +69,17 @@ public final class ExtendedInvite extends Invite {
      * @return The instant this invite expires, if possible.
      */
     public Optional<Instant> getExpiration() {
-        final boolean temporary = getData().temporary().toOptional().orElse(false);
         final int maxAge = getData().maxAge().toOptional().orElseThrow(IllegalStateException::new);
+        return Optional.of(getCreation().plus(maxAge, ChronoUnit.SECONDS));
+    }
 
-        return temporary ? Optional.of(getCreation().plus(maxAge, ChronoUnit.SECONDS)) : Optional.empty();
+    /**
+     * Gets the temporary member status of the joined user
+     * @return true if the invite only grant temporary membership
+     */
+    public boolean isTemporary() {
+        return getData().temporary().toOptional()
+            .orElseThrow(IllegalStateException::new);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/ExtendedInvite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedInvite.java
@@ -66,11 +66,11 @@ public final class ExtendedInvite extends Invite {
     /**
      * Gets the instant this invite expires, if possible.
      *
-     * @return The instant this invite expires, if possible.
+     * @return The instant this invite expires, if empty, invite is never expiring.
      */
     public Optional<Instant> getExpiration() {
         final int maxAge = getData().maxAge().toOptional().orElseThrow(IllegalStateException::new);
-        return Optional.of(getCreation().plus(maxAge, ChronoUnit.SECONDS));
+        return maxAge > 0 ? Optional.of(getCreation().plus(maxAge, ChronoUnit.SECONDS)): Optional.empty();
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/ExtendedInvite.java
+++ b/core/src/main/java/discord4j/core/object/ExtendedInvite.java
@@ -74,8 +74,9 @@ public final class ExtendedInvite extends Invite {
     }
 
     /**
-     * Gets the temporary member status of the joined user
-     * @return true if the invite only grant temporary membership
+     * Gets whether this invite only grants temporary membership.
+     *
+     * @return {@code true} if this invite only grants temporary membership
      */
     public boolean isTemporary() {
         return getData().temporary().toOptional()


### PR DESCRIPTION
…bership attribute

<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->

Fixed ExtendedInvite.getExpiration() falsely depending on the temporary membership flag on the invite.
It seems that the temporary keyword has been misinterpreted.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
https://discord.com/developers/docs/resources/invite#invite-metadata-object-invite-metadata-structure

`
Invite Metadata Structure
[...]
temporary | boolean | whether this invite only grants temporary membership`
