### PR TITLE
Fix wrong variable name in GetAutoModRuleByIdAction

### DIFF
--- a/common/src/main/java/discord4j/common/store/action/read/GetAutoModRuleByIdAction.java
+++ b/common/src/main/java/discord4j/common/store/action/read/GetAutoModRuleByIdAction.java
@@ -5,18 +5,18 @@ import discord4j.discordjson.json.AutoModRuleData;
 
 public class GetAutoModRuleByIdAction implements StoreAction<AutoModRuleData> {
     private final long guildId;
-    private final long stickerId;
+    private final long autoModRuleId;
 
-    GetAutoModRuleByIdAction(long guildId, long stickerId) {
+    GetAutoModRuleByIdAction(long guildId, long autoModRuleId) {
         this.guildId = guildId;
-        this.stickerId = stickerId;
+        this.autoModRuleId = autoModRuleId;
     }
 
     public long getGuildId() {
         return guildId;
     }
 
-    public long getStickerId() {
-        return stickerId;
+    public long getAutoModRuleId() {
+        return autoModRuleId;
     }
 }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->
This PR fixes tiny error about the name of a field in `GetAutoModRuleByIdAction`.
The field has been renamed from `stickerId` to `autoModRuleId`.

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
I suspect this typo comes from a copy-paste from the [`GetStickerByIdAction`](https://github.com/Discord4J/Discord4J/blob/3.2.x/common/src/main/java/discord4j/common/store/action/read/GetStickerByIdAction.java) file and the author forgot to change it. The name I put comes from it's usage [here](https://github.com/Discord4J/Discord4J/blob/3.2.x/common/src/main/java/discord4j/common/store/action/read/ReadActions.java#L276):
```java
public static GetAutoModRuleByIdAction getAutoModRuleById(long guildId, long autoModRuleId) {
    return new GetAutoModRuleByIdAction(guildId, autoModRuleId);
}
```