### PR TITLE
Propagate request cancellation to HttpClient

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,6 @@ jobs:
   build:
     name: Build for JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'Discord4J/Discord4J' }}
     strategy:
       matrix:
         java: [ 8, 11 ]

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
@@ -65,16 +65,21 @@ public class DefaultRouter implements Router {
 
     @Override
     public DiscordWebResponse exchange(DiscordWebRequest request) {
+        Sinks.Empty<Void> cancelSink = Sinks.empty();
         return new DiscordWebResponse(Mono.deferContextual(
                 ctx -> {
                     Sinks.One<ClientResponse> callback = Sinks.one();
                     housekeepIfNecessary();
                     BucketKey bucketKey = BucketKey.of(request);
                     RequestStream stream = streamMap.computeIfAbsent(bucketKey, key -> createStream(key, request));
-                    if (!stream.push(new RequestCorrelation<>(request, callback, ctx))) {
+                    if (!stream.push(new RequestCorrelation<>(request, callback, ctx, cancelSink))) {
                         callback.emitError(new DiscardedRequestException(request), FAIL_FAST);
                     }
                     return callback.asMono();
+                })
+                .doOnCancel(() -> {
+                    log.info("Cancelling a router exchange");
+                    cancelSink.emitEmpty(FAIL_FAST);
                 })
                 .checkpoint("Request to " + request.getDescription() + " [DefaultRouter]"), reactorResources);
     }

--- a/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
+++ b/rest/src/main/java/discord4j/rest/request/DefaultRouter.java
@@ -77,10 +77,7 @@ public class DefaultRouter implements Router {
                     }
                     return callback.asMono();
                 })
-                .doOnCancel(() -> {
-                    log.info("Cancelling a router exchange");
-                    cancelSink.emitEmpty(FAIL_FAST);
-                })
+                .doOnCancel(() -> cancelSink.emitEmpty(FAIL_FAST))
                 .checkpoint("Request to " + request.getDescription() + " [DefaultRouter]"), reactorResources);
     }
 

--- a/rest/src/main/java/discord4j/rest/request/RequestCorrelation.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestCorrelation.java
@@ -17,6 +17,7 @@
 
 package discord4j.rest.request;
 
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.util.context.ContextView;
 
@@ -25,11 +26,13 @@ class RequestCorrelation<T> {
     private final DiscordWebRequest request;
     private final Sinks.One<T> response;
     private final ContextView context;
+    private final Sinks.Empty<Void> cancel;
 
-    RequestCorrelation(DiscordWebRequest request, Sinks.One<T> response, ContextView context) {
+    RequestCorrelation(DiscordWebRequest request, Sinks.One<T> response, ContextView context, Sinks.Empty<Void> cancel) {
         this.request = request;
         this.response = response;
         this.context = context;
+        this.cancel = cancel;
     }
 
     public DiscordWebRequest getRequest() {
@@ -42,6 +45,10 @@ class RequestCorrelation<T> {
 
     public ContextView getContext() {
         return context;
+    }
+
+    public Mono<Void> onCancel() {
+        return cancel.asMono();
     }
 
     @Override

--- a/rest/src/main/java/discord4j/rest/request/RequestStream.java
+++ b/rest/src/main/java/discord4j/rest/request/RequestStream.java
@@ -208,6 +208,7 @@ class RequestStream {
                     .retryWhen(Retry.withThrowable(rateLimitRetryOperator::apply))
                     .transform(getResponseTransformers(request))
                     .retryWhen(serverErrorRetryFactory())
+                    .takeUntilOther(correlation.onCancel())
                     .doFinally(this::next)
                     .checkpoint("Request to " + clientRequest.getDescription() + " [RequestStream]")
                     .subscribe(


### PR DESCRIPTION
**Description:** If a user cancels a request under rate-limit, it is propagated to the RequestStream subscription and avoids running extra requests.

**Justification:** Cancelling an API request under rate-limit should not hit the API after it completes.


