### PR TITLE
Minor Change for FindBugs compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ allprojects {
         api platform("io.projectreactor:reactor-bom:$reactor_bom_version")
         api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_datatype_jsr310_version"
         api "com.discord4j:discord-json:$discordJsonVersion"
+
+        compileOnly "com.google.code.findbugs:annotations:3.0.1"
+        testCompileOnly "com.google.code.findbugs:annotations:3.0.1"
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,14 +11,6 @@ dependencies {
 
     compileOnly "com.discord4j:discord-json-encoding:$discordJsonVersion"
 
-    if (JavaVersion.current().isJava8()) {
-        compileOnly "com.google.code.findbugs:annotations:3.0.1"
-        testCompileOnly "com.google.code.findbugs:annotations:3.0.1"
-    } else {
-        compileOnly "javax.annotation:javax.annotation-api:1.3.2"
-        testCompileOnly "javax.annotation:javax.annotation-api:1.3.2"
-    }
-
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"


### PR DESCRIPTION
**Description:** Currently the build shows a warning for "unknown enum constant When.MAYBE" this is caused by an annotation in reactor for Nullable in the core build exists a dependency for fix that but only works if compile with Java 8, this PR change that for call that dependency in all modules.

Note: The alternative of that is not use the reactor annotation for nullable and move to another annotations like the Jetbrains annotations for NotNull/Nullable
