### PR TITLE
Implement AuditLogEntryCreateEvent

### DIFF
--- a/core/src/main/java/discord4j/core/event/ReactiveEventAdapter.java
+++ b/core/src/main/java/discord4j/core/event/ReactiveEventAdapter.java
@@ -307,6 +307,17 @@ public abstract class ReactiveEventAdapter {
     }
 
     /**
+     * Invoked when a new entry in Audit Log is created in a guild.
+     *
+     * @param event the event instance
+     * @return a {@link Publisher} that completes when this listener has done processing the event, for example,
+     * returning any {@link Mono}, {@link Flux} or synchronous code using {@link Mono#fromRunnable(Runnable)}.
+     */
+    public Publisher<?> onAuditLogEntryCreate(AuditLogEntryCreateEvent event) {
+        return Mono.empty();
+    }
+
+    /**
      * Invoked when a user is banned from a guild.
      *
      * @param event the event instance
@@ -952,6 +963,7 @@ public abstract class ReactiveEventAdapter {
         if (event instanceof MemberChunkEvent) compatibleHooks.add(onMemberChunk((MemberChunkEvent) event));
         if (event instanceof EmojisUpdateEvent) compatibleHooks.add(onEmojisUpdate((EmojisUpdateEvent) event));
         if (event instanceof StickersUpdateEvent) compatibleHooks.add(onStickersUpdate((StickersUpdateEvent) event));
+        if (event instanceof AuditLogEntryCreateEvent) compatibleHooks.add(onAuditLogEntryCreate((AuditLogEntryCreateEvent) event));
         if (event instanceof BanEvent) compatibleHooks.add(onBan((BanEvent) event));
         if (event instanceof UnbanEvent) compatibleHooks.add(onUnban((UnbanEvent) event));
         if (event instanceof IntegrationsUpdateEvent) compatibleHooks.add(onIntegrationsUpdate((IntegrationsUpdateEvent) event));

--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
@@ -26,6 +26,7 @@ import discord4j.core.event.domain.integration.IntegrationDeleteEvent;
 import discord4j.core.event.domain.integration.IntegrationUpdateEvent;
 import discord4j.core.event.domain.interaction.*;
 import discord4j.core.object.VoiceState;
+import discord4j.core.object.audit.AuditLogEntry;
 import discord4j.core.object.command.ApplicationCommand;
 import discord4j.core.object.command.ApplicationCommandInteraction;
 import discord4j.core.object.command.Interaction;
@@ -34,6 +35,7 @@ import discord4j.core.object.entity.Integration;
 import discord4j.core.object.entity.Member;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.presence.Presence;
+import discord4j.discordjson.json.AuditLogEntryData;
 import discord4j.discordjson.json.PartialUserData;
 import discord4j.discordjson.json.PresenceData;
 import discord4j.discordjson.json.UserData;
@@ -61,6 +63,7 @@ public class DispatchHandlers implements DispatchEventMapper {
         addHandler(ChannelDelete.class, ChannelDispatchHandlers::channelDelete);
         addHandler(ChannelPinsUpdate.class, ChannelDispatchHandlers::channelPinsUpdate);
         addHandler(ChannelUpdate.class, ChannelDispatchHandlers::channelUpdate);
+        addHandler(AuditLogEntryCreate.class, DispatchHandlers::auditLogEntryCreate);
         addHandler(GuildBanAdd.class, GuildDispatchHandlers::guildBanAdd);
         addHandler(GuildBanRemove.class, GuildDispatchHandlers::guildBanRemove);
         addHandler(GuildCreate.class, GuildDispatchHandlers::guildCreate);
@@ -214,6 +217,13 @@ public class DispatchHandlers implements DispatchEventMapper {
         long channelId = Snowflake.asLong(context.getDispatch().channelId());
 
         return Mono.just(new WebhooksUpdateEvent(context.getGateway(), context.getShardInfo(), guildId, channelId));
+    }
+
+    private static Mono<AuditLogEntryCreateEvent> auditLogEntryCreate(DispatchContext<AuditLogEntryCreate, Void> context) {
+        long guildId = Snowflake.asLong(context.getDispatch().guildId());
+        AuditLogEntry auditLogEntry = new AuditLogEntry(context.getGateway(), context.getDispatch());
+
+        return Mono.just(new AuditLogEntryCreateEvent(context.getGateway(), context.getShardInfo(), guildId, auditLogEntry));
     }
 
     private static Mono<InviteCreateEvent> inviteCreate(DispatchContext<InviteCreate, Void> context) {

--- a/core/src/main/java/discord4j/core/event/domain/AuditLogEntryCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/AuditLogEntryCreateEvent.java
@@ -1,0 +1,65 @@
+package discord4j.core.event.domain;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.guild.GuildEvent;
+import discord4j.core.object.audit.AuditLogEntry;
+import discord4j.core.object.entity.Guild;
+import discord4j.gateway.ShardInfo;
+import reactor.core.publisher.Mono;
+
+/**
+ * Dispatched when an Entry of an Audit Log is created in a guild.
+ * <p>
+ * This event is dispatched by Discord.
+ *
+ * @see <a href="https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create">Guild Audit Log Entry Create</a>
+ */
+public class AuditLogEntryCreateEvent extends GuildEvent {
+
+    private final long guildId;
+    private final AuditLogEntry auditLogEntry;
+
+    public AuditLogEntryCreateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long guildId, AuditLogEntry auditLogEntry) {
+        super(gateway, shardInfo);
+        this.guildId = guildId;
+        this.auditLogEntry = auditLogEntry;
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event.
+     *
+     * @return The ID of the {@link Guild}.
+     */
+    public Snowflake getGuildId() {
+        return Snowflake.of(guildId);
+    }
+
+    /**
+     * Requests to retrieve the {@link Guild} whose the entry was created.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Guild> getGuild() {
+        return getClient().getGuildById(getGuildId());
+    }
+
+
+    /**
+     * Get the {@link AuditLogEntry} related to this event.
+     *
+     * @return a {@link AuditLogEntry}.
+     */
+    public AuditLogEntry getAuditLogEntry() {
+        return this.auditLogEntry;
+    }
+
+    @Override
+    public String toString() {
+        return "AuditLogEntryCreateEvent{" +
+                "guildId=" + guildId +
+                ", auditLogEntry=" + auditLogEntry +
+                '}';
+    }
+}

--- a/core/src/main/java/discord4j/core/object/audit/AuditLogEntry.java
+++ b/core/src/main/java/discord4j/core/object/audit/AuditLogEntry.java
@@ -18,10 +18,12 @@ package discord4j.core.object.audit;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.AuditLogEntryCreateEvent;
 import discord4j.core.object.entity.Entity;
 import discord4j.core.object.entity.User;
 import discord4j.core.util.AuditLogUtil;
 import discord4j.discordjson.json.AuditLogEntryData;
+import reactor.util.annotation.Nullable;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -56,9 +58,15 @@ public class AuditLogEntry implements Entity {
     private final AuditLogEntryData data;
 
     AuditLogEntry(final GatewayDiscordClient gateway, final AuditLogPart auditLogPart,
-                  final AuditLogEntryData data) {
+                         final AuditLogEntryData data) {
         this.gateway = gateway;
         this.auditLogPart = auditLogPart;
+        this.data = data;
+    }
+
+    public AuditLogEntry(final GatewayDiscordClient gateway, final AuditLogEntryData data) {
+        this.gateway = gateway;
+        this.auditLogPart = null;
         this.data = data;
     }
 
@@ -161,8 +169,9 @@ public class AuditLogEntry implements Entity {
     /**
      * Gets the {@link AuditLogPart audit log part} that this entry belongs to.
      *
-     * @return The audit log part that this entry belongs to.
+     * @return The audit log part that this entry belongs to. or null if the entry get from the {@link AuditLogEntryCreateEvent}
      */
+    @Nullable
     public AuditLogPart getParent() {
         return auditLogPart;
     }

--- a/gateway/src/main/java/discord4j/gateway/intent/Intent.java
+++ b/gateway/src/main/java/discord4j/gateway/intent/Intent.java
@@ -52,12 +52,24 @@ public enum Intent {
     GUILD_MEMBERS(1),
 
     /**
+     * Events which will be received by subscribing to GUILD_MODERATION
+     * <ul>
+     *     <li>GUILD_AUDIT_LOG_ENTRY_CREATE</li>
+     *     <li>GUILD_BAN_ADD</li>
+     *     <li>GUILD_BAN_REMOVE</li>
+     * </ul>
+     */
+    GUILD_MODERATION(2),
+
+    /**
      * Events which will be received by subscribing to GUILD_BANS
      * <ul>
      *     <li>GUILD_BAN_ADD</li>
      *     <li>GUILD_BAN_REMOVE</li>
      * </ul>
+     * @deprecated deprecated in favor of {@link #GUILD_MODERATION}
      */
+    @Deprecated()
     GUILD_BANS(2),
 
     /**

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
@@ -58,6 +58,7 @@ public abstract class EventNames {
     public static final String APPLICATION_COMMAND_UPDATE = "APPLICATION_COMMAND_UPDATE";
     public static final String APPLICATION_COMMAND_DELETE = "APPLICATION_COMMAND_DELETE";
     public static final String INTERACTION_CREATE = "INTERACTION_CREATE";
+    public static final String GUILD_AUDIT_LOG_ENTRY_CREATE = "GUILD_AUDIT_LOG_ENTRY_CREATE";
 
     // Ignored
     public static final String PRESENCES_REPLACE = "PRESENCES_REPLACE";

--- a/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
+++ b/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
@@ -79,6 +79,7 @@ public class PayloadDeserializer extends StdDeserializer<GatewayPayload<?>> {
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_UPDATE, ApplicationCommandUpdate.class);
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_DELETE, ApplicationCommandDelete.class);
         dispatchTypes.put(EventNames.INTERACTION_CREATE, InteractionCreate.class);
+        dispatchTypes.put(EventNames.GUILD_AUDIT_LOG_ENTRY_CREATE, AuditLogEntryCreate.class);
 
         // Ignored
         dispatchTypes.put(EventNames.PRESENCES_REPLACE, null);


### PR DESCRIPTION
This resolve #1112 
**Description:** 
- Implement a new event for AuditLog Entry created 
- Make Nullable the getParent of the EntryAuditLog because the event use this object but with not parent
- Add the new intent GUILD_MODERATION and deprecate the old GUILD_BANS for the rename in intent docs

**Justification:** https://github.com/discord/discord-api-docs/pull/5849

**Needs of:** https://github.com/Discord4J/discord-json/pull/132
