### PR TITLE
Implement fields for raid mention and safety alerts

### DIFF
--- a/core/src/main/java/discord4j/core/object/automod/AutoModRuleTriggerMetaData.java
+++ b/core/src/main/java/discord4j/core/object/automod/AutoModRuleTriggerMetaData.java
@@ -83,6 +83,15 @@ public class AutoModRuleTriggerMetaData {
     }
 
     /**
+     * Gets whether to automatically detect mention raids.
+     *
+     * @return Whether the mention raid protecton is enabled.
+     */
+    public boolean isMentionRaidProtectionEnabled() {
+        return data.mentionRaidProtectionEnabled().toOptional().orElse(false);
+    }
+
+    /**
      * Gets the internally pre-defined wordsets which will be searched for in content.
      *
      * @return a EnumSet with all the presets in the class.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -735,6 +735,45 @@ public final class Guild implements Entity {
     }
 
     /**
+     * Gets the id of the channel where admins and moderators of Community guilds receive safety alerts from Discord, if
+     * present.
+     *
+     * @return The id of the channel where admins and moderators of Community guilds receive safety alerts from Discord, if
+     * present.
+     */
+    public Optional<Snowflake> getSafetyAlertsChannelId() {
+        return data.safetyAlertsChannelId().map(Snowflake::of);
+    }
+
+    /**
+     * Requests to retrieve the channel where admins and moderators of Community guilds receive safety alerts from Discord,
+     * if present.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} where admins
+     * and moderators of Community guilds receive safety alerts from Discord, if present. If an error is received, it is
+     * emitted through the {@code Mono}.
+     */
+    public Mono<TextChannel> getPublicUpdatesChannel() {
+        return Mono.justOrEmpty(getSafetyAlertsChannelId()).flatMap(gateway::getChannelById).cast(TextChannel.class);
+    }
+
+    /**
+     * Requests to retrieve the channel where admins and moderators of Community guilds receive safety alerts from Discord,
+     * if present,
+     * using the given retrieval strategy.
+     *
+     * @param retrievalStrategy the strategy to use to get the rules channel
+     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} where admins
+     * and moderators of Community guilds receive safety alerts from Discord, if present. If an error is received, it is
+     * emitted through the {@code Mono}.
+     */
+    public Mono<TextChannel> getPublicUpdatesChannel(EntityRetrievalStrategy retrievalStrategy) {
+        return Mono.justOrEmpty(getSafetyAlertsChannelId())
+            .flatMap(id -> gateway.withRetrievalStrategy(retrievalStrategy).getChannelById(id))
+            .cast(TextChannel.class);
+    }
+
+    /**
      * Gets the maximum amount of users in a video channel, if present.
      *
      * @return The maximum amount of users in a video channel, if present.

--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -746,34 +746,6 @@ public final class Guild implements Entity {
     }
 
     /**
-     * Requests to retrieve the channel where admins and moderators of Community guilds receive safety alerts from Discord,
-     * if present.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} where admins
-     * and moderators of Community guilds receive safety alerts from Discord, if present. If an error is received, it is
-     * emitted through the {@code Mono}.
-     */
-    public Mono<TextChannel> getPublicUpdatesChannel() {
-        return Mono.justOrEmpty(getSafetyAlertsChannelId()).flatMap(gateway::getChannelById).cast(TextChannel.class);
-    }
-
-    /**
-     * Requests to retrieve the channel where admins and moderators of Community guilds receive safety alerts from Discord,
-     * if present,
-     * using the given retrieval strategy.
-     *
-     * @param retrievalStrategy the strategy to use to get the rules channel
-     * @return A {@link Mono} where, upon successful completion, emits the {@link TextChannel channel} where admins
-     * and moderators of Community guilds receive safety alerts from Discord, if present. If an error is received, it is
-     * emitted through the {@code Mono}.
-     */
-    public Mono<TextChannel> getPublicUpdatesChannel(EntityRetrievalStrategy retrievalStrategy) {
-        return Mono.justOrEmpty(getSafetyAlertsChannelId())
-            .flatMap(id -> gateway.withRetrievalStrategy(retrievalStrategy).getChannelById(id))
-            .cast(TextChannel.class);
-    }
-
-    /**
      * Gets the maximum amount of users in a video channel, if present.
      *
      * @return The maximum amount of users in a video channel, if present.

--- a/core/src/main/java/discord4j/core/spec/GuildEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/GuildEditSpecGenerator.java
@@ -39,42 +39,44 @@ import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
 interface GuildEditSpecGenerator extends AuditSpec<GuildModifyRequest> {
 
     Possible<String> name();
-    
+
     Possible<Optional<Region>> region();
-    
+
     Possible<Optional<Guild.VerificationLevel>> verificationLevel();
-    
+
     Possible<Optional<Guild.NotificationLevel>> defaultMessageNotificationsLevel();
 
     Possible<Optional<Guild.ContentFilterLevel>> explicitContentFilter();
-    
+
     Possible<Optional<Snowflake>> afkChannelId();
 
     Possible<Integer> afkTimeout();
-    
+
     Possible<Optional<Image>> icon();
 
     Possible<Snowflake> ownerId();
-    
+
     Possible<Optional<Image>> splash();
-    
+
     Possible<Optional<Image>> discoverySplash();
-    
+
     Possible<Optional<Image>> banner();
-    
+
     Possible<Optional<Snowflake>> systemChannelId();
-    
+
     Possible<Guild.SystemChannelFlag> systemChannelFlags();
-    
+
     Possible<Optional<Snowflake>> rulesChannelId();
-    
+
     Possible<Optional<Snowflake>> publicUpdatesChannelId();
-    
+
     Possible<Optional<Locale>> preferredLocale();
-    
+
     Possible<List<String>> features();
-    
+
     Possible<Optional<String>> description();
+
+    Possible<Optional<Snowflake>> safetyAlertsChannelId();
 
     @Override
     default GuildModifyRequest asRequest() {
@@ -95,6 +97,7 @@ interface GuildEditSpecGenerator extends AuditSpec<GuildModifyRequest> {
                 .systemChannelId(mapPossibleOptional(systemChannelId(), Snowflake::asString))
                 .systemChannelFlags(mapPossible(systemChannelFlags(), Guild.SystemChannelFlag::getValue))
                 .rulesChannelId(mapPossibleOptional(rulesChannelId(), Snowflake::asString))
+                .safetyAlertsChannelId(mapPossibleOptional(safetyAlertsChannelId(), Snowflake::asString))
                 .publicUpdatesChannelId(mapPossibleOptional(publicUpdatesChannelId(), Snowflake::asString))
                 .preferredLocale(mapPossibleOptional(preferredLocale(), Locale::toLanguageTag))
                 .features(mapPossible(features(), ArrayList::new))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.2.5-SNAPSHOT
-discordJsonVersion=1.6.14
+discordJsonVersion=1.6.15-SNAPSHOT
 storesVersion=3.2.2


### PR DESCRIPTION
**Description:** Implement the alert channel defined in guild for notice safety things by discord, also this PR include a new field for automod metadata related to raid mention protection.

**Justification:** https://github.com/discord/discord-api-docs/commit/7467461237468e01f79ec2d88bcb8b77a024ea34

**Depends:** https://github.com/Discord4J/discord-json/pull/148
