### PR TITLE
Add Discord Application Command Permissions Update Event

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/ApplicationCommandDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ApplicationCommandDispatchHandlers.java
@@ -21,13 +21,19 @@ import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.command.ApplicationCommandCreateEvent;
 import discord4j.core.event.domain.command.ApplicationCommandDeleteEvent;
+import discord4j.core.event.domain.command.ApplicationCommandPermissionUpdateEvent;
 import discord4j.core.event.domain.command.ApplicationCommandUpdateEvent;
 import discord4j.core.object.command.ApplicationCommand;
+import discord4j.core.object.command.ApplicationCommandGuildPermissions;
 import discord4j.discordjson.json.ApplicationCommandData;
+import discord4j.discordjson.json.ApplicationCommandGuildPermissionsData;
+import discord4j.discordjson.json.ApplicationCommandPermissionsData;
 import discord4j.discordjson.json.gateway.ApplicationCommandCreate;
 import discord4j.discordjson.json.gateway.ApplicationCommandDelete;
+import discord4j.discordjson.json.gateway.ApplicationCommandPermissionUpdate;
 import discord4j.discordjson.json.gateway.ApplicationCommandUpdate;
 import discord4j.gateway.ShardInfo;
+import java.util.List;
 import reactor.core.publisher.Mono;
 
 class ApplicationCommandDispatchHandlers {
@@ -52,14 +58,24 @@ class ApplicationCommandDispatchHandlers {
                 new ApplicationCommand(gateway, command), guildId));
     }
 
-    static Mono<ApplicationCommandDeleteEvent> applicationCommandDelete(DispatchContext<ApplicationCommandDelete, Void> context) {
+    static Mono<ApplicationCommandDeleteEvent> applicationCommandDelete(
+        DispatchContext<ApplicationCommandDelete, Void> context) {
         GatewayDiscordClient gateway = context.getGateway();
         ShardInfo shardInfo = context.getShardInfo();
         Long guildId = Snowflake.asLong(context.getDispatch().guildId());
         ApplicationCommandData command = context.getDispatch().command();
 
         return Mono.just(new ApplicationCommandDeleteEvent(gateway, shardInfo,
-                new ApplicationCommand(gateway, command), guildId));
+            new ApplicationCommand(gateway, command), guildId));
     }
 
+    static Mono<ApplicationCommandPermissionUpdateEvent> applicationCommandPermissionUpdate(
+        DispatchContext<ApplicationCommandPermissionUpdate, Void> context) {
+        GatewayDiscordClient gateway = context.getGateway();
+        ShardInfo shardInfo = context.getShardInfo();
+        ApplicationCommandGuildPermissionsData data = context.getDispatch().data();
+
+        return Mono.just(new ApplicationCommandPermissionUpdateEvent(gateway, shardInfo,
+            new ApplicationCommandGuildPermissions(gateway, data)));
+    }
 }

--- a/core/src/main/java/discord4j/core/event/dispatch/ApplicationCommandDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ApplicationCommandDispatchHandlers.java
@@ -26,14 +26,12 @@ import discord4j.core.event.domain.command.ApplicationCommandUpdateEvent;
 import discord4j.core.object.command.ApplicationCommand;
 import discord4j.core.object.command.ApplicationCommandGuildPermissions;
 import discord4j.discordjson.json.ApplicationCommandData;
-import discord4j.discordjson.json.ApplicationCommandGuildPermissionsData;
-import discord4j.discordjson.json.ApplicationCommandPermissionsData;
+import discord4j.discordjson.json.GuildApplicationCommandPermissionsData;
 import discord4j.discordjson.json.gateway.ApplicationCommandCreate;
 import discord4j.discordjson.json.gateway.ApplicationCommandDelete;
 import discord4j.discordjson.json.gateway.ApplicationCommandPermissionUpdate;
 import discord4j.discordjson.json.gateway.ApplicationCommandUpdate;
 import discord4j.gateway.ShardInfo;
-import java.util.List;
 import reactor.core.publisher.Mono;
 
 class ApplicationCommandDispatchHandlers {
@@ -73,7 +71,7 @@ class ApplicationCommandDispatchHandlers {
         DispatchContext<ApplicationCommandPermissionUpdate, Void> context) {
         GatewayDiscordClient gateway = context.getGateway();
         ShardInfo shardInfo = context.getShardInfo();
-        ApplicationCommandGuildPermissionsData data = context.getDispatch().data();
+        GuildApplicationCommandPermissionsData data = context.getDispatch().data();
 
         return Mono.just(new ApplicationCommandPermissionUpdateEvent(gateway, shardInfo,
             new ApplicationCommandGuildPermissions(gateway, data)));

--- a/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/DispatchHandlers.java
@@ -97,6 +97,7 @@ public class DispatchHandlers implements DispatchEventMapper {
         addHandler(ApplicationCommandCreate.class, ApplicationCommandDispatchHandlers::applicationCommandCreate);
         addHandler(ApplicationCommandUpdate.class, ApplicationCommandDispatchHandlers::applicationCommandUpdate);
         addHandler(ApplicationCommandDelete.class, ApplicationCommandDispatchHandlers::applicationCommandDelete);
+        addHandler(ApplicationCommandPermissionUpdate.class, ApplicationCommandDispatchHandlers::applicationCommandPermissionUpdate);
         addHandler(IntegrationCreate.class, DispatchHandlers::integrationCreate);
         addHandler(IntegrationUpdate.class, DispatchHandlers::integrationUpdate);
         addHandler(IntegrationDelete.class, DispatchHandlers::integrationDelete);

--- a/core/src/main/java/discord4j/core/event/domain/command/ApplicationCommandPermissionUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/command/ApplicationCommandPermissionUpdateEvent.java
@@ -20,11 +20,12 @@ package discord4j.core.event.domain.command;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.command.ApplicationCommandGuildPermissions;
+import discord4j.core.object.command.ApplicationCommandPermission;
 import discord4j.core.object.entity.Guild;
-import discord4j.discordjson.json.ApplicationCommandPermissionsData;
 import discord4j.gateway.ShardInfo;
-import java.util.List;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 /**
  * Dispatched when an application command permission relevant to the current user is updated. This
@@ -36,12 +37,13 @@ import reactor.core.publisher.Mono;
  */
 public class ApplicationCommandPermissionUpdateEvent extends ApplicationCommandEvent {
 
-    private final ApplicationCommandGuildPermissions data;
+    private final ApplicationCommandGuildPermissions permissions;
 
     public ApplicationCommandPermissionUpdateEvent(GatewayDiscordClient gateway,
-        ShardInfo shardInfo, ApplicationCommandGuildPermissions data) {
+                                                   ShardInfo shardInfo,
+                                                   ApplicationCommandGuildPermissions permissions) {
         super(gateway, shardInfo);
-        this.data = data;
+        this.permissions = permissions;
     }
 
     /**
@@ -50,7 +52,7 @@ public class ApplicationCommandPermissionUpdateEvent extends ApplicationCommandE
      * @return The unique id of the command.
      */
     public Snowflake getId() {
-        return data.getId();
+        return permissions.getId();
     }
 
     /**
@@ -59,7 +61,7 @@ public class ApplicationCommandPermissionUpdateEvent extends ApplicationCommandE
      * @return The ID of the guild involved.
      */
     public Snowflake getGuildId() {
-        return data.getGuildId();
+        return permissions.getGuildId();
     }
 
     /**
@@ -70,24 +72,24 @@ public class ApplicationCommandPermissionUpdateEvent extends ApplicationCommandE
      * the event. If an error is received, it is emitted through the {@code Mono}.
      */
     public Mono<Guild> getGuild() {
-        return getClient().getGuildById(data.getGuildId());
+        return getClient().getGuildById(permissions.getGuildId());
     }
 
     /**
-     * Gets the unique id of the parent application.
+     * Gets the ID of the application the command belongs to.
      *
-     * @return The unique id of the parent application.
+     * @return th ID of the application the command belongs to
      */
     public Snowflake getApplicationId() {
-        return data.getApplicationId();
+        return permissions.getApplicationId();
     }
 
     /**
-     * Get all permissions for this command on given guild
+     * Returns the permissions for the command in the guild.
      *
-     * @return Set permissions for this application command
+     * @return the permissions for the command in the guild.
      */
-    public List<ApplicationCommandPermissionsData> getPermissions() {
-        return data.getPermissions();
+    public List<ApplicationCommandPermission> getPermissions() {
+        return permissions.getPermissions();
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/command/ApplicationCommandPermissionUpdateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/command/ApplicationCommandPermissionUpdateEvent.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.event.domain.command;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.command.ApplicationCommandGuildPermissions;
+import discord4j.core.object.entity.Guild;
+import discord4j.discordjson.json.ApplicationCommandPermissionsData;
+import discord4j.gateway.ShardInfo;
+import java.util.List;
+import reactor.core.publisher.Mono;
+
+/**
+ * Dispatched when an application command permission relevant to the current user is updated. This
+ * event is dispatched by Discord.
+ *
+ * @see <a
+ * href="https://discord.com/developers/docs/topics/gateway-events#application-commands">Application
+ * Command Permissions Update</a>
+ */
+public class ApplicationCommandPermissionUpdateEvent extends ApplicationCommandEvent {
+
+    private final ApplicationCommandGuildPermissions data;
+
+    public ApplicationCommandPermissionUpdateEvent(GatewayDiscordClient gateway,
+        ShardInfo shardInfo, ApplicationCommandGuildPermissions data) {
+        super(gateway, shardInfo);
+        this.data = data;
+    }
+
+    /**
+     * Gets unique id of the command.
+     *
+     * @return The unique id of the command.
+     */
+    public Snowflake getId() {
+        return data.getId();
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Guild} involved in the event.
+     *
+     * @return The ID of the guild involved.
+     */
+    public Snowflake getGuildId() {
+        return data.getGuildId();
+    }
+
+    /**
+     * Requests to retrieve the {@link Guild} that had an application command updated in this
+     * event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} involved in
+     * the event. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Guild> getGuild() {
+        return getClient().getGuildById(data.getGuildId());
+    }
+
+    /**
+     * Gets the unique id of the parent application.
+     *
+     * @return The unique id of the parent application.
+     */
+    public Snowflake getApplicationId() {
+        return data.getApplicationId();
+    }
+
+    /**
+     * Get all permissions for this command on given guild
+     *
+     * @return Set permissions for this application command
+     */
+    public List<ApplicationCommandPermissionsData> getPermissions() {
+        return data.getPermissions();
+    }
+}

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandGuildPermissions.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandGuildPermissions.java
@@ -21,8 +21,8 @@ import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.DiscordObject;
-import discord4j.discordjson.json.ApplicationCommandGuildPermissionsData;
 import discord4j.discordjson.json.ApplicationCommandPermissionsData;
+import discord4j.discordjson.json.GuildApplicationCommandPermissionsData;
 import java.util.List;
 import java.util.Objects;
 
@@ -49,7 +49,7 @@ public class ApplicationCommandGuildPermissions implements DiscordObject {
     /**
      * The raw data as represented by Discord.
      */
-    private final ApplicationCommandGuildPermissionsData data;
+    private final GuildApplicationCommandPermissionsData data;
 
     /**
      * Constructs an {@code ApplicationCommandGuildPermissions} with an associated
@@ -59,7 +59,7 @@ public class ApplicationCommandGuildPermissions implements DiscordObject {
      * @param data    The raw data as represented by Discord, must be non-null.
      */
     public ApplicationCommandGuildPermissions(final GatewayDiscordClient gateway,
-        final ApplicationCommandGuildPermissionsData data) {
+        final GuildApplicationCommandPermissionsData data) {
         this.gateway = Objects.requireNonNull(gateway);
         this.data = Objects.requireNonNull(data);
     }

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandGuildPermissions.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandGuildPermissions.java
@@ -17,23 +17,23 @@
 
 package discord4j.core.object.command;
 
-import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.DiscordObject;
-import discord4j.discordjson.json.ApplicationCommandPermissionsData;
 import discord4j.discordjson.json.GuildApplicationCommandPermissionsData;
+
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
- * A Discord application command.
+ * Represents a guild application command permissions. Includes information about the command, the application, the
+ * guild and a list of all permissions created for the command in the guild.
  *
  * @see <a
- * href="https://discord.com/developers/docs/interactions/slash-commands#applicationcommand">
- * Application Command Object</a>
+ * href="https://discord.com/developers/docs/interactions/application-commands#permissions">
+ * Application Command Permissions</a>
  */
-@Experimental
 public class ApplicationCommandGuildPermissions implements DiscordObject {
 
     /**
@@ -59,15 +59,15 @@ public class ApplicationCommandGuildPermissions implements DiscordObject {
      * @param data    The raw data as represented by Discord, must be non-null.
      */
     public ApplicationCommandGuildPermissions(final GatewayDiscordClient gateway,
-        final GuildApplicationCommandPermissionsData data) {
+                                              final GuildApplicationCommandPermissionsData data) {
         this.gateway = Objects.requireNonNull(gateway);
         this.data = Objects.requireNonNull(data);
     }
 
     /**
-     * Gets unique id of the command.
+     * Returns the ID of the command or the application ID.
      *
-     * @return The unique id of the command.
+     * @return the ID of the command or the application ID
      */
     public Snowflake getId() {
         return Snowflake.of(data.id());
@@ -75,34 +75,44 @@ public class ApplicationCommandGuildPermissions implements DiscordObject {
 
 
     /**
-     * Gets the id of the guild if the command is guild scoped.
+     * Returns the id of the guild.
      *
-     * @return The id of the guild
+     * @return the id of the guild
      */
     public Snowflake getGuildId() {
         return Snowflake.of(data.guildId());
     }
 
     /**
-     * Gets the unique id of the parent application.
+     * Returns the ID of the application the command belongs to.
      *
-     * @return The unique id of the parent application.
+     * @return the ID of the application the command belongs to
      */
     public Snowflake getApplicationId() {
         return Snowflake.of(data.applicationId());
     }
 
     /**
-     * Gets the name of the command.
+     * Returns the permissions for the command in the guild.
      *
-     * @return The name of the command.
+     * @return the permissions for the command in the guild.
      */
-    public List<ApplicationCommandPermissionsData> getPermissions() {
-        return data.permissions();
+    public List<ApplicationCommandPermission> getPermissions() {
+        return data.permissions()
+                .stream()
+                .map(data -> new ApplicationCommandPermission(gateway, getGuildId(), data))
+                .collect(Collectors.toList());
     }
 
     @Override
     public GatewayDiscordClient getClient() {
         return gateway;
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationCommandGuildPermissions{" +
+                "data=" + data +
+                '}';
     }
 }

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandGuildPermissions.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandGuildPermissions.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.object.command;
+
+import discord4j.common.annotations.Experimental;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.DiscordObject;
+import discord4j.discordjson.json.ApplicationCommandGuildPermissionsData;
+import discord4j.discordjson.json.ApplicationCommandPermissionsData;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A Discord application command.
+ *
+ * @see <a
+ * href="https://discord.com/developers/docs/interactions/slash-commands#applicationcommand">
+ * Application Command Object</a>
+ */
+@Experimental
+public class ApplicationCommandGuildPermissions implements DiscordObject {
+
+    /**
+     * The maximum amount of permission overrides for this command.
+     */
+    public static final int MAX_PERMISSION_ENTRIES = 100;
+
+    /**
+     * The gateway associated to this object.
+     */
+    private final GatewayDiscordClient gateway;
+
+    /**
+     * The raw data as represented by Discord.
+     */
+    private final ApplicationCommandGuildPermissionsData data;
+
+    /**
+     * Constructs an {@code ApplicationCommandGuildPermissions} with an associated
+     * {@link GatewayDiscordClient} and Discord data.
+     *
+     * @param gateway The {@link GatewayDiscordClient} associated to this object, must be non-null.
+     * @param data    The raw data as represented by Discord, must be non-null.
+     */
+    public ApplicationCommandGuildPermissions(final GatewayDiscordClient gateway,
+        final ApplicationCommandGuildPermissionsData data) {
+        this.gateway = Objects.requireNonNull(gateway);
+        this.data = Objects.requireNonNull(data);
+    }
+
+    /**
+     * Gets unique id of the command.
+     *
+     * @return The unique id of the command.
+     */
+    public Snowflake getId() {
+        return Snowflake.of(data.id());
+    }
+
+
+    /**
+     * Gets the id of the guild if the command is guild scoped.
+     *
+     * @return The id of the guild
+     */
+    public Snowflake getGuildId() {
+        return Snowflake.of(data.guildId());
+    }
+
+    /**
+     * Gets the unique id of the parent application.
+     *
+     * @return The unique id of the parent application.
+     */
+    public Snowflake getApplicationId() {
+        return Snowflake.of(data.applicationId());
+    }
+
+    /**
+     * Gets the name of the command.
+     *
+     * @return The name of the command.
+     */
+    public List<ApplicationCommandPermissionsData> getPermissions() {
+        return data.permissions();
+    }
+
+    @Override
+    public GatewayDiscordClient getClient() {
+        return gateway;
+    }
+}

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandPermission.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandPermission.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discord4j.core.object.command;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.DiscordObject;
+import discord4j.discordjson.json.ApplicationCommandPermissionsData;
+
+/**
+ * Represents an individual application command permission, allowing you to enable or disable commands for specific
+ * users, roles, or channels within a guild.
+ */
+public class ApplicationCommandPermission implements DiscordObject {
+
+    /**
+     * The gateway associated to this object.
+     */
+    private final GatewayDiscordClient gateway;
+    /**
+     * The guild this command permission belongs to.
+     */
+    private final long guildId;
+    /**
+     * The raw data as represented by Discord.
+     */
+    private final ApplicationCommandPermissionsData data;
+
+    /**
+     * Constructs an {@code ApplicationCommandPermission} with an associated
+     * {@link GatewayDiscordClient} and Discord data.
+     *
+     * @param gateway the {@link GatewayDiscordClient} associated to this object, must be non-null.
+     * @param data the raw data as represented by Discord, must be non-null.
+     */
+    public ApplicationCommandPermission(GatewayDiscordClient gateway, Snowflake guildId,
+                                        ApplicationCommandPermissionsData data) {
+        this.gateway = gateway;
+        this.guildId = guildId.asLong();
+        this.data = data;
+    }
+
+    /**
+     * Return the ID of the role, user, or channel. It can also be a permission constant which can be detected by
+     * {@link #appliesToEveryone()} or {@link #appliesToAllChannels()}.
+     *
+     * @return the permission target as a Snowflake ID
+     */
+    public Snowflake getId() {
+        return Snowflake.of(data.id());
+    }
+
+    /**
+     * Returns whether this role permission uses a constant representing it applies to everyone.
+     *
+     * @return {@code true} if this permission applies to all members in a guild, {@code false} if otherwise
+     */
+    public boolean appliesToEveryone() {
+        return guildId == data.id().asLong();
+    }
+
+    /**
+     * Returns whether this channel permission uses a constant representing it applies to all channels.
+     *
+     * @return {@code true} if this permission applies to all channels in a guild, {@code false} if otherwise
+     */
+    public boolean appliesToAllChannels() {
+        return guildId - 1 == data.id().asLong();
+    }
+
+    /**
+     * Returns the type of this permission.
+     *
+     * @return the type of this permission
+     */
+    public Type getType() {
+        return Type.of(data.type());
+    }
+
+    /**
+     * Returns whether this permission allows or disallows a command for the target given by {@link #getType()} and
+     * {@link #getId()}.
+     *
+     * @return {@code true} if this permission is allowing the command, {@code false} if it disallows it.
+     */
+    public boolean isAllowed() {
+        return data.permission();
+    }
+
+    @Override
+    public GatewayDiscordClient getClient() {
+        return gateway;
+    }
+
+    /**
+     * Represents the various types of application command permissions.
+     */
+    public enum Type {
+
+        /**
+         * Unknown type.
+         */
+        UNKNOWN(-1),
+
+        /**
+         * A role permission, can also target all members in the guild.
+         */
+        ROLE(1),
+
+        /**
+         * A user permission.
+         */
+        USER(2),
+
+        /**
+         * A channel permission, can also target all channels in the guild.
+         */
+        CHANNEL(3);
+
+        /**
+         * The underlying value as represented by Discord.
+         */
+        private final int value;
+
+        /**
+         * Constructs an {@code ApplicationCommandPermission.Type}.
+         *
+         * @param value The underlying value as represented by Discord.
+         */
+        Type(int value) {
+            this.value = value;
+        }
+
+        /**
+         * Gets the underlying value as represented by Discord.
+         *
+         * @return The underlying value as represented by Discord.
+         */
+        public int getValue() {
+            return value;
+        }
+
+        /**
+         * Gets the type of permission. It is guaranteed that invoking {@link #getValue()} from the returned enum will
+         * be equal ({@code ==}) to the supplied {@code value}.
+         *
+         * @param value The underlying value as represented by Discord.
+         * @return The type of permission.
+         */
+        public static Type of(final int value) {
+            switch (value) {
+                case 1: return ROLE;
+                case 2: return USER;
+                case 3: return CHANNEL;
+                default: return UNKNOWN;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationCommandPermission{" +
+                "data=" + data +
+                '}';
+    }
+}

--- a/core/src/test/java/discord4j/core/ExampleSoundboard.java
+++ b/core/src/test/java/discord4j/core/ExampleSoundboard.java
@@ -29,9 +29,11 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.playback.MutableAudioFrame;
 import com.sedmelluq.discord.lavaplayer.track.playback.NonAllocatingAudioFrameBuffer;
 import discord4j.common.util.Snowflake;
+import discord4j.core.event.domain.command.ApplicationCommandPermissionUpdateEvent;
 import discord4j.core.event.domain.interaction.ButtonInteractionEvent;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.object.VoiceState;
+import discord4j.core.object.command.ApplicationCommandPermission;
 import discord4j.core.object.component.ActionRow;
 import discord4j.core.object.component.Button;
 import discord4j.core.object.component.LayoutComponent;
@@ -154,10 +156,26 @@ public class ExampleSoundboard {
             return Mono.empty();
         });
 
+        Publisher<?> onPermsUpdate = client.on(ApplicationCommandPermissionUpdateEvent.class, event -> {
+            log.info("Permission update for command {}, application {}, guild {}",
+                    event.getId(), event.getApplicationId(), event.getGuildId());
+            for (ApplicationCommandPermission permission : event.getPermissions()) {
+                log.info("*** {} {} {} ***",
+                        permission.isAllowed() ? "Allows" : "Disallows",
+                        permission.getType(),
+                        permission.appliesToEveryone() ? "everyone"
+                                : (permission.appliesToAllChannels() ? "all channels" : permission.getId()));
+            }
+            if (event.getPermissions().isEmpty()) {
+                log.info("*** No permissions overridden ***");
+            }
+            return Mono.empty();
+        });
+
         // register the command and then subscribe to multiple listeners, using Mono.when
         return GuildCommandRegistrar.create(client.getRestClient(), guildId, getCommandSources())
                 .registerCommands()
-                .thenMany(Mono.when(onChatInputInteraction, onButtonInteraction));
+                .thenMany(Mono.when(onChatInputInteraction, onButtonInteraction, onPermsUpdate));
     }
 
     private static List<LayoutComponent> getButtons() {

--- a/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
+++ b/gateway/src/main/java/discord4j/gateway/json/dispatch/EventNames.java
@@ -57,6 +57,7 @@ public abstract class EventNames {
     public static final String APPLICATION_COMMAND_CREATE = "APPLICATION_COMMAND_CREATE";
     public static final String APPLICATION_COMMAND_UPDATE = "APPLICATION_COMMAND_UPDATE";
     public static final String APPLICATION_COMMAND_DELETE = "APPLICATION_COMMAND_DELETE";
+    public static final String APPLICATION_COMMAND_PERMISSIONS_UPDATE = "APPLICATION_COMMAND_PERMISSIONS_UPDATE";
     public static final String INTERACTION_CREATE = "INTERACTION_CREATE";
 
     // Ignored

--- a/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
+++ b/gateway/src/main/java/discord4j/gateway/json/jackson/PayloadDeserializer.java
@@ -78,6 +78,7 @@ public class PayloadDeserializer extends StdDeserializer<GatewayPayload<?>> {
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_CREATE, ApplicationCommandCreate.class);
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_UPDATE, ApplicationCommandUpdate.class);
         dispatchTypes.put(EventNames.APPLICATION_COMMAND_DELETE, ApplicationCommandDelete.class);
+        dispatchTypes.put(EventNames.APPLICATION_COMMAND_PERMISSIONS_UPDATE, ApplicationCommandPermissionUpdate.class);
         dispatchTypes.put(EventNames.INTERACTION_CREATE, InteractionCreate.class);
 
         // Ignored


### PR DESCRIPTION
Supersedes #1117 from @dominoxp , I was unable to commit changes to it.

--

Requires Pull Request in discord-json: https://github.com/Discord4J/discord-json/pull/136

**Description:** <!-- A description of the changes made in this pull request. -->
Added Missing Event handling from Command Permission Update Event Data

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
https://discord.com/developers/docs/topics/gateway-events#application-commands
https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure