### PR TITLE
Promote and standardize the creation of displayable strings for emoji

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
+++ b/core/src/main/java/discord4j/core/object/entity/GuildEmoji.java
@@ -18,6 +18,7 @@ package discord4j.core.object.entity;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.reaction.ReactionEmoji;
 import discord4j.core.retriever.EntityRetrievalStrategy;
 import discord4j.core.spec.GuildEmojiEditMono;
 import discord4j.core.spec.GuildEmojiEditSpec;
@@ -326,7 +327,7 @@ public final class GuildEmoji implements Entity {
      * @return The formatted version of this emoji (i.e., to display in the client).
      */
     public String asFormat() {
-        return '<' + (isAnimated() ? "a" : "") + ':' + getName() + ':' + getId().asString() + '>';
+        return ReactionEmoji.Custom.asFormat(this.isAnimated(), this.getName(), this.getId());
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -217,7 +217,19 @@ public abstract class ReactionEmoji {
 
         @Override
         public String asFormat() {
-            return '<' + (this.isAnimated() ? "a" : "") + ':' + this.getName() + ':' + this.getId().asString() + '>';
+            return asFormat(this.isAnimated(), this.getName(), this.getId());
+        }
+
+        /**
+         * Gets the formatted version of this emoji (i.e., to display in the client).
+         *
+         * @param isAnimated Whether the emoji is animated.
+         * @param id The ID of the custom emoji.
+         * @param name The name of the custom emoji.
+         * @return The formatted version of this emoji (i.e., to display in the client).
+         */
+        public static String asFormat(final boolean isAnimated, final String name, final Snowflake id) {
+            return '<' + (isAnimated ? "a" : "") + ':' + Objects.requireNonNull(name) + ':' + Objects.requireNonNull(id).asString() + '>';
         }
 
         @Override

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -136,6 +136,13 @@ public abstract class ReactionEmoji {
     }
 
     /**
+     * Gets the formatted version of this emoji (i.e., to display in the client).
+     *
+     * @return The formatted version of this emoji (i.e., to display in the client).
+     */
+    public abstract String asFormat();
+
+    /**
      * Gets this emoji as downcasted to {@link Custom a custom reaction emoji}.
      *
      * @return This emoji downcasted to a custom emoji, if possible.
@@ -208,11 +215,7 @@ public abstract class ReactionEmoji {
                     .build();
         }
 
-        /**
-         * Gets the formatted version of this emoji (i.e., to display in the client).
-         *
-         * @return The formatted version of this emoji (i.e., to display in the client).
-         */
+        @Override
         public String asFormat() {
             return '<' + (this.isAnimated() ? "a" : "") + ':' + this.getName() + ':' + this.getId().asString() + '>';
         }
@@ -261,6 +264,11 @@ public abstract class ReactionEmoji {
             return EmojiData.builder()
                     .name(raw)
                     .build();
+        }
+
+        @Override
+        public String asFormat() {
+            return this.getRaw();
         }
 
         @Override


### PR DESCRIPTION
**Description/Justification:** This pull request does two things:
- promotes the `ReactionEmoji.Custom#asFormat` method to `ReactionEmoji` to simplify converting a `ReactionEmoji` to a `String` displayable in the client
- standardizes the creation of a displayable `String` for custom emoji across `GuildEmoji` and `ReactionEmoji.Custom` to reduce duplication