### PR TITLE
Add ThreadChannelCreateEvent#NewlyCreated

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/ThreadDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/ThreadDispatchHandlers.java
@@ -36,9 +36,10 @@ class ThreadDispatchHandlers {
     static Mono<? extends Event> threadCreate(DispatchContext<ThreadCreate, Void> context) {
         GatewayDiscordClient gateway = context.getGateway();
         ChannelData channel = context.getDispatch().thread();
+        boolean threadNewlyCreated = context.getDispatch().newlyCreated().toOptional().orElse(false);
 
         return Mono.just(new ThreadChannelCreateEvent(gateway, context.getShardInfo(),
-                new ThreadChannel(gateway, channel)));
+                new ThreadChannel(gateway, channel), threadNewlyCreated));
     }
 
     static Mono<? extends Event> threadUpdate(DispatchContext<ThreadUpdate, ChannelData> context) {

--- a/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelCreateEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/thread/ThreadChannelCreateEvent.java
@@ -29,20 +29,32 @@ import discord4j.gateway.ShardInfo;
 public class ThreadChannelCreateEvent extends ThreadEvent {
 
     private final ThreadChannel channel;
+    private final boolean threadNewlyCreated;
 
-    public ThreadChannelCreateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, ThreadChannel channel) {
+    public ThreadChannelCreateEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, ThreadChannel channel, boolean threadNewlyCreated) {
         super(gateway, shardInfo);
         this.channel = channel;
+        this.threadNewlyCreated = threadNewlyCreated;
     }
 
     public ThreadChannel getChannel() {
         return channel;
     }
 
+    /**
+     * Gets if the thread related to this event was newly created.
+     *
+     * @return {@code true} if was newly created, {@code false} otherwise.
+     */
+    public boolean isNewlyCreated() {
+        return threadNewlyCreated;
+    }
+
     @Override
     public String toString() {
         return "ThreadChannelCreateEvent{" +
                 "channel=" + channel +
+                ",newlyCreated=" + threadNewlyCreated +
                 '}';
     }
 }


### PR DESCRIPTION
**Description:** This PR pass the field newly_created to the ThreadChannelCreateEvent for allow users know if the thread was created or not.
NOTE: This require another PR for the other case because can get a threadmember...
**Justification:** https://canary.discord.com/channels/208023865127862272/451125724766535710/1239362437690425385
