### PR TITLE
Fix ThreadChannel#getParent causing ClassCastException when parent channel is a forum channel

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -78,16 +78,16 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
                 .map(Snowflake::of);
     }
 
-    public Mono<TopLevelGuildMessageChannel> getParent() {
+    public Mono<TopLevelGuildChannel> getParent() {
         return Mono.justOrEmpty(getParentId())
                 .flatMap(getClient()::getChannelById)
-                .cast(TopLevelGuildMessageChannel.class);
+                .cast(TopLevelGuildChannel.class);
     }
 
-    public Mono<TopLevelGuildMessageChannel> getParent(EntityRetrievalStrategy retrievalStrategy) {
+    public Mono<TopLevelGuildChannel> getParent(EntityRetrievalStrategy retrievalStrategy) {
         return Mono.justOrEmpty(getParentId())
                 .flatMap(getClient().withRetrievalStrategy(retrievalStrategy)::getChannelById)
-                .cast(TopLevelGuildMessageChannel.class);
+                .cast(TopLevelGuildChannel.class);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -78,12 +78,25 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
                 .map(Snowflake::of);
     }
 
+    /**
+     * Fetches the parent channel for this thread object.
+     * When the parent channel is a message channel, an appropriate target class for casting is {@link TopLevelGuildMessageChannel}.
+     *
+     * @return A {@link Mono} which, upon completion, emits a {@link TopLevelGuildChannel}. Any error is emitted through the mono.
+     */
     public Mono<TopLevelGuildChannel> getParent() {
         return Mono.justOrEmpty(getParentId())
                 .flatMap(getClient()::getChannelById)
                 .cast(TopLevelGuildChannel.class);
     }
 
+    /**
+     * Fetches the parent channel for this thread object using the provided retrieval strategy.
+     * When the parent channel is a message channel, an appropriate target class for casting is {@link TopLevelGuildMessageChannel}.
+     *
+     * @param retrievalStrategy The selected retrieval strategy for this request
+     * @return A {@link Mono} which, upon completion, emits a {@link TopLevelGuildChannel}. Any error is emitted through the mono.
+     */
     public Mono<TopLevelGuildChannel> getParent(EntityRetrievalStrategy retrievalStrategy) {
         return Mono.justOrEmpty(getParentId())
                 .flatMap(getClient().withRetrievalStrategy(retrievalStrategy)::getChannelById)


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** Fix wrong cast target when fetching a Thread channel parent. This change implies a breaking change from previous development version, as `ThreadChannel#getParent` methods will now return a `Mono<TopLevelGuildChannel>` instead of a `Mono<TopLevelGuildMessageChannel>`.

**Justification:** Issue #1173 

**Quick test:** Here is a snapshot usable for this fix, use this Gradle DSL :

```Gradle
repositories {
    mavenCentral()
    maven { url("https://nexus.klutometis.net/repository/maven-public") }
}

dependencies {
    testImplementation(platform("org.junit:junit-bom:5.9.1"))
    testImplementation("org.junit.jupiter:junit-jupiter")
    implementation("com.discord4j:discord4j-core:3.3.0-FIX-1173-SNAPSHOT")
}
```

I tested it using the same code as in #1173 and this is working well :
```
> Task :Main.main()
[ INFO] (main) Discord4J 3.3.0-M1-91-gc2afd14 (https://discord4j.com)
[ INFO] (reactor-http-epoll-3) [G:1e487e9, S:0] Connected to Gateway
[ INFO] (reactor-http-epoll-3) [G:1e487e9, S:0] Shard connected
Received message in channel ID 1172561366813528114 of type GUILD_PUBLIC_THREAD
Channel ID 1172561366813528114 is a ThreadChannel, getting its parent
Parent channel ID is 1172561288967241829, its type is GUILD_FORUM
```

**Migration from old semantic**

If you need to fetch a `TopLevelGuildMessageChannel` instead of a `TopLevelGuildChannel`, consider using the method [`Mono#ofType`](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#ofType-java.lang.Class-). 

This won't however work with a thread located in a forum channel. If you need to check the parent channel type, use [`Channel#getType`](https://javadoc.io/static/com.discord4j/discord4j-core/3.3.0-M2/discord4j/core/object/entity/channel/Channel.html#getType()).

**Suggested changelog for v3.3 Tracker #1011**

- `ThreadChannel#getParent` methods now return a `Mono<TopLevelGuildChannel>` object in order to support `ForumChannel` as a parent channel. Consider filtering or using `Mono#ofType` method to keep using `TopLevelGuildMessageChannel` if you ignore forum channels.