### PR TITLE
Migrate to discord-json encoding 1.6.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     jackson_datatype_jdk8_version = '2.12.7'
     caffeine_version = '2.8.8'
     immutables_group = 'org.immutables'
-    immutables_version = '2.9.0'
+    immutables_version = '2.10.1'
 
     // Test dependencies
     junit_version = '5.7.1'
@@ -64,6 +64,9 @@ allprojects {
         api platform("io.projectreactor:reactor-bom:$reactor_bom_version")
         api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_datatype_jsr310_version"
         api "com.discord4j:discord-json:$discordJsonVersion"
+
+        compileOnly "com.google.code.findbugs:jsr305:3.0.1"
+        testCompileOnly "com.google.code.findbugs:jsr305:3.0.1"
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,9 +11,6 @@ dependencies {
 
     compileOnly "com.discord4j:discord-json-encoding:$discordJsonVersion"
 
-    compileOnly "com.google.code.findbugs:jsr305:3.0.1"
-    testCompileOnly "com.google.code.findbugs:jsr305:3.0.1"
-
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,13 +11,8 @@ dependencies {
 
     compileOnly "com.discord4j:discord-json-encoding:$discordJsonVersion"
 
-    if (JavaVersion.current().isJava8()) {
-        compileOnly "com.google.code.findbugs:annotations:3.0.1"
-        testCompileOnly "com.google.code.findbugs:annotations:3.0.1"
-    } else {
-        compileOnly "javax.annotation:javax.annotation-api:1.3.2"
-        testCompileOnly "javax.annotation:javax.annotation-api:1.3.2"
-    }
+    compileOnly "com.google.code.findbugs:jsr305:3.0.1"
+    testCompileOnly "com.google.code.findbugs:jsr305:3.0.1"
 
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"

--- a/core/src/main/java/discord4j/core/spec/SpecStyle.java
+++ b/core/src/main/java/discord4j/core/spec/SpecStyle.java
@@ -18,6 +18,7 @@ package discord4j.core.spec;
 
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -32,6 +33,7 @@ import java.lang.annotation.Target;
         deepImmutablesDetection = true,
         allMandatoryParameters = true,
         depluralize = true,
-        instance = "create"
+        instance = "create",
+        allowedClasspathAnnotations = Nullable.class
 )
 public @interface SpecStyle {}

--- a/core/src/main/java/discord4j/core/spec/package-info.java
+++ b/core/src/main/java/discord4j/core/spec/package-info.java
@@ -22,5 +22,5 @@
 @SpecStyle
 package discord4j.core.spec;
 
-import discord4j.discordjson.MetaEncodingEnabled;
+import discord4j.discordjson.encoding.MetaEncodingEnabled;
 import reactor.util.annotation.NonNullApi;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.2.7-SNAPSHOT
-discordJsonVersion=1.6.19
+discordJsonVersion=1.6.20
 storesVersion=3.2.2


### PR DESCRIPTION
---

:warning: **This PR depends on https://github.com/Discord4J/discord-json/pull/172 and assumes that the `1.6.20` version is already tagged and published to Maven Central.**

---

<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->

Updates the import of `@MetaEncodingEnabled` in the `package-info.java` of immutable specs, after updating to discord-json 1.6.20

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->

The discord-json encoding module was completely unusable in a project declaring a `module-info.java` requiring the encoding module because of a package name clash. The package has been moved in the PR linked above to address this.