### PR TITLE
Add news Message.Type for INCIDENT/PURCHASE and include if are deletable

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -991,7 +991,7 @@ public final class Message implements Entity {
         /**
          * Unknown type.
          */
-        UNKNOWN(-1),
+        UNKNOWN(-1, false),
 
         /**
          * A message created by a user.
@@ -1001,27 +1001,27 @@ public final class Message implements Entity {
         /**
          * A message created when a recipient was added to a DM.
          */
-        RECIPIENT_ADD(1),
+        RECIPIENT_ADD(1, false),
 
         /**
          * A message created when a recipient left a DM.
          */
-        RECIPIENT_REMOVE(2),
+        RECIPIENT_REMOVE(2, false),
 
         /**
          * A message created when a call was started.
          */
-        CALL(3),
+        CALL(3, false),
 
         /**
          * A message created when a channel's name changed.
          */
-        CHANNEL_NAME_CHANGE(4),
+        CHANNEL_NAME_CHANGE(4, false),
 
         /**
          * A message created when a channel's icon changed.
          */
-        CHANNEL_ICON_CHANGE(5),
+        CHANNEL_ICON_CHANGE(5, false),
 
         /**
          * A message created when a message was pinned.
@@ -1029,33 +1029,34 @@ public final class Message implements Entity {
         CHANNEL_PINNED_MESSAGE(6),
 
         /**
-         * A message created when an user joins a guild.
+         * A message created when a user joins a guild.
          */
         GUILD_MEMBER_JOIN(7),
 
         /**
-         * A message created when an user boost a guild.
+         * A message created when a user boost a guild.
          */
         USER_PREMIUM_GUILD_SUBSCRIPTION(8),
 
         /**
-         * A message created when an user boost a guild and the guild reach the tier 1.
+         * A message created when a user boost a guild and the guild reach the tier 1.
          */
         USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1(9),
 
         /**
-         * A message created when an user boost a guild and the guild reach the tier 2.
+         * A message created when a user boost a guild and the guild reach the tier 2.
          */
         USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2(10),
 
         /**
-         * A message created when an user boost a guild and the guild reach the tier 3.
+         * A message created when a user boost a guild and the guild reach the tier 3.
          */
         USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3(11),
 
         /**
-         * A message created when a user follows a channel from another guild into specific channel (
-         * <a href="https://support.discord.com/hc/en-us/articles/360028384531-Server-Following-FAQ">Server Following</a>).
+         * A message created when a user follows a channel from another guild into specific channel.
+         *
+         * @see <a href="https://support.discord.com/hc/en-us/articles/360028384531-Channel-Following-FAQ">Channel Following</a>
          */
         CHANNEL_FOLLOW_ADD(12),
 
@@ -1085,7 +1086,7 @@ public final class Message implements Entity {
         /**
          * The first message in a thread pointing to a related message in the parent channel from which the thread was started
          * <br>
-         * <b>Note: </b> Only supported from v9 of API
+         * <b>Note:</b> Only supported from v9 of API
         **/
         THREAD_STARTER_MESSAGE(21),
 
@@ -1094,6 +1095,11 @@ public final class Message implements Entity {
 
         CONTEXT_MENU_COMMAND(23),
 
+        /**
+         * A message created by AutoMod.
+         * <br>
+         * <b>Note:</b> For remove this type of message you need {@link discord4j.rest.util.Permission#MANAGE_MESSAGES}
+         */
         AUTO_MODERATION_ACTION(24),
 
         ROLE_SUBSCRIPTION_PURCHASE(25),
@@ -1108,7 +1114,17 @@ public final class Message implements Entity {
 
         STAGE_TOPIC(31),
 
-        GUILD_APPLICATION_PREMIUM_SUBSCRIPTION(32);
+        GUILD_APPLICATION_PREMIUM_SUBSCRIPTION(32),
+
+        GUILD_INCIDENT_ALERT_MODE_ENABLED(36),
+
+        GUILD_INCIDENT_ALERT_MODE_DISABLED(37),
+
+        GUILD_INCIDENT_REPORT_RAID(38),
+
+        GUILD_INCIDENT_REPORT_FALSE_ALARM(39),
+
+        PURCHASE_NOTIFICATION(40);
 
         /**
          * The underlying value as represented by Discord.
@@ -1116,12 +1132,28 @@ public final class Message implements Entity {
         private final int value;
 
         /**
+         * Define if this type of message are deletable
+         */
+        private final boolean deletable;
+
+        /**
          * Constructs a {@code Message.Type}.
          *
          * @param value The underlying value as represented by Discord.
          */
         Type(final int value) {
+            this(value, true);
+        }
+
+        /**
+         * Constructs a {@code Message.Type}.
+         *
+         * @param value The underlying value as represented by Discord.
+         * @param deletable If this type of message is deletable.
+         */
+        Type(final int value, final boolean deletable) {
             this.value = value;
+            this.deletable = deletable;
         }
 
         /**
@@ -1131,6 +1163,15 @@ public final class Message implements Entity {
          */
         public int getValue() {
             return value;
+        }
+
+        /**
+         * Gets if this type of Message can be deleted.
+         *
+         * @return {@code true} if this type of message can be deleted.
+         */
+        public boolean isDeletable() {
+            return deletable;
         }
 
         /**
@@ -1173,6 +1214,11 @@ public final class Message implements Entity {
                 case 29: return STAGE_SPEAKER;
                 case 31: return STAGE_TOPIC;
                 case 32: return GUILD_APPLICATION_PREMIUM_SUBSCRIPTION;
+                case 36: return GUILD_INCIDENT_ALERT_MODE_ENABLED;
+                case 37: return GUILD_INCIDENT_ALERT_MODE_DISABLED;
+                case 38: return GUILD_INCIDENT_REPORT_RAID;
+                case 39: return GUILD_INCIDENT_REPORT_FALSE_ALARM;
+                case 44: return PURCHASE_NOTIFICATION;
                 default: return UNKNOWN;
             }
         }


### PR DESCRIPTION
**Description:** This PR add missing messages types and also include the field in docs for define if that type is deletable or not.

**Justification:** Changes in https://discord.com/developers/docs/resources/channel#message-object-message-types
- https://github.com/discord/discord-api-docs/commit/174c1a18933e068d70d56c2340b9936eed8b366a
- https://github.com/discord/discord-api-docs/commit/e5cd463cd1412df2e55fce8ecb81e7d1ed5755b0

