### PR TITLE
Migration to reactor.util.retry.Retry after old retry deprecation (#1125)

### DIFF
--- a/common/src/main/java/discord4j/common/retry/ReconnectContext.java
+++ b/common/src/main/java/discord4j/common/retry/ReconnectContext.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Encapsulate retrying state for reconnect operations.
  * <p>
- * Used as context for {@link reactor.retry.Retry} calls, keeps track of the current retry attempt for backoff
+ * Used as context for {@link reactor.util.retry.Retry} calls, keeps track of the current retry attempt for backoff
  * calculations (through {@link #next()} and restarting the attempt count once a retry has succeeded (through
  * {@link #reset()}).
  */

--- a/rest/src/main/java/discord4j/rest/http/client/ClientException.java
+++ b/rest/src/main/java/discord4j/rest/http/client/ClientException.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClientResponse;
-import reactor.retry.RetryContext;
 import reactor.util.annotation.Nullable;
 import reactor.util.retry.Retry;
 
@@ -171,32 +170,6 @@ public class ClientException extends RuntimeException {
             }
             return false;
         };
-    }
-
-    /**
-     * {@link Predicate} helper to further classify a {@link ClientException}, while creating a {@link Retry}
-     * factory, depending on the underlying HTTP status code. A {@link Retry} factory can be created through methods
-     * like {@link reactor.retry.Retry#onlyIf(Predicate)} where this method can be used as argument.
-     *
-     * @param code the status code for which this {@link Predicate} should return {@code true}
-     * @return a {@link Predicate} that returns {@code true} if the given {@link RetryContext} exception is a
-     * {@link ClientException} containing the given HTTP status code
-     */
-    public static Predicate<RetryContext<?>> isRetryContextStatusCode(int code) {
-        return ctx -> isStatusCode(code).test(ctx.exception());
-    }
-
-    /**
-     * {@link Predicate} helper to further classify a {@link ClientException}, while creating a {@link Retry}
-     * factory, depending on the underlying HTTP status code. A {@link Retry} factory can be created through methods
-     * like {@link reactor.retry.Retry#onlyIf(Predicate)} where this method can be used as argument.
-     *
-     * @param codes the status codes for which this {@link Predicate} should return {@code true}
-     * @return a {@link Predicate} that returns {@code true} if the given {@link Throwable} is a {@link ClientException}
-     * containing the given HTTP status code
-     */
-    public static Predicate<RetryContext<?>> isRetryContextStatusCode(Integer... codes) {
-        return ctx -> isStatusCode(codes).test(ctx.exception());
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -32,6 +32,7 @@ import reactor.netty.http.client.HttpClientResponse;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -83,16 +84,18 @@ class RequestStream {
      * 500, 502, 503 and 504). The delay is calculated using exponential backoff with jitter.
      */
     private reactor.util.retry.Retry serverErrorRetryFactory() {
-        return Retry.withThrowable(reactor.retry.Retry.onlyIf(ClientException.isRetryContextStatusCode(500, 502, 503,
-                504, 520))
-                .withBackoffScheduler(timedTaskScheduler)
-                .exponentialBackoffWithJitter(Duration.ofSeconds(2), Duration.ofSeconds(30))
-                .doOnRetry(ctx -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Retry {} in bucket {} due to {} for {}",
-                                ctx.iteration(), id.toString(), ctx.exception().toString(), ctx.backoff());
-                    }
-                }));
+        return RetryBackoffSpec.backoff(10, Duration.ofSeconds(2))
+            .jitter(0.5)
+            .maxBackoff(Duration.ofSeconds(30))
+            .scheduler(timedTaskScheduler)
+            .doBeforeRetry(retrySignal -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("Retry {} in bucket {} due to {}",
+                        retrySignal.totalRetries(),
+                        id.toString(),
+                        retrySignal.failure().toString());
+                }
+            });
     }
 
     boolean push(RequestCorrelation<ClientResponse> request) {

--- a/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
+++ b/rest/src/main/java/discord4j/rest/response/ResponseFunction.java
@@ -25,6 +25,7 @@ import discord4j.rest.request.RouteMatcher;
 import discord4j.rest.request.Router;
 import discord4j.rest.request.RouterOptions;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.RetryBackoffSpec;
 
 import java.time.Duration;
 import java.util.function.Function;
@@ -107,9 +108,8 @@ public interface ResponseFunction {
      */
     static RetryingTransformer retryOnceOnErrorStatus(Integer... codes) {
         return new RetryingTransformer(RouteMatcher.any(),
-                reactor.retry.Retry.onlyIf(ClientException.isRetryContextStatusCode(codes))
-                        .fixedBackoff(Duration.ofSeconds(1))
-                        .retryOnce());
+            RetryBackoffSpec.backoff(1, Duration.ofSeconds(1))
+                .filter(exception -> ClientException.isStatusCode(codes).test(exception)));
     }
 
     /**
@@ -130,9 +130,8 @@ public interface ResponseFunction {
      */
     static RetryingTransformer retryOnceOnErrorStatus(RouteMatcher routeMatcher, Integer... codes) {
         return new RetryingTransformer(routeMatcher,
-                reactor.retry.Retry.onlyIf(ClientException.isRetryContextStatusCode(codes))
-                        .fixedBackoff(Duration.ofSeconds(1))
-                        .retryOnce());
+            RetryBackoffSpec.backoff(1, Duration.ofSeconds(1))
+                .filter(exception -> ClientException.isStatusCode(codes).test(exception)));
     }
 
     /**
@@ -143,11 +142,11 @@ public interface ResponseFunction {
      * effectively block further requests on the same rate limiting bucket.
      *
      * @param routeMatcher the {@link RouteMatcher} determining whether to match a particular request
-     * @param retry the {@link reactor.retry.Retry} factory to install while applying this transformation
+     * @param retry the {@link reactor.util.retry.Retry} factory to install while applying this transformation
      * @return a {@link ResponseFunction} that transforms matching response statuses into sequence that retries the
      * request once after waiting 1 second.
      */
-    static RetryingTransformer retryWhen(RouteMatcher routeMatcher, reactor.retry.Retry<?> retry) {
+    static RetryingTransformer retryWhen(RouteMatcher routeMatcher, reactor.util.retry.Retry retry) {
         return new RetryingTransformer(routeMatcher, retry);
     }
 }

--- a/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
+++ b/rest/src/main/java/discord4j/rest/response/RetryingTransformer.java
@@ -22,7 +22,6 @@ import discord4j.rest.http.client.ClientResponse;
 import discord4j.rest.request.DiscordWebRequest;
 import discord4j.rest.request.RouteMatcher;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 import java.util.function.Function;
 
@@ -33,17 +32,17 @@ import java.util.function.Function;
 public class RetryingTransformer implements ResponseFunction {
 
     private final RouteMatcher routeMatcher;
-    private final reactor.retry.Retry<?> retryFactory;
+    private final reactor.util.retry.Retry retryStrategy;
 
-    public RetryingTransformer(RouteMatcher routeMatcher, reactor.retry.Retry<?> retryFactory) {
+    public RetryingTransformer(RouteMatcher routeMatcher, reactor.util.retry.Retry retryStrategy) {
         this.routeMatcher = routeMatcher;
-        this.retryFactory = retryFactory;
+        this.retryStrategy = retryStrategy;
     }
 
     @Override
     public Function<Mono<ClientResponse>, Mono<ClientResponse>> transform(DiscordWebRequest request) {
         if (routeMatcher.matches(request)) {
-            return mono -> mono.retryWhen(Retry.withThrowable(retryFactory));
+            return mono -> mono.retryWhen(retryStrategy);
         }
         return mono -> mono;
     }

--- a/rest/src/test/java/discord4j/rest/request/ClockGlobalRateLimiter.java
+++ b/rest/src/test/java/discord4j/rest/request/ClockGlobalRateLimiter.java
@@ -21,8 +21,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
-import reactor.retry.BackoffDelay;
-import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -94,8 +93,7 @@ public class ClockGlobalRateLimiter implements GlobalRateLimiter {
                         sink.success();
                     }
                 })
-                .retryWhen(Retry.withThrowable(reactor.retry.Retry.any()
-                        .backoff(ctx -> new BackoffDelay(Duration.ofNanos(retryIn.get())))))
-                .thenMany(stage);
+            .retryWhen(RetryBackoffSpec.backoff(1, Duration.ofNanos(retryIn.get())))
+            .thenMany(stage);
     }
 }


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** I tried to migrate from the old reactor Retry<?> interface to the abstract class reactor.util.retry.Retry and its two subclasses RetrySpec and RetryBackoffSpec.

I tried to refactor only, but it seems we have 2 functionnal changes that I'm going to describe in review below for feedback. 

**Justification:** This PR fixes the issue #1125 
