### PR TITLE
Add OptionKey for Application Id

### DIFF
--- a/core/src/main/java/discord4j/core/object/audit/OptionKey.java
+++ b/core/src/main/java/discord4j/core/object/audit/OptionKey.java
@@ -51,6 +51,8 @@ public class OptionKey<T> {
     public static final OptionKey<String> AUTO_MODERATION_RULE_NAME = optionKey("auto_moderation_rule_name", Function.identity());
     /** Trigger type of the Auto Moderation rule that was triggered **/
     public static final OptionKey<String> AUTO_MODERATION_RULE_TRIGGER_TYPE = optionKey("auto_moderation_rule_trigger_type", Function.identity());
+    /** ID of the app whose permissions were targeted. */
+    public static final OptionKey<Snowflake> APPLICATION_ID = optionKey("application_id", Snowflake::of);
 
     private static <T> OptionKey<T> optionKey(String field, Function<String, T> parser) {
         return new OptionKey<>(field, parser);

--- a/core/src/main/java/discord4j/core/util/AuditLogUtil.java
+++ b/core/src/main/java/discord4j/core/util/AuditLogUtil.java
@@ -45,6 +45,7 @@ public class AuditLogUtil {
         options.integrationType().toOptional().ifPresent(it -> map.put(OptionKey.INTEGRATION_TYPE.getField(), it));
         options.autoModerationRuleName().toOptional().ifPresent(it -> map.put(OptionKey.AUTO_MODERATION_RULE_NAME.getField(), it));
         options.autoModerationRuleTriggerType().toOptional().ifPresent(it -> map.put(OptionKey.AUTO_MODERATION_RULE_TRIGGER_TYPE.getField(), it));
+        options.applicationId().toOptional().ifPresent(it -> map.put(OptionKey.APPLICATION_ID.getField(), it.asString()));
         return map;
     }
 


### PR DESCRIPTION
**Description:** Add the missing Application Id for the OptionKey in AuditLogs

**Justification:** https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info
