### PR TITLE
Add support for new select menu components

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
@@ -274,6 +274,10 @@ public class DispatchHandlers implements DispatchEventMapper {
                     case BUTTON:
                         return Mono.just(new ButtonInteractionEvent(gateway, context.getShardInfo(), interaction));
                     case SELECT_MENU:
+                    case SELECT_MENU_ROLE:
+                    case SELECT_MENU_USER:
+                    case SELECT_MENU_MENTIONABLE:
+                    case SELECT_MENU_CHANNEL:
                         return Mono.just(new SelectMenuInteractionEvent(gateway, context.getShardInfo(), interaction));
                     default:
                         return Mono.just(new ComponentInteractionEvent(gateway, context.getShardInfo(), interaction));

--- a/core/src/main/java/discord4j/core/event/domain/interaction/SelectMenuInteractionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/SelectMenuInteractionEvent.java
@@ -20,6 +20,7 @@ import discord4j.common.annotations.Experimental;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.command.ApplicationCommandInteraction;
 import discord4j.core.object.command.Interaction;
+import discord4j.core.object.component.MessageComponent;
 import discord4j.core.object.component.SelectMenu;
 import discord4j.gateway.ShardInfo;
 
@@ -53,9 +54,10 @@ public class SelectMenuInteractionEvent extends ComponentInteractionEvent {
     }
 
     /**
-     * Get the values selected in the menu.
+     * Get the string values selected in the menu.
+     * If type of select menu is not {@link MessageComponent.Type#SELECT_MENU} then ids of entities will be returned.
      *
-     * @return The values selected in the menu.
+     * @return The string values selected in the menu.
      * @see SelectMenu.Option#getValue()
      */
     public List<String> getValues() {

--- a/core/src/main/java/discord4j/core/object/component/MessageComponent.java
+++ b/core/src/main/java/discord4j/core/object/component/MessageComponent.java
@@ -37,6 +37,10 @@ public class MessageComponent {
         switch (Type.of(data.type())) {
             case ACTION_ROW: return new ActionRow(data);
             case BUTTON: return new Button(data);
+            case SELECT_MENU_ROLE:
+            case SELECT_MENU_CHANNEL:
+            case SELECT_MENU_MENTIONABLE:
+            case SELECT_MENU_USER:
             case SELECT_MENU: return new SelectMenu(data);
             case TEXT_INPUT: return new TextInput(data);
             default: return new MessageComponent(data);
@@ -72,7 +76,11 @@ public class MessageComponent {
         ACTION_ROW(1),
         BUTTON(2),
         SELECT_MENU(3),
-        TEXT_INPUT(4);
+        TEXT_INPUT(4),
+        SELECT_MENU_USER(5),
+        SELECT_MENU_ROLE(6),
+        SELECT_MENU_MENTIONABLE(7),
+        SELECT_MENU_CHANNEL(8);
 
         private final int value;
 
@@ -90,6 +98,10 @@ public class MessageComponent {
                 case 2: return BUTTON;
                 case 3: return SELECT_MENU;
                 case 4: return TEXT_INPUT;
+                case 5: return SELECT_MENU_USER;
+                case 6: return SELECT_MENU_ROLE;
+                case 7: return SELECT_MENU_MENTIONABLE;
+                case 8: return SELECT_MENU_CHANNEL;
                 default: return UNKNOWN;
             }
         }

--- a/core/src/main/java/discord4j/core/object/component/SelectMenu.java
+++ b/core/src/main/java/discord4j/core/object/component/SelectMenu.java
@@ -94,6 +94,17 @@ public class SelectMenu extends ActionComponent {
      * @param channelTypes The allowed channel types.
      * @return A select menu with the given data.
      */
+    public static SelectMenu ofChannel(String customId, Channel.Type... channelTypes) {
+        return of(Type.SELECT_MENU_CHANNEL, customId, null, Arrays.asList(channelTypes));
+    }
+
+    /**
+     * Creates a channel select menu.
+     *
+     * @param customId A developer-defined identifier for the select menu.
+     * @param channelTypes The allowed channel types.
+     * @return A select menu with the given data.
+     */
     public static SelectMenu ofChannel(String customId, List<Channel.Type> channelTypes) {
         return of(Type.SELECT_MENU_CHANNEL, customId, null, channelTypes);
     }

--- a/core/src/test/java/discord4j/core/ExampleSelectMenu.java
+++ b/core/src/test/java/discord4j/core/ExampleSelectMenu.java
@@ -22,8 +22,11 @@ import discord4j.core.event.domain.interaction.SelectMenuInteractionEvent;
 import discord4j.core.object.component.ActionRow;
 import discord4j.core.object.component.SelectMenu;
 import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.TextChannel;
 import reactor.core.publisher.Mono;
+
+import java.util.Collections;
 
 public class ExampleSelectMenu {
 
@@ -39,18 +42,18 @@ public class ExampleSelectMenu {
                             .next()
                             .flatMap(e -> e.getGuild().getChannelById(Snowflake.of(channelId)))
                             .ofType(TextChannel.class)
-                            .flatMap(channel -> channel.createMessage(msg -> {
-                                msg.setContent("Select some options!");
-                                msg.setComponents(
-                                        ActionRow.of(
-                                                SelectMenu.of("mySelectMenu",
-                                                        SelectMenu.Option.of("option 1", "foo"),
-                                                        SelectMenu.Option.of("option 2", "bar"),
-                                                        SelectMenu.Option.of("option 3", "baz"))
-                                                        .withMaxValues(2)
-                                        )
-                                );
-                            }));
+                            .flatMap(channel -> channel.createMessage("Select some string options!")
+                                    .withComponents(ActionRow.of(
+                                            SelectMenu.of("mySelectMenu1",
+                                                            SelectMenu.Option.of("option 1", "foo"),
+                                                            SelectMenu.Option.of("option 2", "bar"),
+                                                            SelectMenu.Option.of("option 3", "baz"))
+                                                    .withMaxValues(2)))
+                                    .then(channel.createMessage("Select some user options!")
+                                            .withComponents(ActionRow.of(SelectMenu.ofUser("mySelectMenu2"))))
+                                    .then(channel.createMessage("Select some channel options!")
+                                            .withComponents(ActionRow.of(SelectMenu.ofChannel("mySelectMenu3",
+                                                    Collections.singletonList(Channel.Type.GUILD_TEXT))))));
 
                     return sendMessage
                             .map(Message::getId)


### PR DESCRIPTION
**Description:** Add new factory methods for role, user and other types of select menu components.
Since now `MessageComponent.Type.SELECT_MENU` is not the only one, it's maybe better to rename it to `SELECT_MENU_TEXT`

Depends on https://github.com/Discord4J/discord-json/pull/129

**Justification:** https://discord.com/developers/docs/change-log#new-select-menu-components
