### PR TITLE
Change scope of com.discord4j:stores-api from implementation to api.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jackson_datatype_jdk8_version"
     api "com.github.ben-manes.caffeine:caffeine:$caffeine_version"
 
-    implementation "com.discord4j:stores-api:$storesVersion"
+    api "com.discord4j:stores-api:$storesVersion"
 
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
     testImplementation "io.projectreactor:reactor-test"


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** Change scope of com.discord4j:stores-api from implementation to api.
**Justification:** Fix #1200 according to [gradle official doc](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_recognizing_dependencies). 
