### PR TITLE
feat(core): allow populating EmbedCreateSpec$Builder from existing EmbedData

### DIFF
--- a/core/src/main/java/discord4j/core/spec/EmbedCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/EmbedCreateSpecGenerator.java
@@ -17,7 +17,10 @@
 
 package discord4j.core.spec;
 
+import discord4j.discordjson.json.EmbedAuthorData;
 import discord4j.discordjson.json.EmbedData;
+import discord4j.discordjson.json.EmbedFieldData;
+import discord4j.discordjson.json.EmbedFooterData;
 import discord4j.discordjson.json.EmbedImageData;
 import discord4j.discordjson.json.EmbedThumbnailData;
 import discord4j.discordjson.possible.Possible;
@@ -31,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static discord4j.core.spec.InternalSpecUtils.flatMapPossible;
 import static discord4j.core.spec.InternalSpecUtils.mapPossible;
 import static discord4j.core.spec.InternalSpecUtils.toPossible;
 
@@ -76,5 +80,49 @@ interface EmbedCreateSpecGenerator extends Spec<EmbedData> {
                 .author(mapPossible(toPossible(author()), EmbedCreateFields.Author::asRequest))
                 .fields(fields().stream().map(EmbedCreateFields.Field::asRequest).collect(Collectors.toList()))
                 .build();
+    }
+
+    abstract class Builder {
+        public EmbedCreateSpec.Builder from(final EmbedData data) {
+            final EmbedCreateSpec.Builder $this = EmbedCreateSpec.Builder.class.cast(this)
+                    .title(data.title())
+                    .description(data.description())
+                    .url(data.url())
+                    .timestamp(mapPossible(data.timestamp(), Instant::parse))
+                    .color(mapPossible(data.color(), Color::of))
+                    .image(flatMapPossible(data.image(), EmbedImageData::url))
+                    .thumbnail(flatMapPossible(data.thumbnail(), EmbedThumbnailData::url));
+
+            if (!data.footer().isAbsent()) {
+                final EmbedFooterData footer = data.footer().get();
+                $this.footer(footer.text(), footer.iconUrl().toOptional().orElse(null));
+            } else {
+                $this.footer(null);
+            }
+
+            if (!data.author().isAbsent()) {
+                final EmbedAuthorData author = data.author().get();
+                $this.author(EmbedCreateFields.Author.of(
+                        author.name().toOptional().orElseThrow(IllegalStateException::new),
+                        author.url().toOptional().orElse(null),
+                        author.iconUrl().toOptional().orElse(null)
+                ));
+            } else {
+                $this.author(null);
+            }
+
+            if (!data.fields().isAbsent()) {
+                final List<EmbedFieldData> fields = data.fields().get();
+                $this.fields(
+                        fields.stream()
+                                .map(field -> EmbedCreateFields.Field.of(field.name(), field.value(), field.inline().toOptional().orElse(false)))
+                                .collect(Collectors.toList())
+                );
+            } else {
+                $this.fields(Collections.emptyList());
+            }
+
+            return $this;
+        }
     }
 }

--- a/core/src/main/java/discord4j/core/spec/InternalSpecUtils.java
+++ b/core/src/main/java/discord4j/core/spec/InternalSpecUtils.java
@@ -62,6 +62,10 @@ final class InternalSpecUtils {
         return value.isAbsent() ? Possible.absent() : Possible.of(mapper.apply(value.get()));
     }
 
+    static <T, R> Possible<R> flatMapPossible(Possible<T> value, Function<? super T, ? extends Possible<R>> mapper) {
+        return value.isAbsent() ? Possible.absent() : mapper.apply(value.get());
+    }
+
     static <T, R> Possible<Optional<R>> mapPossibleOptional(Possible<Optional<T>> value,
                                                            Function<? super T, ? extends R> mapper) {
         return value.isAbsent() ? Possible.absent() : Possible.of(value.get().map(mapper));


### PR DESCRIPTION
**Description:** Introduces a method to allow populating a ´EmbedCreateSpec.Builder´ from an existing `EmbedData`.

**Justification:** Restores functionality originally introduced in #868 but lost in #927.