### PR TITLE
feat: add ReactionAddEvent#getMessageAuthorId method

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
@@ -105,6 +105,7 @@ class MessageDispatchHandlers {
         long userId = Snowflake.asLong(context.getDispatch().userId());
         long channelId = Snowflake.asLong(context.getDispatch().channelId());
         long messageId = Snowflake.asLong(context.getDispatch().messageId());
+        long messageAuthorId = Snowflake.asLong(context.getDispatch().messageAuthorId());
         Long guildId = context.getDispatch().guildId()
                 .toOptional()
                 .map(Snowflake::asLong)
@@ -125,7 +126,7 @@ class MessageDispatchHandlers {
         Member member = memberData != null ? new Member(gateway, memberData, guildId) : null;
 
         return Mono.just(new ReactionAddEvent(gateway, context.getShardInfo(), userId, channelId,
-                messageId, guildId, emoji, member));
+                messageId, guildId, emoji, member, messageAuthorId));
     }
 
     static Mono<ReactionRemoveEvent> messageReactionRemove(DispatchContext<MessageReactionRemove, Void> context) {

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
@@ -49,9 +49,10 @@ public class ReactionAddEvent extends MessageEvent {
     private final ReactionEmoji emoji;
     @Nullable
     private final Member member;
+    private final long messageAuthorId;
 
     public ReactionAddEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long userId, long channelId, long messageId, @Nullable Long guildId,
-                            ReactionEmoji emoji, @Nullable Member member) {
+                            ReactionEmoji emoji, @Nullable Member member, long messageAuthorId) {
         super(gateway, shardInfo);
         this.userId = userId;
         this.channelId = channelId;
@@ -59,6 +60,7 @@ public class ReactionAddEvent extends MessageEvent {
         this.guildId = guildId;
         this.emoji = emoji;
         this.member = member;
+        this.messageAuthorId = messageAuthorId;
     }
 
     /**
@@ -156,6 +158,16 @@ public class ReactionAddEvent extends MessageEvent {
      */
     public Optional<Member> getMember() {
         return Optional.ofNullable(member);
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link User} who sent the {@link Message} that was reacted to.
+     * Note that this id will be 0 if the message was sent by a webhook.
+     *
+     * @return The ID of the {@link User} who sent the {@link Message} that was reacted to.
+     */
+    public Snowflake getMessageAuthorId() {
+        return Snowflake.of(messageAuthorId);
     }
 
     @Override


### PR DESCRIPTION
**Description:** Add the method getMessageAuthorId on the ReactionAddEvent class

**Justification:** https://github.com/discord/discord-api-docs/pull/6102

Requires https://github.com/Discord4J/discord-json/pull/153 to be merged
