### PR TITLE
feat: add shortcut methods for ChatInputInteractionEvent to get option values

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/interaction/ChatInputInteractionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ChatInputInteractionEvent.java
@@ -17,11 +17,19 @@
 
 package discord4j.core.event.domain.interaction;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import discord4j.common.annotations.Experimental;
+import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.command.ApplicationCommandInteractionOption;
+import discord4j.core.object.command.ApplicationCommandInteractionOptionValue;
 import discord4j.core.object.command.Interaction;
+import discord4j.core.object.entity.Attachment;
+import discord4j.core.object.entity.Role;
+import discord4j.core.object.entity.User;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.gateway.ShardInfo;
+import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 import java.util.List;
@@ -54,6 +62,7 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
     /////////////////////////////////////////////////////////////////////////////////////////////
     // Convenience methods forwarding to ApplicationCommandInteraction methods.
     // We can assume these properties are present, because this is a chat input command interaction.
+    /////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
      * Gets the options of the invoked command.
@@ -76,5 +85,125 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
         return getInteraction().getCommandInteraction()
                 .orElseThrow(IllegalStateException::new) // should always be present for chat input commands
                 .getOption(name);
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a string.
+     *
+     * @param name The name of the option.
+     * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * @throws IllegalArgumentException If the option is present but its value cannot be converted to a string.
+     */
+    public Optional<String> getOptionAsString(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asString);
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a boolean.
+     *
+     * @param name The name of the option.
+     * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * @throws IllegalArgumentException If the option is present but its value cannot be converted to a boolean.
+     */
+    public Optional<Boolean> getOptionAsBoolean(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asBoolean);
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a long.
+     *
+     * @param name The name of the option.
+     * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * @throws IllegalArgumentException If the option is present but its value cannot be converted to a long.
+     */
+    public Optional<Long> getOptionAsLong(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asLong);
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a double.
+     *
+     * @param name The name of the option.
+     * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * @throws IllegalArgumentException If the option is present but its value cannot be converted to a double.
+     */
+    public Optional<Double> getOptionAsDouble(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asDouble);
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a snowflake.
+     *
+     * @param name The name of the option.
+     * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * @throws IllegalArgumentException If the option is present but its value cannot be converted to a snowflake.
+     */
+    public Optional<Snowflake> getOptionAsSnowflake(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asSnowflake);
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a user.
+     *
+     * @param name The name of the option.
+     * @return A {@link Mono} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * If the option is present but its value cannot be converted to a user, the {@link Mono} will complete with an error.
+     */
+    public Mono<User> getOptionAsUser(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asUser)
+            .orElse(Mono.empty());
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a role.
+     *
+     * @param name The name of the option.
+     * @return A {@link Mono} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * If the option is present but its value cannot be converted to a role, the {@link Mono} will complete with an error.
+     */
+    public Mono<Role> getOptionAsRole(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asRole)
+            .orElse(Mono.empty());
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as a channel.
+     *
+     * @param name The name of the option.
+     * @return A {@link Mono} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * If the option is present but its value cannot be converted to a channel, the {@link Mono} will complete with an error.
+     */
+    public Mono<Channel> getOptionAsChannel(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asChannel)
+            .orElse(Mono.empty());
+    }
+
+    /**
+     * Gets the value of the option corresponding to the provided name, if present, as an attachment.
+     *
+     * @param name The name of the option.
+     * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
+     * @throws IllegalArgumentException If the option is present but its value cannot be converted to an attachment.
+     */
+    public Optional<Attachment> getOptionAsAttachment(final String name) {
+        return getOption(name)
+            .flatMap(ApplicationCommandInteractionOption::getValue)
+            .map(ApplicationCommandInteractionOptionValue::asAttachment);
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/interaction/ChatInputInteractionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ChatInputInteractionEvent.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.event.domain.interaction;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;

--- a/core/src/main/java/discord4j/core/event/domain/interaction/ChatInputInteractionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ChatInputInteractionEvent.java
@@ -139,7 +139,7 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
     }
 
     /**
-     * Gets the value of the option corresponding to the provided name, if present, as a snowflake.
+     * Gets the value of the option corresponding to the provided name, if present, as a {@link Snowflake}.
      *
      * @param name The name of the option.
      * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
@@ -152,7 +152,7 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
     }
 
     /**
-     * Gets the value of the option corresponding to the provided name, if present, as a user.
+     * Gets the value of the option corresponding to the provided name, if present, as a {@link User}.
      *
      * @param name The name of the option.
      * @return A {@link Mono} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
@@ -166,7 +166,7 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
     }
 
     /**
-     * Gets the value of the option corresponding to the provided name, if present, as a role.
+     * Gets the value of the option corresponding to the provided name, if present, as a {@link Role}.
      *
      * @param name The name of the option.
      * @return A {@link Mono} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
@@ -180,7 +180,7 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
     }
 
     /**
-     * Gets the value of the option corresponding to the provided name, if present, as a channel.
+     * Gets the value of the option corresponding to the provided name, if present, as a {@link Channel}.
      *
      * @param name The name of the option.
      * @return A {@link Mono} containing the value of the option corresponding to the provided name, if present, or empty otherwise.
@@ -194,7 +194,7 @@ public class ChatInputInteractionEvent extends ApplicationCommandInteractionEven
     }
 
     /**
-     * Gets the value of the option corresponding to the provided name, if present, as an attachment.
+     * Gets the value of the option corresponding to the provided name, if present, as an {@link Attachment}.
      *
      * @param name The name of the option.
      * @return An {@link Optional} containing the value of the option corresponding to the provided name, if present, or empty otherwise.


### PR DESCRIPTION
**Description:** Add shortcut methods to the `ChatInputInteractionEvent` class to retrieve option values easily.

**Justification:** Many users write such methods to get the values; an implementation directly in D4J can benefit everyone.

**Additions:**
- `Optional<String> getOptionAsString(final String name)`
- `Optional<Boolean> getOptionAsBoolean(final String name)`
- `Optional<Long> getOptionAsLong(final String name)`
- `Optional<Double> getOptionAsDouble(final String name)`
- `Optional<Snowflake> getOptionAsSnowflake(final String name)`
- `Optional<Attachment> getOptionAsAttachment(final String name)`
- `Mono<User> getOptionAsUser(final String name)`
- `Mono<Role> getOptionAsRole(final String name)`
- `Mono<Channel> getOptionAsChannel(final String name)`
