### PR TITLE
Support rateLimitPerUser for every Guild Message Channel type

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/channel/CategorizableChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/CategorizableChannel.java
@@ -33,6 +33,17 @@ import java.util.function.Consumer;
 public interface CategorizableChannel extends TopLevelGuildChannel {
 
     /**
+     * Gets the amount of seconds a user has to wait before sending another message (0-21600).
+     * <p>
+     * Bots, as well as users with the permission {@code manage_messages} or {@code manage_channel}, are unaffected.
+     *
+     * @return The amount of seconds a user has to wait before sending another message (0-21600).
+     */
+    default int getRateLimitPerUser() {
+        return getData().rateLimitPerUser().toOptional().orElse(0);
+    }
+
+    /**
      * Gets the ID of the category for this channel, if present.
      *
      * @return The ID of the category for this channel, if present.

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -43,18 +43,6 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
     }
 
     /**
-     * Gets the amount of seconds an user has to wait before sending another message (0-120).
-     * <p>
-     * Bots, as well as users with the permission {@code manage_messages} or {@code manage_channel}, are unaffected.
-     *
-     * @return The amount of seconds an user has to wait before sending another message (0-120).
-     */
-    public int getRateLimitPerUser() {
-        return getData().rateLimitPerUser().toOptional()
-                .orElseThrow(IllegalStateException::new); // this should be safe for all TextChannels
-    }
-
-    /**
      * Gets whether this channel is considered NSFW (Not Safe For Work).
      *
      * @return {@code true} if this channel is considered NSFW (Not Safe For Work), {@code false} otherwise.

--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -52,6 +52,17 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
                 .orElseThrow(IllegalStateException::new); // should always be present for threads
     }
 
+    /**
+     * Gets the amount of seconds a user has to wait before sending another message (0-21600).
+     * <p>
+     * Bots, as well as users with the permission {@code manage_messages} or {@code manage_channel}, are unaffected.
+     *
+     * @return The amount of seconds a user has to wait before sending another message (0-21600).
+     */
+    public int getRateLimitPerUser() {
+        return getData().rateLimitPerUser().toOptional().orElse(0);
+    }
+
     // TODO: should this be Member? What if they're not in the guild anymore? Do we consider that anywhere else?
     public Mono<User> getStarter() {
         return getClient().getUserById(getStarterId());

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
@@ -43,17 +43,6 @@ public interface TopLevelGuildMessageChannel extends CategorizableChannel, Guild
     }
 
     /**
-     * Gets the amount of seconds a user has to wait before sending another message (0-21600).
-     * <p>
-     * Bots, as well as users with the permission {@code manage_messages} or {@code manage_channel}, are unaffected.
-     *
-     * @return The amount of seconds a user has to wait before sending another message (0-21600).
-     */
-    default int getRateLimitPerUser() {
-        return getData().rateLimitPerUser().toOptional().orElse(0);
-    }
-
-    /**
      * Requests to create a webhook.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link LegacyWebhookCreateSpec} to be operated on.

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
@@ -43,6 +43,17 @@ public interface TopLevelGuildMessageChannel extends CategorizableChannel, Guild
     }
 
     /**
+     * Gets the amount of seconds a user has to wait before sending another message (0-21600).
+     * <p>
+     * Bots, as well as users with the permission {@code manage_messages} or {@code manage_channel}, are unaffected.
+     *
+     * @return The amount of seconds a user has to wait before sending another message (0-21600).
+     */
+    default int getRateLimitPerUser() {
+        return getData().rateLimitPerUser().toOptional().orElse(0);
+    }
+
+    /**
      * Requests to create a webhook.
      *
      * @param spec A {@link Consumer} that provides a "blank" {@link LegacyWebhookCreateSpec} to be operated on.

--- a/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
@@ -42,6 +42,8 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
 
     Possible<Integer> position();
 
+    Possible<Integer> rateLimitPerUser();
+
     Possible<List<PermissionOverwrite>> permissionOverwrites();
 
     Possible<Snowflake> parentId();
@@ -51,16 +53,17 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
-                .type(Channel.Type.GUILD_NEWS.getValue())
-                .name(name())
-                .topic(topic())
-                .position(position())
-                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                        .map(PermissionOverwrite::getData)
-                        .collect(Collectors.toList())))
-                .parentId(mapPossible(parentId(), Snowflake::asString))
-                .nsfw(nsfw())
-                .build();
+            .type(Channel.Type.GUILD_NEWS.getValue())
+            .name(name())
+            .topic(topic())
+            .position(position())
+            .rateLimitPerUser(rateLimitPerUser())
+            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                .map(PermissionOverwrite::getData)
+                .collect(Collectors.toList())))
+            .parentId(mapPossible(parentId(), Snowflake::asString))
+            .nsfw(nsfw())
+            .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
@@ -39,6 +39,8 @@ interface NewsChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
 
     Possible<Integer> position();
 
+    Possible<Integer> rateLimitPerUser();
+
     Possible<String> topic();
 
     Possible<Boolean> nsfw();
@@ -50,15 +52,16 @@ interface NewsChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
-                .name(name())
-                .position(position())
-                .topic(topic())
-                .nsfw(nsfw())
-                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
-                        .map(PermissionOverwrite::getData)
-                        .collect(Collectors.toList())))
-                .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
-                .build();
+            .name(name())
+            .position(position())
+            .rateLimitPerUser(rateLimitPerUser())
+            .topic(topic())
+            .nsfw(nsfw())
+            .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                .map(PermissionOverwrite::getData)
+                .collect(Collectors.toList())))
+            .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
+            .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/StageChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StageChannelCreateSpecGenerator.java
@@ -42,6 +42,8 @@ interface StageChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
 
     Possible<Integer> position();
 
+    Possible<Integer> rateLimitPerUser();
+
     Possible<List<PermissionOverwrite>> permissionOverwrites();
 
     Possible<Snowflake> parentId();
@@ -49,15 +51,16 @@ interface StageChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
-                .type(Channel.Type.GUILD_STAGE_VOICE.getValue())
-                .name(name())
-                .bitrate(bitrate())
-                .position(position())
-                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                        .map(PermissionOverwrite::getData)
-                        .collect(Collectors.toList())))
-                .parentId(mapPossible(parentId(), Snowflake::asString))
-                .build();
+            .type(Channel.Type.GUILD_STAGE_VOICE.getValue())
+            .name(name())
+            .bitrate(bitrate())
+            .position(position())
+            .rateLimitPerUser(rateLimitPerUser())
+            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                .map(PermissionOverwrite::getData)
+                .collect(Collectors.toList())))
+            .parentId(mapPossible(parentId(), Snowflake::asString))
+            .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/StageChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StageChannelEditSpecGenerator.java
@@ -42,6 +42,8 @@ interface StageChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
 
     Possible<Integer> position();
 
+    Possible<Integer> rateLimitPerUser();
+
     Possible<List<PermissionOverwrite>> permissionOverwrites();
 
     Possible<Optional<Snowflake>> parentId();
@@ -51,15 +53,16 @@ interface StageChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
-                .name(name())
-                .bitrate(bitrate())
-                .position(position())
-                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                        .map(PermissionOverwrite::getData)
-                        .collect(Collectors.toList())))
-                .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
-                .rtcRegion(rtcRegion())
-                .build();
+            .name(name())
+            .bitrate(bitrate())
+            .position(position())
+            .rateLimitPerUser(rateLimitPerUser())
+            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                .map(PermissionOverwrite::getData)
+                .collect(Collectors.toList())))
+            .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
+            .rtcRegion(rtcRegion())
+            .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
@@ -44,6 +44,8 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
 
     Possible<Integer> position();
 
+    Possible<Integer> rateLimitPerUser();
+
     Possible<List<PermissionOverwrite>> permissionOverwrites();
 
     Possible<Snowflake> parentId();
@@ -51,16 +53,17 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
-                .type(Channel.Type.GUILD_VOICE.getValue())
-                .name(name())
-                .bitrate(bitrate())
-                .userLimit(userLimit())
-                .position(position())
-                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                        .map(PermissionOverwrite::getData)
-                        .collect(Collectors.toList())))
-                .parentId(mapPossible(parentId(), Snowflake::asString))
-                .build();
+            .type(Channel.Type.GUILD_VOICE.getValue())
+            .name(name())
+            .bitrate(bitrate())
+            .userLimit(userLimit())
+            .position(position())
+            .rateLimitPerUser(rateLimitPerUser())
+            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                .map(PermissionOverwrite::getData)
+                .collect(Collectors.toList())))
+            .parentId(mapPossible(parentId(), Snowflake::asString))
+            .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
@@ -43,6 +43,8 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
 
     Possible<Integer> position();
 
+    Possible<Integer> rateLimitPerUser();
+
     Possible<List<PermissionOverwrite>> permissionOverwrites();
 
     Possible<Optional<Snowflake>> parentId();
@@ -54,17 +56,18 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
-                .name(name())
-                .bitrate(bitrate())
-                .userLimit(userLimit())
-                .position(position())
-                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                        .map(PermissionOverwrite::getData)
-                        .collect(Collectors.toList())))
-                .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
-                .rtcRegion(rtcRegion())
-                .videoQualityMode(mapPossibleOptional(videoQualityMode(), VoiceChannel.Mode::getValue))
-                .build();
+            .name(name())
+            .bitrate(bitrate())
+            .userLimit(userLimit())
+            .position(position())
+            .rateLimitPerUser(rateLimitPerUser())
+            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                .map(PermissionOverwrite::getData)
+                .collect(Collectors.toList())))
+            .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
+            .rtcRegion(rtcRegion())
+            .videoQualityMode(mapPossibleOptional(videoQualityMode(), VoiceChannel.Mode::getValue))
+            .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/legacy/LegacyTextChannelCreateSpec.java
+++ b/core/src/main/java/discord4j/core/spec/legacy/LegacyTextChannelCreateSpec.java
@@ -67,7 +67,7 @@ public class LegacyTextChannelCreateSpec implements LegacyAuditSpec<ChannelCreat
 
     /**
      * Sets the amount of seconds a user has to wait before sending another message to the created
-     * {@link TextChannel}, from 0 to 120. Does not affect bots or users with {@link Permission#MANAGE_MESSAGES} or
+     * {@link TextChannel}, from 0 to 21600. Does not affect bots or users with {@link Permission#MANAGE_MESSAGES} or
      * {@link Permission#MANAGE_CHANNELS} permissions.
      *
      * @param rateLimitPerUser The channel user rate limit, in seconds.


### PR DESCRIPTION
**Description:** Based in a previous issue all guild channel with messages allow set a rate limit per user in messages send, this currently in code are only for normal messages, things like news channel or voice channel dont allow this, this PR allow get the value and also set also update the docs to reflect the new max value allowed by docs.

**Justification:** This close https://github.com/Discord4J/Discord4J/issues/1111

**Note:** the structure of channel classes is a little mess for me.. then i hope move the method to the correct place.
