### PR TITLE
[ci skip] Improvement of Workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,7 +54,7 @@ jobs:
   release:
     name: Publish artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' && github.repository != 'Discord4J/Discord4J' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'Discord4J/Discord4J' }}
     needs: build
     env:
         HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,14 +53,14 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && ( (vars.runReleaseOnPush || 'true') == 'true' || contains(github.event.head_commit.message, '[release]') ) }}
     needs: build
     env:
-        HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
+        HAS_CREDENTIALS: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
       - name: Validate repository secrets for publish
-        if: ${{ env.HAVE_SONAR_DATA != 'true' }}
+        if: ${{ env.HAS_CREDENTIALS != 'true' }}
         run: |
-            echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
-            echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
-            echo "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
+            echo '### Release Failed ❌' >> $GITHUB_STEP_SUMMARY
+            echo 'This repository does not have all required secrets: signingKey, signingPassword, sonatypeUsername or sonatypePassword).' >> $GITHUB_STEP_SUMMARY
+            echo "::error::This repository does not have all required secrets: signingKey, signingPassword, sonatypeUsername or sonatypePassword)."
             exit -1
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,9 +33,8 @@ jobs:
       - name: PR Check (PR Blocked by Dependency)
         if: ${{ contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR') }}
         run: |
-            echo '### ¡Build Failed! ❌' >> $GITHUB_STEP_SUMMARY
-            echo 'This PR depends of another PR to build correctly.' >> $GITHUB_STEP_SUMMARY
-            echo "::error::This PR is marked blocked because depends in another PR."
+            echo "::error::This PR is blocked to build because depends in another PR."
+            exit -1
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -60,10 +59,9 @@ jobs:
     steps:
       - name: Validate repository secrets for publish
         if: ${{ env.HAVE_SONAR_DATA != 'true' }}
-        run:  |
-            echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
-            echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
-            "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
+        run: |
+            echo "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
+            exit -1
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -50,14 +50,13 @@ jobs:
   release:
     name: Publish artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && ( (vars.runReleaseOnPush || 'true') == 'true' || contains(github.event.head_commit.message, '[release]') ) }}
     needs: build
     env:
-        RUN_RELEASE_ON_PUSH: ${{ vars.runReleaseOnPush || 'true' }}
         HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
       - name: Validate repository secrets for publish
-        if: ${{ ( env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') ) && env.HAVE_SONAR_DATA != 'true' }}
+        if: ${{ env.HAVE_SONAR_DATA != 'true' }}
         run: |
             echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
             echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
@@ -66,23 +65,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'temurin'
-        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - name: Publish with Gradle
         run: ./gradlew -x test publish
-        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signingPassword }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,7 +57,7 @@ jobs:
         HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
       - name: Validate repository secrets for publish
-        if: ${{ ( RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') ) && env.HAVE_SONAR_DATA != 'true' }}
+        if: ${{ ( env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') ) && env.HAVE_SONAR_DATA != 'true' }}
         run: |
             echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
             echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
@@ -66,23 +66,23 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
+        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
+        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'temurin'
-        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
+        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - name: Publish with Gradle
         run: ./gradlew -x test publish
-        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
+        if: ${{ env.RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signingPassword }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,6 +33,8 @@ jobs:
       - name: PR Check (PR Blocked by Dependency)
         if: ${{ contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR') }}
         run: |
+            echo '### ¡Build Failed! ❌' >> $GITHUB_STEP_SUMMARY
+            echo 'This PR depends of another PR to build correctly.' >> $GITHUB_STEP_SUMMARY
             echo "::error::This PR is blocked to build because depends in another PR."
             exit -1
       - uses: actions/checkout@v3
@@ -60,6 +62,8 @@ jobs:
       - name: Validate repository secrets for publish
         if: ${{ env.HAVE_SONAR_DATA != 'true' }}
         run: |
+            echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
+            echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
             echo "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
             exit -1
       - uses: actions/checkout@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,11 +25,16 @@ jobs:
   build:
     name: Build for JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'Discord4J/Discord4J' && !contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR')) }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'Discord4J/Discord4J' }}
     strategy:
       matrix:
         java: [ 8, 11 ]
     steps:
+      - name: PR Check (PR Blocked by Dependency)
+        if: ${{ contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR') }}
+        run: |
+            echo "This PR is marked blocked because depends in another PR."
+            exit 0
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,9 +32,7 @@ jobs:
     steps:
       - name: PR Check (PR Blocked by Dependency)
         if: ${{ contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR') }}
-        run: |
-            echo "This PR is marked blocked because depends in another PR."
-            exit 0
+        run: "::error::This PR is marked blocked because depends in another PR."
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -54,33 +52,25 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' && github.repository != 'Discord4J/Discord4J' }}
     needs: build
-    env:
-      HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
-      - name: Validate publish secrets
-        if: ${{ env.HAVE_SONAR_TOKEN != 'true' }}
-        run: |
-          echo "The secrets for publish are not set."
-          exit 0
+      - name: Validate repository secrets for publish
+        if: ${{ (secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '') != 'true' }}
+        run: "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
       - uses: actions/checkout@v3
-        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         with:
           fetch-depth: 0
       - uses: actions/cache@v3
-        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'temurin'
       - name: Publish with Gradle
-        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         run: ./gradlew -x test publish
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,11 +32,7 @@ jobs:
     steps:
       - name: PR Check (PR Blocked by Dependency)
         if: ${{ contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR') }}
-        run: |
-            echo '### ¡Build Failed! ❌' >> $GITHUB_STEP_SUMMARY
-            echo 'This PR depends of another PR to build correctly.' >> $GITHUB_STEP_SUMMARY
-            echo "::error::This PR is blocked to build because depends in another PR."
-            exit -1
+        run: echo "::warning::This PR was marked with the label 'PR depends on PR' this can cause issues in building"
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Set up JDK
         if: ${{ env.HAVE_SONAR_DATA == 'true' }}
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'corretto'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,10 @@ jobs:
     steps:
       - name: PR Check (PR Blocked by Dependency)
         if: ${{ contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR') }}
-        run: "::error::This PR is marked blocked because depends in another PR."
+        run: |
+            echo '### ¡Build Failed! ❌' >> $GITHUB_STEP_SUMMARY
+            echo 'This PR depends of another PR to build correctly.' >> $GITHUB_STEP_SUMMARY
+            echo "::error::This PR is marked blocked because depends in another PR."
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -57,7 +60,10 @@ jobs:
     steps:
       - name: Validate repository secrets for publish
         if: ${{ env.HAVE_SONAR_DATA != 'true' }}
-        run: "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
+        run:  |
+            echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
+            echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
+            "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,9 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' && github.repository != 'Discord4J/Discord4J' }}
     needs: build
+    env:
+        HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
       - name: Validate repository secrets for publish
-        if: ${{ (secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '') != 'true' }}
+        if: ${{ env.HAVE_SONAR_DATA != 'true' }}
         run: "::error::The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword)."
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: Build with Gradle
         run: ./gradlew build
   release:
@@ -73,7 +73,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: Publish with Gradle
         if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         run: ./gradlew -x test publish

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,46 +25,57 @@ jobs:
   build:
     name: Build for JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'Discord4J/Discord4J' }}
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'Discord4J/Discord4J' && !contains(toJson(github.event.pull_request.labels.*.name), 'PR depends on PR')) }}
     strategy:
       matrix:
         java: [ 8, 11 ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'corretto'
       - name: Build with Gradle
         run: ./gradlew build
-        if: |
-          !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.pull_request.title, '[ci skip]')
   release:
     name: Publish artifacts
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event_name != 'pull_request' && github.repository != 'Discord4J/Discord4J' }}
     needs: build
+    env:
+      HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Validate publish secrets
+        if: ${{ env.HAVE_SONAR_TOKEN != 'true' }}
+        run: |
+          echo "The secrets for publish are not set."
+          exit 0
+      - uses: actions/checkout@v3
+        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         with:
           fetch-depth: 0
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
+        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
+        uses: actions/setup-java@v3.6.0
         with:
           java-version: 11
+          distribution: 'corretto'
       - name: Publish with Gradle
+        if: ${{ env.HAVE_SONAR_DATA == 'true' }}
         run: ./gradlew -x test publish
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -50,13 +50,14 @@ jobs:
   release:
     name: Publish artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'Discord4J/Discord4J' }}
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build
     env:
+        RUN_RELEASE_ON_PUSH: ${{ vars.runReleaseOnPush || 'true' }}
         HAVE_SONAR_DATA: ${{ secrets.signingKey != '' && secrets.signingPassword != '' && secrets.sonatypeUsername != '' && secrets.sonatypePassword != '' }}
     steps:
       - name: Validate repository secrets for publish
-        if: ${{ env.HAVE_SONAR_DATA != 'true' }}
+        if: ${{ ( RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') ) && env.HAVE_SONAR_DATA != 'true' }}
         run: |
             echo '### ¡Release Failed! ❌' >> $GITHUB_STEP_SUMMARY
             echo 'The repository not has the required tokens set (signingKey, signingPassword, sonatypeUsername ir sonatypePassword).' >> $GITHUB_STEP_SUMMARY
@@ -65,19 +66,23 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'temurin'
+        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
       - name: Publish with Gradle
         run: ./gradlew -x test publish
+        if: ${{ RUN_RELEASE_ON_PUSH == 'true' || contains(github.event.head_commit.message, '[release]') }}
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signingPassword }}


### PR DESCRIPTION
**Description:** This PR aims to make a few improvements to the current workflow and close #1056
The changes in the workflow are...
- If the PR has the label 'PR depends on PR' the workflow are skipped because in the most of cases the PR cannot be builded until another necesary PR is merged
- If the repository not has the secrets for publish then this job is skipped, currently in any fork when a push event is handled (like a sync of master) the workflow try to publish
- Update dependencies of actions most of then has deprecation messages for any build based in a few changes by github

This workflow maybe can be improvement a few more but currently works :3
