### PR TITLE
refactor: adjusted naming of NITRO_STICKER_PACKS_GET 

### DIFF
--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -429,6 +429,17 @@ public abstract class Routes {
     public static final Route STICKER_PACKS_GET = Route.get("/sticker-packs");
 
     /**
+     * Returns the list of available sticker packs.
+     *
+     * @see <a href="https://discord.com/developers/docs/resources/sticker#list-sticker-packs">
+     * https://discord.com/developers/docs/resources/sticker#list-sticker-packs</a>
+     *
+     * @deprecated Deprecated in favor of {@link #STICKER_PACKS_GET}. <b>To be removed in 3.3.x</b>
+     */
+    @Deprecated
+    public static final Route NITRO_STICKER_PACKS_GET = STICKER_PACKS_GET;
+
+    /**
      * Returns an array of sticker objects for the given guild. Includes user fields if the bot has the MANAGE_EMOJIS_AND_STICKERS permission.
      *
      * @see <a href="https://discord.com/developers/docs/resources/sticker#list-guild-stickers">

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -421,12 +421,12 @@ public abstract class Routes {
     public static final Route STICKER_GET = Route.get("/stickers/{sticker.id}");
 
     /**
-     * Returns the list of sticker packs available to Nitro subscribers.
+     * Returns the list of available sticker packs.
      *
-     * @see <a href="https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs">
-     * https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs</a>
+     * @see <a href="https://discord.com/developers/docs/resources/sticker#list-sticker-packs">
+     * https://discord.com/developers/docs/resources/sticker#list-sticker-packs</a>
      */
-    public static final Route NITRO_STICKER_PACKS_GET = Route.get("/sticker-packs");
+    public static final Route STICKER_PACKS_GET = Route.get("/sticker-packs");
 
     /**
      * Returns an array of sticker objects for the given guild. Includes user fields if the bot has the MANAGE_EMOJIS_AND_STICKERS permission.

--- a/rest/src/main/java/discord4j/rest/service/StickerService.java
+++ b/rest/src/main/java/discord4j/rest/service/StickerService.java
@@ -23,7 +23,7 @@ public class StickerService extends RestService {
     }
 
     public Flux<StickerPackData> getStickerPacks() {
-        return Routes.NITRO_STICKER_PACKS_GET.newRequest()
+        return Routes.STICKER_PACKS_GET.newRequest()
             .exchange(getRouter())
             .bodyToMono(StickerPackData[].class)
             .flatMapMany(Flux::fromArray);


### PR DESCRIPTION
**Description:** This PR solves the issue #1192  by renaming the package into STICKER_PACKS_GET since a nitro subscription is not needed anymore. The Docu was adjusted accordingly

**Justification:** PR solves the issue #1192

note: old PR #1218 was closed since rebase did not work as expected