### PR TITLE
Fix Permission enum according to official discord doc

### DIFF
--- a/rest/src/main/java/discord4j/rest/util/Permission.java
+++ b/rest/src/main/java/discord4j/rest/util/Permission.java
@@ -85,9 +85,6 @@ public enum Permission {
     /** Allows the usage of custom emojis from other servers. */
     USE_EXTERNAL_EMOJIS(0x00040000, false),
 
-    /** Allows the usage of custom stickers from other servers. */
-    USE_EXTERNAL_STICKERS(0x00000020000000, false),
-
     /** Allows for viewing guild insights. */
     VIEW_GUILD_INSIGHTS(0x00080000, false),
 
@@ -132,14 +129,42 @@ public enum Permission {
     /** Allows management and editing of emojis and stickers. */
     MANAGE_EMOJIS_AND_STICKERS(0x40000000, true),
 
-    /** Allows members to use slash commands in text channels. */
+    /** Allows members to use slash commands in text channels.
+     *
+     *  @deprecated Deprecated in favor of {@link Permission#USE_APPLICATION_COMMANDS}
+     */
+    @Deprecated
     USE_SLASH_COMMANDS(0x80000000L, false),
+
+    /** Allows members to use application commands, including slash commands and context menu commands. */
+    USE_APPLICATION_COMMANDS(0x80000000L, false),
 
     /**
      * Allows for requesting to speak in stage channels.
      */
     @Experimental
-    REQUEST_TO_SPEAK(0x100000000L, false),
+    REQUEST_TO_SPEAK(0x0000000100000000L, false),
+
+    /** Allows for creating, editing, and deleting scheduled events. */
+    MANAGE_EVENTS(0x0000000200000000L, false),
+
+    /** Allows for deleting and archiving threads, and viewing all private threads. */
+    MANAGE_THREADS(0x0000000400000000L, true),
+
+    /** Allows for creating public and announcement threads. */
+    CREATE_PUBLIC_THREADS(0x0000000800000000L, false),
+
+    /** Allows for creating private threads. */
+    CREATE_PRIVATE_THREADS(0x0000001000000000L, false),
+
+    /** Allows the usage of custom stickers from other servers. */
+    USE_EXTERNAL_STICKERS(0x0000002000000000L, false),
+
+    /** Allows for sending messages in threads */
+    SEND_MESSAGES_IN_THREADS(0x0000004000000000L, false),
+
+    /** Allows for using Activities (applications with the EMBEDDED flag) in a voice channel. */
+    USE_EMBEDDED_ACTIVITIES(0x0000008000000000L, false),
 
     /**
      * Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels.


### PR DESCRIPTION
**Description:** Fixes issues in Permission enum:

 * Wrong value for USE_EXTERNAL_STICKERS
 * Wrong name for USE_SLASH_COMMANDS instead of USE_APPLICATION_COMMANDS in official doc
 * Missing enum constants: MANAGE_EVENTS, MANAGE_THREADS, SEND_MESSAGES_IN_THREADS and USE_EMBEDDED_ACTIVITIES (MANAGE_THREADS exists in 3.3.x)
 * Missing enum constants: CREATE_PUBLIC_THREADS and CREATE_PRIVATE_THREADS, they exist in 3.3.x, but have wrong names (USE_PUBLIC_THREADS and USE_PRIVATE_THREADS)
 * Bad location of USE_EXTERNAL_STICKERS enum constant, according to value numerical order.

**Justification:** The relevant issue is here: https://github.com/Discord4J/Discord4J/issues/1098
