### PR TITLE
feat: improvements on threads and forums

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -895,12 +895,12 @@ public final class Message implements Entity {
      * Request to create a thread from the current message with the given name. The thread can be configured further
      * by calling the "withXxx" methods on the returned {@link StartThreadFromMessageMono}.
      *
-     * @param name The name of the thread.
+     * @param threadName The name of the thread.
      * @return A {@link StartThreadFromMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}. If
      * an error is received, it is emitted through the {@link Mono}.
      */
-    public StartThreadFromMessageMono createPublicThread(String name) {
-        return StartThreadFromMessageMono.of(name, this);
+    public StartThreadFromMessageMono createPublicThread(String threadName) {
+        return StartThreadFromMessageMono.of(threadName, this);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -32,10 +32,12 @@ import discord4j.core.object.reaction.ReactionEmoji;
 import discord4j.core.retriever.EntityRetrievalStrategy;
 import discord4j.core.spec.MessageEditMono;
 import discord4j.core.spec.MessageEditSpec;
-import discord4j.core.spec.StartThreadSpec;
+import discord4j.core.spec.StartThreadFromMessageMono;
+import discord4j.core.spec.StartThreadFromMessageSpec;
 import discord4j.core.spec.legacy.LegacyMessageEditSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.discordjson.json.MessageData;
+import discord4j.discordjson.json.StartThreadFromMessageRequest;
 import discord4j.discordjson.json.UserData;
 import discord4j.discordjson.possible.Possible;
 import discord4j.gateway.intent.Intent;
@@ -827,7 +829,7 @@ public final class Message implements Entity {
      * @return A {@link Mono} where, upon successful completion, emits the created {@link ThreadChannel}.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public Mono<ThreadChannel> startThread(StartThreadSpec spec) {
+    public Mono<ThreadChannel> startThread(StartThreadFromMessageSpec spec) {
         return gateway.getRestClient().getChannelService()
                 .startThreadWithMessage(getChannelId().asLong(), getId().asLong(), spec.asRequest())
                 .map(data -> new ThreadChannel(gateway, data));
@@ -874,6 +876,31 @@ public final class Message implements Entity {
         // This can happen in the following cases:
         // - The message is a notification message (ex. message pin), and thus don't have neither content nor embeds, etc.
         // - Discord broke their API :'(
+    }
+
+    /**
+     * Request to create a thread from the current message with the given specification.
+     *
+     * @param spec The specification for the thread.
+     * @return A {@link Mono} where, upon successful completion, emits the created {@link ThreadChannel}. If an error is
+     * received, it is emitted through the {@code Mono}.
+     */
+    public Mono<ThreadChannel> createThread(StartThreadFromMessageRequest spec) {
+        return gateway.getRestClient().getChannelService()
+                .startThreadWithMessage(getChannelId().asLong(), getId().asLong(), spec)
+                .map(data -> new ThreadChannel(gateway, data));
+    }
+
+    /**
+     * Request to create a thread from the current message with the given name. The thread can be configured further
+     * by calling the "withXxx" methods on the returned {@link StartThreadFromMessageMono}.
+     *
+     * @param name The name of the thread.
+     * @return A {@link StartThreadFromMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}. If
+     * an error is received, it is emitted through the {@link Mono}.
+     */
+    public StartThreadFromMessageMono createThread(String name) {
+        return StartThreadFromMessageMono.of(name, this);
     }
 
     @Override
@@ -995,12 +1022,12 @@ public final class Message implements Entity {
         DEFAULT(0),
 
         /**
-         * A message created when a recipient was added to a DM.
+         * A message created when a recipient was added to a DM or a thread.
          */
         RECIPIENT_ADD(1),
 
         /**
-         * A message created when a recipient left a DM.
+         * A message created when a recipient left a DM or a thread.
          */
         RECIPIENT_REMOVE(2),
 
@@ -1010,7 +1037,7 @@ public final class Message implements Entity {
         CALL(3),
 
         /**
-         * A message created when a channel's name changed.
+         * A message created when a thread's name changed.
          */
         CHANNEL_NAME_CHANGE(4),
 

--- a/core/src/main/java/discord4j/core/object/entity/Message.java
+++ b/core/src/main/java/discord4j/core/object/entity/Message.java
@@ -885,7 +885,7 @@ public final class Message implements Entity {
      * @return A {@link Mono} where, upon successful completion, emits the created {@link ThreadChannel}. If an error is
      * received, it is emitted through the {@code Mono}.
      */
-    public Mono<ThreadChannel> createThread(StartThreadFromMessageRequest spec) {
+    public Mono<ThreadChannel> createPublicThread(StartThreadFromMessageRequest spec) {
         return gateway.getRestClient().getChannelService()
                 .startThreadWithMessage(getChannelId().asLong(), getId().asLong(), spec)
                 .map(data -> new ThreadChannel(gateway, data));
@@ -899,7 +899,7 @@ public final class Message implements Entity {
      * @return A {@link StartThreadFromMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}. If
      * an error is received, it is emitted through the {@link Mono}.
      */
-    public StartThreadFromMessageMono createThread(String name) {
+    public StartThreadFromMessageMono createPublicThread(String name) {
         return StartThreadFromMessageMono.of(name, this);
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/channel/ForumChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ForumChannel.java
@@ -126,6 +126,21 @@ public final class ForumChannel extends BaseTopLevelGuildChannel implements Cate
     }
 
     /**
+     * Requests to edit the current forum channel object
+     *
+     * @param spec an immutable object that specifies the modifications requested
+     * @return A {@link Mono} that, upon completion, emits the updated {@link ForumChannel} object
+     */
+    public Mono<ForumChannel> edit(ForumChannelEditSpec spec) {
+        Objects.requireNonNull(spec);
+        return Mono.defer(
+                () -> getClient().getRestClient().getChannelService()
+                    .modifyChannel(getId().asLong(), spec.asRequest(), spec.reason()))
+            .map(data -> EntityUtil.getChannel(getClient(), data))
+            .cast(ForumChannel.class);
+    }
+
+    /**
      * Starts a new {@link ThreadChannel} in this forum channel
      *
      * @param request an immutable object that specifies how to create the thread
@@ -147,21 +162,6 @@ public final class ForumChannel extends BaseTopLevelGuildChannel implements Cate
      */
     public StartThreadInForumChannelMono startThread(String name, ForumThreadMessageCreateSpec messageCreateSpec) {
         return StartThreadInForumChannelMono.of(name, messageCreateSpec, this);
-    }
-
-    /**
-     * Requests to edit the current forum channel object
-     *
-     * @param spec an immutable object that specifies the modifications requested
-     * @return A {@link Mono} that, upon completion, emits the updated {@link ForumChannel} object
-     */
-    public Mono<ForumChannel> edit(ForumChannelEditSpec spec) {
-        Objects.requireNonNull(spec);
-        return Mono.defer(
-                () -> getClient().getRestClient().getChannelService()
-                    .modifyChannel(getId().asLong(), spec.asRequest(), spec.reason()))
-            .map(data -> EntityUtil.getChannel(getClient(), data))
-            .cast(ForumChannel.class);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/ForumChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ForumChannel.java
@@ -5,6 +5,8 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.ForumTag;
 import discord4j.core.object.reaction.DefaultReaction;
 import discord4j.core.spec.ForumChannelEditSpec;
+import discord4j.core.spec.ForumThreadMessageCreateSpec;
+import discord4j.core.spec.StartThreadInForumChannelMono;
 import discord4j.core.spec.StartThreadInForumChannelSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.discordjson.json.ChannelData;
@@ -248,6 +250,19 @@ public final class ForumChannel extends BaseTopLevelGuildChannel implements Cate
     public Mono<ThreadChannel> startThread(StartThreadInForumChannelSpec request) {
         return getClient().getRestClient().getChannelService().startThreadInForumChannel(getId().asLong(), request.asRequest())
             .map(channelData -> new ThreadChannel(getClient(), channelData));
+    }
+
+    /**
+     * Starts a new {@link ThreadChannel} in this forum channel. Properties specifying how to create this channel
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadInForumChannelMono}.
+     *
+     * @param name The name of the thread
+     * @param messageCreateSpec The message to start the thread with
+     * @return A {@link StartThreadInForumChannelMono} where, upon successful completion, emits the created
+     * {@link ThreadChannel}. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public StartThreadInForumChannelMono startThread(String name, ForumThreadMessageCreateSpec messageCreateSpec) {
+        return StartThreadInForumChannelMono.of(name, messageCreateSpec, this);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -115,6 +115,13 @@ public final class NewsChannel extends BaseTopLevelGuildChannel implements TopLe
     }
 
     @Override
+    public Mono<ThreadChannel> startPublicThreadWithoutMessage(StartThreadWithoutMessageSpec spec) {
+        spec = spec.withType(ThreadChannel.Type.GUILD_NEWS_THREAD);
+
+        return TopLevelGuildMessageWithThreadsChannel.super.startPublicThreadWithoutMessage(spec);
+    }
+
+    @Override
     public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String threadName) {
         return StartThreadWithoutMessageMono.of(threadName, ThreadChannel.Type.GUILD_NEWS_THREAD, this);
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -115,8 +115,8 @@ public final class NewsChannel extends BaseTopLevelGuildChannel implements TopLe
     }
 
     @Override
-    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
-        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_NEWS_THREAD, this);
+    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String threadName) {
+        return StartThreadWithoutMessageMono.of(threadName, ThreadChannel.Type.GUILD_NEWS_THREAD, this);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -19,8 +19,11 @@ package discord4j.core.object.entity.channel;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.FollowedChannel;
+import discord4j.core.object.entity.Message;
 import discord4j.core.spec.NewsChannelEditMono;
 import discord4j.core.spec.NewsChannelEditSpec;
+import discord4j.core.spec.StartThreadFromMessageMono;
+import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.legacy.LegacyNewsChannelEditSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.discordjson.json.ChannelData;
@@ -106,6 +109,16 @@ public final class NewsChannel extends BaseTopLevelGuildChannel implements TopLe
                         .webhookChannelId(targetChannelId.asString())
                         .build())
                 .map(data -> new FollowedChannel(getClient(), data));
+    }
+
+    @Override
+    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
+        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_NEWS_THREAD, this);
+    }
+
+    @Override
+    public StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
+        return StartThreadFromMessageMono.of(name, message);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/NewsChannel.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 /** A Discord news channel. */
-public final class NewsChannel extends BaseTopLevelGuildChannel implements TopLevelGuildMessageChannel {
+public final class NewsChannel extends BaseTopLevelGuildChannel implements TopLevelGuildMessageWithThreadsChannel {
 
     /**
      * Constructs an {@code NewsChannel} with an associated {@link GatewayDiscordClient} and Discord data.
@@ -114,61 +114,9 @@ public final class NewsChannel extends BaseTopLevelGuildChannel implements TopLe
                 .map(data -> new FollowedChannel(getClient(), data));
     }
 
-    /**
-     * Request to retrieve all threads in this channel.
-     *
-     * @return A {@link Flux} that continually emits the {@link ThreadChannel threads} of the channel. If an error is
-     * received, it is emitted through the {@code Flux}.
-     */
-    public Flux<ThreadChannel> getAllThreads() {
-        return getClient().getGuildChannels(getGuildId())
-            .ofType(ThreadChannel.class)
-            .filter(thread -> thread.getParentId().map(id -> id.equals(getId())).orElse(false));
-    }
-
-    /**
-     * Requests to retrieve the public archived threads for this channel.
-     * <p>
-     * The audit log parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
-     * <pre>
-     * {@code
-     * channel.getPublicArchivedThreads()
-     *     .take(10)
-     *     .reduce(ThreadListPart::combine)
-     * }
-     * </pre>
-     *
-     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
-     * through the {@code Flux}.
-     */
-    public Flux<ThreadListPart> getPublicArchivedThreads() {
-        return getRestChannel().getPublicArchivedThreads()
-            .map(data -> new ThreadListPart(getClient(), data));
-    }
-
-    /**
-     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
-     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
-     *
-     * @param name the name of the thread
-     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public StartThreadWithoutMessageMono startThreadWithoutMessage(String name) {
+    @Override
+    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
         return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_NEWS_THREAD, this);
-    }
-
-    /**
-     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
-     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
-     *
-     * @param name the name of the thread
-     * @param message the message to start the thread with
-     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public StartThreadFromMessageMono startThreadWithMessage(String name, Message message) {
-        return StartThreadFromMessageMono.of(name, message);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -145,20 +145,20 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
     }
 
     @Override
-    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
-        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
+    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String threadName) {
+        return StartThreadWithoutMessageMono.of(threadName, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
     }
 
     /**
      * Start a new private thread. Properties specifying how to create the thread can be set via the {@code withXxx}
      * methods of the returned {@link StartThreadWithoutMessageMono}.
      *
-     * @param name the name of the thread
+     * @param threadName the name of the thread
      * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    public StartThreadWithoutMessageMono startPrivateThread(String name) {
-        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PRIVATE_THREAD, this);
+    public StartThreadWithoutMessageMono startPrivateThread(String threadName) {
+        return StartThreadWithoutMessageMono.of(threadName, ThreadChannel.Type.GUILD_PRIVATE_THREAD, this);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -17,6 +17,9 @@
 package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.StartThreadFromMessageMono;
+import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.TextChannelEditMono;
 import discord4j.core.spec.TextChannelEditSpec;
 import discord4j.core.spec.legacy.LegacyTextChannelEditSpec;
@@ -104,4 +107,27 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
     public String toString() {
         return "TextChannel{} " + super.toString();
     }
+
+    @Override
+    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
+        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
+    }
+
+    @Override
+    public StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
+        return StartThreadFromMessageMono.of(name, message);
+    }
+
+    /**
+     * Start a new private thread. Properties specifying how to create the thread can be set via the {@code withXxx}
+     * methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public StartThreadWithoutMessageMono startPrivateThread(String name) {
+        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PRIVATE_THREAD, this);
+    }
+
 }

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -18,6 +18,8 @@ package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.ThreadListPart;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.StartThreadFromMessageSpec;
 import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.TextChannelEditMono;
@@ -149,6 +151,13 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
         return StartThreadWithoutMessageMono.of(threadName, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
     }
 
+    @Override
+    public Mono<ThreadChannel> startPublicThreadWithoutMessage(StartThreadWithoutMessageSpec spec) {
+        spec = spec.withType(ThreadChannel.Type.GUILD_PUBLIC_THREAD);
+
+        return TopLevelGuildMessageWithThreadsChannel.super.startPublicThreadWithoutMessage(spec);
+    }
+
     /**
      * Start a new private thread. Properties specifying how to create the thread can be set via the {@code withXxx}
      * methods of the returned {@link StartThreadWithoutMessageMono}.
@@ -170,6 +179,8 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
      * received, it is emitted through the {@link Mono}.
      */
     public Mono<ThreadChannel> startPrivateThread(StartThreadWithoutMessageSpec spec) {
+        spec = spec.withType(ThreadChannel.Type.GUILD_PRIVATE_THREAD);
+
         return getRestChannel().startThreadWithoutMessage(spec.asRequest())
             .map(data -> new ThreadChannel(getClient(), data));
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -17,9 +17,6 @@
 package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.object.ThreadListPart;
-import discord4j.core.object.entity.Message;
-import discord4j.core.spec.StartThreadFromMessageSpec;
 import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.TextChannelEditMono;
@@ -128,22 +125,15 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
 
     /**
      * Requests to retrieve the joined private archived threads for this channel.
-     * <p>
-     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
-     * <pre>
-     * {@code
-     * channel.getJoinedPrivateArchivedThreads()
-     *     .take(10)
-     *     .reduce(ThreadListPart::combine)
-     * }
-     * </pre>
      *
-     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
-     * through the {@code Flux}.
+     * @return A {@link Flux} that continually emits the joined private archived {@link ThreadChannel threads} of the channel.
+     * If an error is received, it is emitted through the {@code Flux}.
      */
-    public Flux<ThreadListPart> getJoinedPrivateArchivedThreads() {
+    public Flux<ThreadChannel> getJoinedPrivateArchivedThreads() {
         return getRestChannel().getJoinedPrivateArchivedThreads()
-            .map(data -> new ThreadListPart(getClient(), data));
+            .map(ListThreadsData::threads)
+            .flatMap(Flux::fromIterable)
+            .map(channelData -> new ThreadChannel(getClient(), channelData));
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TextChannel.java
@@ -17,6 +17,7 @@
 package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.ThreadListPart;
 import discord4j.core.object.entity.Message;
 import discord4j.core.spec.StartThreadFromMessageMono;
 import discord4j.core.spec.StartThreadWithoutMessageMono;
@@ -25,6 +26,7 @@ import discord4j.core.spec.TextChannelEditSpec;
 import discord4j.core.spec.legacy.LegacyTextChannelEditSpec;
 import discord4j.core.util.EntityUtil;
 import discord4j.discordjson.json.ChannelData;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
@@ -108,12 +110,99 @@ public final class TextChannel extends BaseTopLevelGuildChannel implements TopLe
         return "TextChannel{} " + super.toString();
     }
 
-    @Override
+    /**
+     * Request to retrieve all threads in this channel.
+     *
+     * @return A {@link Flux} that continually emits the {@link ThreadChannel threads} of the channel. If an error is
+     * received, it is emitted through the {@code Flux}.
+     */
+    public Flux<ThreadChannel> getAllThreads() {
+        return getClient().getGuildChannels(getGuildId())
+            .ofType(ThreadChannel.class)
+            .filter(thread -> thread.getParentId().map(id -> id.equals(getId())).orElse(false));
+    }
+
+    /**
+     * Requests to retrieve the public archived threads for this channel.
+     * <p>
+     * The audit log parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getPublicArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    public Flux<ThreadListPart> getPublicArchivedThreads() {
+        return getRestChannel().getPublicArchivedThreads()
+            .map(data -> new ThreadListPart(getClient(), data));
+    }
+
+    /**
+     * Requests to retrieve the private archived threads for this channel.
+     * <p>
+     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getPrivateArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    public Flux<ThreadListPart> getPrivateArchivedThreads() {
+        return getRestChannel().getPrivateArchivedThreads()
+            .map(data -> new ThreadListPart(getClient(), data));
+    }
+
+    /**
+     * Requests to retrieve the joined private archived threads for this channel.
+     * <p>
+     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getJoinedPrivateArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    public Flux<ThreadListPart> getJoinedPrivateArchivedThreads() {
+        return getRestChannel().getJoinedPrivateArchivedThreads()
+            .map(data -> new ThreadListPart(getClient(), data));
+    }
+
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
     public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
         return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
     }
 
-    @Override
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @param message the message to start the thread with
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
     public StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
         return StartThreadFromMessageMono.of(name, message);
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -35,6 +35,7 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -262,6 +263,32 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
                     .modifyThread(getId().asLong(), spec.asRequest(), spec.reason()))
             .map(data -> EntityUtil.getChannel(getClient(), data))
             .cast(ThreadChannel.class);
+    }
+
+    /**
+     * Request to pin the current thread. Only available for threads created in a {@link ForumChannel}.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits an empty {@code Mono}. If an error is received, it
+     * is emitted through the {@code Mono}.
+     */
+    public Mono<Void> pin() {
+        return getParent()
+            .filter(ForumChannel.class::isInstance)
+            .map(__ -> this)
+            .flatMap(threadChannel -> threadChannel.edit().withFlags(EnumSet.of(ForumChannel.Flag.PINNED)).then());
+    }
+
+    /**
+     * Request to unpin the current thread. Only available for threads created in a {@link ForumChannel}.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits an empty {@code Mono}. If an error is received, it
+     * is emitted through the {@code Mono}.
+     */
+    public Mono<Void> unpin() {
+        return getParent()
+            .filter(ForumChannel.class::isInstance)
+            .map(__ -> this)
+            .flatMap(threadChannel -> threadChannel.edit().withFlags(EnumSet.noneOf(ForumChannel.Flag.class)).then());
     }
 
     /** Duration in minutes to automatically archive the thread after recent activity. */

--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -306,21 +306,26 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
     public enum Type {
 
         /** Unknown type. */
-        UNKNOWN(-1),
-        GUILD_NEWS_THREAD(10),
-        GUILD_PUBLIC_THREAD(11),
-        GUILD_PRIVATE_THREAD(12);
+        UNKNOWN(-1, false),
+        GUILD_NEWS_THREAD(10, true),
+        GUILD_PUBLIC_THREAD(11, true),
+        GUILD_PRIVATE_THREAD(12, false);
 
         /** The underlying value as represented by Discord. */
         private final int value;
 
+        /** If the thread type is public */
+        private final boolean isPublic;
+
         /**
          * Constructs a {@code ThreadChannel.Type}.
          *
-         * @param value The underlying value as represented by Discord.
+         * @param value    The underlying value as represented by Discord.
+         * @param isPublic If the thread type is public
          */
-        Type(final int value) {
+        Type(final int value, boolean isPublic) {
             this.value = value;
+            this.isPublic = isPublic;
         }
 
         /**
@@ -330,6 +335,15 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
          */
         public int getValue() {
             return value;
+        }
+
+        /**
+         * Gets whether the thread type is public.
+         *
+         * @return If the thread type is public
+         */
+        public boolean isPublic() {
+            return this.isPublic;
         }
 
         /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
@@ -16,12 +16,7 @@
  */
 package discord4j.core.object.entity.channel;
 
-import discord4j.core.object.ThreadListPart;
-import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.Webhook;
-import discord4j.core.spec.StartThreadFromMessageMono;
-import discord4j.core.spec.StartThreadWithoutMessageMono;
-import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.WebhookCreateMono;
 import discord4j.core.spec.WebhookCreateSpec;
 import discord4j.core.spec.legacy.LegacyWebhookCreateSpec;
@@ -103,109 +98,4 @@ public interface TopLevelGuildMessageChannel extends CategorizableChannel, Guild
                 .map(data -> new Webhook(getClient(), data));
     }
 
-    /**
-     * Creates a new thread that is not connected to an existing message.
-     *
-     * @param spec an immutable object that specifies how to create the thread
-     * @return A {@link Mono} where, upon successful completion, emits the created {@link ThreadChannel}.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    default Mono<ThreadChannel> startThread(StartThreadWithoutMessageSpec spec) {
-        return getClient().getRestClient().getChannelService()
-                .startThreadWithoutMessage(getId().asLong(), spec.asRequest())
-                .map(data -> new ThreadChannel(getClient(), data));
-    }
-
-    /**
-     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
-     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
-     *
-     * @param name the name of the thread
-     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name);
-
-    /**
-     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
-     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
-     *
-     * @param name the name of the thread
-     * @param message the message to start the thread with
-     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message);
-
-    /**
-     * Request to retrieve all threads in this channel.
-     *
-     * @return A {@link Flux} that continually emits the {@link ThreadChannel threads} of the channel. If an error is
-     * received, it is emitted through the {@code Flux}.
-     */
-    default Flux<ThreadChannel> getAllThreads() {
-        return getClient().getGuildChannels(getGuildId())
-                .ofType(ThreadChannel.class)
-                .filter(thread -> thread.getParentId().map(id -> id.equals(getId())).orElse(false));
-    }
-
-    /**
-     * Requests to retrieve the public archived threads for this channel.
-     * <p>
-     * The audit log parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
-     * <pre>
-     * {@code
-     * channel.getPublicArchivedThreads()
-     *     .take(10)
-     *     .reduce(ThreadListPart::combine)
-     * }
-     * </pre>
-     *
-     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
-     * through the {@code Flux}.
-     */
-    default Flux<ThreadListPart> getPublicArchivedThreads() {
-        return getRestChannel().getPublicArchivedThreads()
-                .map(data -> new ThreadListPart(getClient(), data));
-    }
-
-    /**
-     * Requests to retrieve the private archived threads for this channel.
-     * <p>
-     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
-     * <pre>
-     * {@code
-     * channel.getPrivateArchivedThreads()
-     *     .take(10)
-     *     .reduce(ThreadListPart::combine)
-     * }
-     * </pre>
-     *
-     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
-     * through the {@code Flux}.
-     */
-    default Flux<ThreadListPart> getPrivateArchivedThreads() {
-        return getRestChannel().getPrivateArchivedThreads()
-                .map(data -> new ThreadListPart(getClient(), data));
-    }
-
-    /**
-     * Requests to retrieve the joined private archived threads for this channel.
-     * <p>
-     * The thread list parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
-     * <pre>
-     * {@code
-     * channel.getJoinedPrivateArchivedThreads()
-     *     .take(10)
-     *     .reduce(ThreadListPart::combine)
-     * }
-     * </pre>
-     *
-     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
-     * through the {@code Flux}.
-     */
-    default Flux<ThreadListPart> getJoinedPrivateArchivedThreads() {
-        return getRestChannel().getJoinedPrivateArchivedThreads()
-                .map(data -> new ThreadListPart(getClient(), data));
-    }
 }

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageChannel.java
@@ -17,7 +17,10 @@
 package discord4j.core.object.entity.channel;
 
 import discord4j.core.object.ThreadListPart;
+import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.Webhook;
+import discord4j.core.spec.StartThreadFromMessageMono;
+import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.WebhookCreateMono;
 import discord4j.core.spec.WebhookCreateSpec;
@@ -111,6 +114,39 @@ public interface TopLevelGuildMessageChannel extends CategorizableChannel, Guild
         return getClient().getRestClient().getChannelService()
                 .startThreadWithoutMessage(getId().asLong(), spec.asRequest())
                 .map(data -> new ThreadChannel(getClient(), data));
+    }
+
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name);
+
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @param message the message to start the thread with
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message);
+
+    /**
+     * Request to retrieve all threads in this channel.
+     *
+     * @return A {@link Flux} that continually emits the {@link ThreadChannel threads} of the channel. If an error is
+     * received, it is emitted through the {@code Flux}.
+     */
+    default Flux<ThreadChannel> getAllThreads() {
+        return getClient().getGuildChannels(getGuildId())
+                .ofType(ThreadChannel.class)
+                .filter(thread -> thread.getParentId().map(id -> id.equals(getId())).orElse(false));
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageWithThreadsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageWithThreadsChannel.java
@@ -1,0 +1,99 @@
+package discord4j.core.object.entity.channel;
+
+import discord4j.core.object.ThreadListPart;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.StartThreadFromMessageMono;
+import discord4j.core.spec.StartThreadFromMessageSpec;
+import discord4j.core.spec.StartThreadWithoutMessageMono;
+import discord4j.core.spec.StartThreadWithoutMessageSpec;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * A Discord message channel in a guild that isn't a thread and can have threads.
+ */
+public interface TopLevelGuildMessageWithThreadsChannel extends TopLevelGuildMessageChannel {
+
+    /**
+     * Request to retrieve all threads in this channel.
+     *
+     * @return A {@link Flux} that continually emits the {@link ThreadChannel threads} of the channel. If an error is
+     * received, it is emitted through the {@code Flux}.
+     */
+    default Flux<ThreadChannel> getAllThreads() {
+        return getClient().getGuildChannels(getGuildId())
+            .ofType(ThreadChannel.class)
+            .filter(thread -> thread.getParentId().map(id -> id.equals(getId())).orElse(false));
+    }
+
+    /**
+     * Requests to retrieve the public archived threads for this channel.
+     * <p>
+     * The audit log parts can be {@link ThreadListPart#combine(ThreadListPart) combined} for easier querying. For example,
+     * <pre>
+     * {@code
+     * channel.getPublicArchivedThreads()
+     *     .take(10)
+     *     .reduce(ThreadListPart::combine)
+     * }
+     * </pre>
+     *
+     * @return A {@link Flux} that continually parts of this channel's thread list. If an error is received, it is emitted
+     * through the {@code Flux}.
+     */
+    default Flux<ThreadListPart> getPublicArchivedThreads() {
+        return getRestChannel().getPublicArchivedThreads()
+            .map(data -> new ThreadListPart(getClient(), data));
+    }
+
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@link StartThreadWithoutMessageSpec} specifier.
+     *
+     * @param spec the properties to create the thread with
+     * @return A {@link Mono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@link Mono}.
+     */
+    default Mono<ThreadChannel> startPublicThreadWithoutMessage(StartThreadWithoutMessageSpec spec) {
+        return getRestChannel().startThreadWithoutMessage(spec.asRequest())
+            .map(data -> new ThreadChannel(getClient(), data));
+    }
+
+    /**
+     * Start a new public thread that is connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@link StartThreadFromMessageSpec} specifier.
+     *
+     * @param message the message to start the thread with
+     * @param spec the properties to create the thread with
+     * @return A {@link Mono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@link Mono}.
+     */
+    default Mono<ThreadChannel> startPublicThreadWithMessage(Message message, StartThreadFromMessageSpec spec) {
+        return getRestChannel().startThreadFromMessage(message.getId().asLong(), spec.asRequest())
+            .map(data -> new ThreadChannel(getClient(), data));
+    }
+
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name);
+
+    /**
+     * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
+     * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @param message the message to start the thread with
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    default StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
+        return StartThreadFromMessageMono.of(name, message);
+    }
+
+}

--- a/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageWithThreadsChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/TopLevelGuildMessageWithThreadsChannel.java
@@ -77,23 +77,23 @@ public interface TopLevelGuildMessageWithThreadsChannel extends TopLevelGuildMes
      * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
      * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
      *
-     * @param name the name of the thread
+     * @param threadName the name of the thread
      * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name);
+    StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String threadName);
 
     /**
      * Start a new public thread that is not connected to an existing message. Properties specifying how to create the thread
      * can be set via the {@code withXxx} methods of the returned {@link StartThreadWithoutMessageMono}.
      *
-     * @param name the name of the thread
+     * @param threadName the name of the thread
      * @param message the message to start the thread with
      * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
      * If an error is received, it is emitted through the {@code Mono}.
      */
-    default StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
-        return StartThreadFromMessageMono.of(name, message);
+    default StartThreadFromMessageMono startPublicThreadWithMessage(String threadName, Message message) {
+        return StartThreadFromMessageMono.of(threadName, message);
     }
 
 }

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -18,8 +18,6 @@ package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.StartThreadFromMessageMono;
-import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.VoiceChannelEditMono;
 import discord4j.core.spec.VoiceChannelEditSpec;
 import discord4j.core.spec.legacy.LegacyVoiceChannelEditSpec;
@@ -111,28 +109,6 @@ public final class VoiceChannel extends BaseTopLevelGuildChannel implements Audi
     @Override
     public String toString() {
         return "VoiceChannel{} " + super.toString();
-    }
-
-    @Override
-    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
-        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
-    }
-
-    @Override
-    public StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
-        return StartThreadFromMessageMono.of(name, message);
-    }
-
-    /**
-     * Start a new private thread. Properties specifying how to create the thread can be set via the {@code withXxx}
-     * methods of the returned {@link StartThreadWithoutMessageMono}.
-     *
-     * @param name the name of the thread
-     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public StartThreadWithoutMessageMono startPrivateThread(String name) {
-        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PRIVATE_THREAD, this);
     }
 
     /** Represents the various video quality modes. */

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -17,7 +17,6 @@
 package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.object.entity.Message;
 import discord4j.core.spec.VoiceChannelEditMono;
 import discord4j.core.spec.VoiceChannelEditSpec;
 import discord4j.core.spec.legacy.LegacyVoiceChannelEditSpec;

--- a/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/VoiceChannel.java
@@ -17,6 +17,9 @@
 package discord4j.core.object.entity.channel;
 
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.StartThreadFromMessageMono;
+import discord4j.core.spec.StartThreadWithoutMessageMono;
 import discord4j.core.spec.VoiceChannelEditMono;
 import discord4j.core.spec.VoiceChannelEditSpec;
 import discord4j.core.spec.legacy.LegacyVoiceChannelEditSpec;
@@ -108,6 +111,28 @@ public final class VoiceChannel extends BaseTopLevelGuildChannel implements Audi
     @Override
     public String toString() {
         return "VoiceChannel{} " + super.toString();
+    }
+
+    @Override
+    public StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name) {
+        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PUBLIC_THREAD, this);
+    }
+
+    @Override
+    public StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message) {
+        return StartThreadFromMessageMono.of(name, message);
+    }
+
+    /**
+     * Start a new private thread. Properties specifying how to create the thread can be set via the {@code withXxx}
+     * methods of the returned {@link StartThreadWithoutMessageMono}.
+     *
+     * @param name the name of the thread
+     * @return A {@link StartThreadWithoutMessageMono} where, upon successful completion, emits the created {@link ThreadChannel}.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public StartThreadWithoutMessageMono startPrivateThread(String name) {
+        return StartThreadWithoutMessageMono.of(name, ThreadChannel.Type.GUILD_PRIVATE_THREAD, this);
     }
 
     /** Represents the various video quality modes. */

--- a/core/src/main/java/discord4j/core/spec/StartThreadFromMessageSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StartThreadFromMessageSpecGenerator.java
@@ -19,7 +19,7 @@ package discord4j.core.spec;
 
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.channel.ThreadChannel;
-import discord4j.discordjson.json.StartThreadRequest;
+import discord4j.discordjson.json.StartThreadFromMessageRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -41,7 +41,7 @@ import static discord4j.core.spec.InternalSpecUtils.mapPossible;
  * @see <a href="https://discord.com/developers/docs/resources/channel#start-thread-from-message">Documentation</a>
  */
 @Value.Immutable
-public interface StartThreadSpecGenerator extends AuditSpec<StartThreadRequest> {
+public interface StartThreadFromMessageSpecGenerator extends AuditSpec<StartThreadFromMessageRequest> {
 
     String name();
 
@@ -50,8 +50,8 @@ public interface StartThreadSpecGenerator extends AuditSpec<StartThreadRequest> 
     Possible<Integer> rateLimitPerUser();
 
     @Override
-    default StartThreadRequest asRequest() {
-        return StartThreadRequest.builder()
+    default StartThreadFromMessageRequest asRequest() {
+        return StartThreadFromMessageRequest.builder()
                 .name(name())
                 .autoArchiveDuration(mapPossible(autoArchiveDuration(), ThreadChannel.AutoArchiveDuration::getValue))
                 .rateLimitPerUser(rateLimitPerUser())
@@ -61,13 +61,13 @@ public interface StartThreadSpecGenerator extends AuditSpec<StartThreadRequest> 
 
 @SuppressWarnings("immutables:subtype")
 @Value.Immutable(builder = false)
-abstract class StartThreadMonoGenerator extends Mono<ThreadChannel> implements StartThreadSpecGenerator {
+abstract class StartThreadFromMessageMonoGenerator extends Mono<ThreadChannel> implements StartThreadFromMessageSpecGenerator {
 
     abstract Message message();
 
     @Override
     public void subscribe(CoreSubscriber<? super ThreadChannel> actual) {
-        message().startThread(StartThreadSpec.copyOf(this)).subscribe(actual);
+        message().startThread(StartThreadFromMessageSpec.copyOf(this)).subscribe(actual);
     }
 
     @Override

--- a/core/src/main/java/discord4j/core/spec/ThreadChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/ThreadChannelEditSpecGenerator.java
@@ -18,13 +18,16 @@ package discord4j.core.spec;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.PermissionOverwrite;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.ThreadChannel;
+import discord4j.discordjson.Id;
 import discord4j.discordjson.json.ThreadModifyRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -47,6 +50,10 @@ interface ThreadChannelEditSpecGenerator extends AuditSpec<ThreadModifyRequest> 
 
     Possible<Boolean> invitable();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
+    Possible<List<Snowflake>> appliedTags();
+
     @Override
     default ThreadModifyRequest asRequest() {
         return ThreadModifyRequest.builder()
@@ -56,6 +63,8 @@ interface ThreadChannelEditSpecGenerator extends AuditSpec<ThreadModifyRequest> 
             .autoArchiveDuration(mapPossible(autoArchiveDuration(), ThreadChannel.AutoArchiveDuration::getValue))
             .locked(locked())
             .invitable(invitable())
+            .appliedTags(mapPossible(appliedTags(), tags -> tags.stream().map(Snowflake::asLong).map(Id::of).collect(Collectors.toList())))
+            .flags(mapPossible(flags(), Channel.Flag::toBitfield))
             .build();
     }
 }

--- a/core/src/test/java/discord4j/core/ExampleThread.java
+++ b/core/src/test/java/discord4j/core/ExampleThread.java
@@ -28,7 +28,7 @@ import discord4j.core.object.command.ApplicationCommandOption;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.entity.channel.ThreadChannel;
 import discord4j.core.object.entity.channel.TopLevelGuildMessageChannel;
-import discord4j.core.spec.StartThreadSpec;
+import discord4j.core.spec.StartThreadFromMessageSpec;
 import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.ThreadChannelEditSpec;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
@@ -274,7 +274,7 @@ public class ExampleThread {
                             return event.deferReply()
                                     .withEphemeral(true)
                                     .then(event.getTargetMessage())
-                                    .flatMap(msg -> msg.startThread(StartThreadSpec.builder()
+                                    .flatMap(msg -> msg.startThread(StartThreadFromMessageSpec.builder()
                                             .name("Thread from " + msg.getId())
                                             .build()))
                                     .then(event.editReply("Done!"))

--- a/core/src/test/java/discord4j/core/ExampleThread.java
+++ b/core/src/test/java/discord4j/core/ExampleThread.java
@@ -27,9 +27,8 @@ import discord4j.core.object.command.ApplicationCommandInteractionOptionValue;
 import discord4j.core.object.command.ApplicationCommandOption;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.entity.channel.ThreadChannel;
-import discord4j.core.object.entity.channel.TopLevelGuildMessageChannel;
+import discord4j.core.object.entity.channel.TopLevelGuildMessageWithThreadsChannel;
 import discord4j.core.spec.StartThreadFromMessageSpec;
-import discord4j.core.spec.StartThreadWithoutMessageSpec;
 import discord4j.core.spec.ThreadChannelEditSpec;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
 import discord4j.discordjson.json.ApplicationCommandRequest;
@@ -167,11 +166,8 @@ public class ExampleThread {
                             return event.deferReply()
                                     .withEphemeral(true)
                                     .then(event.getInteraction().getChannel())
-                                    .ofType(TopLevelGuildMessageChannel.class) // TextChannel or NewsChannel
-                                    .flatMap(ch -> ch.startThread(StartThreadWithoutMessageSpec.builder()
-                                            .name(title)
-                                            .type(ThreadChannel.Type.GUILD_PUBLIC_THREAD)
-                                            .build()))
+                                    .ofType(TopLevelGuildMessageWithThreadsChannel.class) // TextChannel or NewsChannel
+                                    .flatMap(ch -> ch.startPublicThreadWithoutMessage(title))
                                     .then(event.editReply("Done!"))
                                     .onErrorResume(ex -> event.editReply("Error: " + ex).then(Mono.error(ex)));
 

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -18,7 +18,24 @@
 package discord4j.rest.entity;
 
 import discord4j.common.util.Snowflake;
-import discord4j.discordjson.json.*;
+import discord4j.discordjson.json.BulkDeleteRequest;
+import discord4j.discordjson.json.ChannelData;
+import discord4j.discordjson.json.ChannelModifyRequest;
+import discord4j.discordjson.json.EmbedData;
+import discord4j.discordjson.json.FollowedChannelData;
+import discord4j.discordjson.json.GroupAddRecipientRequest;
+import discord4j.discordjson.json.InviteCreateRequest;
+import discord4j.discordjson.json.InviteData;
+import discord4j.discordjson.json.ListThreadsData;
+import discord4j.discordjson.json.MessageCreateRequest;
+import discord4j.discordjson.json.MessageData;
+import discord4j.discordjson.json.NewsChannelFollowRequest;
+import discord4j.discordjson.json.PermissionsEditRequest;
+import discord4j.discordjson.json.StartThreadFromMessageRequest;
+import discord4j.discordjson.json.StartThreadWithoutMessageRequest;
+import discord4j.discordjson.json.ThreadMemberData;
+import discord4j.discordjson.json.ThreadMetadata;
+import discord4j.discordjson.json.WebhookData;
 import discord4j.rest.RestClient;
 import discord4j.rest.util.MultipartRequest;
 import discord4j.rest.util.PaginationUtil;
@@ -29,10 +46,15 @@ import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.ToLongFunction;
 
 /**
  * Represents a guild or DM channel within Discord.
@@ -475,11 +497,25 @@ public class RestChannel {
     }
 
     public Flux<ListThreadsData> listThreads(Function<Map<String, Object>, Mono<ListThreadsData>> doRequest) {
-        ToLongFunction<ListThreadsData> getLastThreadId = response -> {
+        Function<ListThreadsData, String> getLastThreadId = response -> {
             List<ChannelData> threads = response.threads();
-            return threads.isEmpty() ? Long.MAX_VALUE : Snowflake.asLong(threads.get(threads.size() - 1).id());
+
+            if (!response.hasMore().toOptional().orElse(false)) {
+                return null;
+            }
+
+            if (threads.isEmpty()) {
+                return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now());
+            }
+
+            return threads.get(threads.size() - 1)
+                .threadMetadata()
+                .toOptional()
+                .map(ThreadMetadata::archiveTimestamp)
+                .orElse(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
         };
-        return PaginationUtil.paginateBefore(doRequest.andThen(Mono::flux), getLastThreadId, 0, 100);
+
+        return PaginationUtil.paginateBefore(doRequest.andThen(Mono::flux), getLastThreadId, DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()), 100);
     }
 
     public Flux<ListThreadsData> getPublicArchivedThreads() {

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -494,6 +494,14 @@ public class RestChannel {
         return listThreads(params -> restClient.getChannelService().listJoinedPrivateArchivedThreads(id, params));
     }
 
+    public Mono<ChannelData> startThreadWithoutMessage(StartThreadWithoutMessageRequest request) {
+        return restClient.getChannelService().startThreadWithoutMessage(id, request);
+    }
+
+    public Mono<ChannelData> startThreadFromMessage(long messageId, StartThreadFromMessageRequest request) {
+        return restClient.getChannelService().startThreadWithMessage(id, messageId, request);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/rest/src/main/java/discord4j/rest/service/ChannelService.java
+++ b/rest/src/main/java/discord4j/rest/service/ChannelService.java
@@ -227,7 +227,7 @@ public class ChannelService extends RestService {
                 .bodyToMono(Void.class);
     }
 
-    public Mono<ChannelData> startThreadWithMessage(long channelId, long messageId, StartThreadRequest request) {
+    public Mono<ChannelData> startThreadWithMessage(long channelId, long messageId, StartThreadFromMessageRequest request) {
         return Routes.START_THREAD_WITH_MESSAGE.newRequest(channelId, messageId)
                 .body(request)
                 .exchange(getRouter())


### PR DESCRIPTION
Closes #1223 

### Additions
- Add missing `flags` and `appliedTags` methods to `ThreadChannelEditSpec` and `ThreadChannelEditMono`
- Created a new interface, `TopLevelGuildMessageWithThreadsChannel` that extends `TopLevelGuildMessageChannel`, used for `TextChannel` and `NewsChannel`. This interface represents text channels that can have threads (A `VoiceChannel` is also a `TopLevelGuildMessageChannel` but cannot have threads). This interface has the following methods:
  - `Flux<ThreadChannel> getAllThreads()`
  - `Flux<ThreadChannel> getPublicArchivedThreads()`
  - `Mono<ThreadChannel> startPublicThreadWithoutMessage(StartThreadWithoutMessageSpec spec)`
  - `Mono<ThreadChannel> startPublicThreadWithMessage(Message message, StartThreadFromMessageSpec spec)`
  - `StartThreadWithoutMessageMono startPublicThreadWithoutMessage(String name)`
  - `StartThreadFromMessageMono startPublicThreadWithMessage(String name, Message message)`

### Add missing methods for threads:
- In `Message`: 
  - `Mono<ThreadChannel> createPublicThread(StartThreadFromMessageRequest spec)`
  - `StartThreadFromMessageMono createPublicThread(String threadName)`
- In `TextChannel`:
  - `Flux<ThreadChannel> getJoinedPrivateArchivedThreads()`
  - `Flux<ThreadChannel> getPrivateArchivedThreads()`
  - `StartThreadWithoutMessageMono startPrivateThread(String threadName)`
  - `Mono<ThreadChannel> startPrivateThread(StartThreadWithoutMessageSpec spec)`
- In `ForumChannel`:
  - `StartThreadInForumChannelMono startThread(String name, ForumThreadMessageCreateSpec messageCreateSpec)`
  - `Flux<ThreadChannel> getAllThreads()`
- In `ThreadChannel`:
  - `Mono<Void> pin()`
  - `Mono<Void> unpin()`

### Fixes:
- Fix `RestChannel#listThreads` and associated `getPublicArchivedThreads`, `getPrivateArchivedThreads`, and `getJoinedPrivateArchivedThreads` methods not working due to pagination issues

### Breaking changes:
- Renamed `StartThreadSpec` to `StartThreadFromMessageSpec`
- Renamed `StartThreadMono` to `StartThreadFromMessageMono`
- Removed the following methods from `TopLevelGuildMessageChannel` because `VoiceChannel` can't contain threads:
  - `Flux<ThreadListPart> getPublicArchivedThreads()`
  - `Mono<ThreadChannel> startThread(StartThreadWithoutMessageSpec spec)`
  - `Flux<ThreadListPart> getPublicArchivedThreads()`
  - `Flux<ThreadListPart> getPrivateArchivedThreads()`
  - `Flux<ThreadListPart> getJoinedPrivateArchivedThreads()`