### PR TITLE
follow the specified user-agent format exactly

### DIFF
--- a/gateway/src/main/java/discord4j/gateway/DefaultGatewayClient.java
+++ b/gateway/src/main/java/discord4j/gateway/DefaultGatewayClient.java
@@ -367,7 +367,7 @@ public class DefaultGatewayClient implements GatewayClient {
         final Properties properties = GitProperties.getProperties();
         final String version = properties.getProperty(GitProperties.APPLICATION_VERSION, "3");
         final String url = properties.getProperty(GitProperties.APPLICATION_URL, "https://discord4j.com");
-        return "DiscordBot(" + url + ", " + version + ")";
+        return "DiscordBot (" + url + ", " + version + ")";
     }
 
     private void notifyObserver(ConnectionObserver.State state) {

--- a/rest/src/main/java/discord4j/rest/http/client/DiscordWebClient.java
+++ b/rest/src/main/java/discord4j/rest/http/client/DiscordWebClient.java
@@ -71,7 +71,7 @@ public class DiscordWebClient {
         final HttpHeaders defaultHeaders = new DefaultHttpHeaders();
         defaultHeaders.add(HttpHeaderNames.CONTENT_TYPE, "application/json");
         defaultHeaders.add(HttpHeaderNames.AUTHORIZATION, authorizationScheme + " " + token);
-        defaultHeaders.add(HttpHeaderNames.USER_AGENT, "DiscordBot(" + url + ", " + version + ")");
+        defaultHeaders.add(HttpHeaderNames.USER_AGENT, "DiscordBot (" + url + ", " + version + ")");
 
         this.httpClient = configureHttpClient(httpClient.baseUrl(discordBaseUrl));
         this.defaultHeaders = defaultHeaders;

--- a/voice/src/main/java/discord4j/voice/DefaultVoiceGatewayClient.java
+++ b/voice/src/main/java/discord4j/voice/DefaultVoiceGatewayClient.java
@@ -154,7 +154,7 @@ public class DefaultVoiceGatewayClient {
         this.ipDiscoveryRetrySpec = Objects.requireNonNull(options.getIpDiscoveryRetrySpec());
 
         this.httpClient = reactorResources.getHttpClient()
-                .headers(headers -> headers.add(USER_AGENT, "DiscordBot(https://discord4j.com, 3)"));
+                .headers(headers -> headers.add(USER_AGENT, "DiscordBot (https://discord4j.com, 3)"));
         this.voiceSocket = new VoiceSocket(reactorResources.getUdpClient());
         this.heartbeat = new ResettableInterval(reactorResources.getTimerTaskScheduler());
         this.cleanup = Disposables.swap();


### PR DESCRIPTION
**Description:** Inserts a missing space in the `User-Agent` header sent to Discord.

**Justification:** As per https://discord.com/developers/docs/reference#http-api, a `User-Agent` header must be provided following a specific format. This works as is, luckily, but Discord4J should follow the exact format provided by Discord.