### PR TITLE
Fix Jackson parsing in application commands when channels are DM channels

### DIFF
--- a/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
@@ -24,10 +24,13 @@ import discord4j.core.object.DiscordObject;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.retriever.EntityRetrievalStrategy;
 import discord4j.discordjson.json.ResolvedChannelData;
+import discord4j.discordjson.json.ThreadMetadata;
+import discord4j.discordjson.possible.Possible;
 import discord4j.rest.util.PermissionSet;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A Discord channel that was resolved in a command.
@@ -80,12 +83,13 @@ public class ResolvedChannel implements DiscordObject {
     }
 
     /**
-     * Gets the name of the channel.
+     * Gets the name of the channel, if given.
+     * This field can be absent when you are not in a guild, e.g. when providing a DM channel.
      *
      * @return The name of the channel.
      */
-    public String getName() {
-        return data.name();
+    public Optional<String> getName() {
+        return data.name().toOptional().flatMap(opt -> opt);
     }
 
     /**
@@ -99,11 +103,30 @@ public class ResolvedChannel implements DiscordObject {
 
     /**
      * Gets the computed permissions for the invoking user in the channel, including overwrites.
+     * This field can be absent when you are not in a guild, e.g. when providing a DM channel.
      *
      * @return The permissions of the channel.
      */
-    public PermissionSet getEffectivePermissions() {
-        return PermissionSet.of(data.permissions());
+    public Optional<PermissionSet> getEffectivePermissions() {
+        return Possible.flatOpt(data.permissions()).map(PermissionSet::of);
+    }
+
+    /**
+     * Gets the associated thread metadata, if the provided channel is a thread.
+     *
+     * @return Associated {@link ThreadMetadata}, if present.
+     */
+    public Optional<ThreadMetadata> getThreadMetadata() {
+        return data.threadMetadata().toOptional();
+    }
+
+    /**
+     * Gets the thread parent id, if the provided channel is a thread.
+     *
+     * @return The parent ID as a {@link Snowflake}, if present.
+     */
+    public Optional<Snowflake> getParentId() {
+        return data.parentId().toOptional().map(Snowflake::of);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/command/ResolvedMember.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedMember.java
@@ -94,6 +94,15 @@ public class ResolvedMember implements DiscordObject {
     }
 
     /**
+     * Gets the avatar hash of this member, if provided.
+     *
+     * @return The avatar hash, if present.
+     */
+    public Optional<String> getAvatar() {
+        return Possible.flatOpt(data.avatar());
+    }
+
+    /**
      * Gets the ID of the guild this user is associated to.
      *
      * @return The ID of the guild this user is associated to.


### PR DESCRIPTION
**Description:** This PR (which requires https://github.com/Discord4J/discord-json/pull/161 to be merged and released) is a fix of resolved objects in application command interactions.


The commit adapts https://github.com/Discord4J/discord-json/pull/161 and edits the ResolvedChannel and ResolvedMember objects to include missing fields and adapt tha mandatory fields.

**Justification:** #1171 and see https://github.com/Discord4J/discord-json/pull/161 for other changes

**Changelog notes**:

- Updates discord-json to `1.7.8`
- `ResolvedChannel#getName` now returns an `Optional<String>` instead of a `String`
- `ResolvedChannel#getPermissions` now returns an `Optional<PermissionSet>` instead of a `PermissionSet`
- `ResolvedChannel` now supports `getThreadMetadata` and `getParentId` methods if the resolved channel is a thread.
- `ResolvedMember` now includes the member avatar hash in `getAvatar` method, if provided.

*Testing changes*

I released a snapshot for this PR on my repo using my own discord-json snapshot.
Use this Gradle DSL to test it :

```Gradle
repositories {
    mavenCentral()
    maven { url("https://nexus.klutometis.net/repository/maven-public") }
}

dependencies {
    implementation("com.discord4j:discord4j-core:3.3.0-FIX-1171-SNAPSHOT")
}
```

Regarding #1171, using the reproduction code, we do not have any error now : 

```
> Task :Main.main()
[ INFO] (main) Discord4J 3.3.0-M1-3-g850a5c6 (https://discord4j.com)
[ INFO] (reactor-http-epoll-3) [G:d02f0e0, S:0] Connected to Gateway
[ INFO] (reactor-http-epoll-3) [G:d02f0e0, S:0] Shard connected
Found channel option with value 1172838873936707584
Selected channel ID is 1172838873936707584, its type is DM
```