### PR TITLE
Fix LegacyStoreLayout ReactionEvent handling not managing count_details nor me_burst fields

### DIFF
--- a/common/src/main/java/discord4j/common/store/legacy/LegacyStoreLayout.java
+++ b/common/src/main/java/discord4j/common/store/legacy/LegacyStoreLayout.java
@@ -1071,11 +1071,25 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
                     ImmutableMessageData.Builder newMessageBuilder = MessageData.builder().from(oldMessage);
 
                     if (oldMessage.reactions().isAbsent()) {
-                        newMessageBuilder.addReaction(ReactionData.builder()
-                                .count(1)
-                                .me(me)
-                                .emoji(dispatch.emoji())
-                                .build());
+                        // If burst, increment the burst count, otherwise the normal count
+                        ReactionCountDetailsData countDetailsData = ReactionCountDetailsData.builder()
+                                .normal(dispatch.burst() ? 0 : 1)
+                                .burst(dispatch.burst() ? 1 : 0)
+                                .build();
+
+                        ImmutableReactionData.Builder reactionBuilder = ReactionData.builder()
+                            .count(1)
+                            .countDetails(countDetailsData)
+                            .me(me)
+                            // If I added the reaction, and this is a burst, this is a me_burst
+                            .meBurst(me && dispatch.burst())
+                            .emoji(dispatch.emoji());
+
+                        if (!dispatch.burstColors().isAbsent()) {
+                            reactionBuilder.burstColors(dispatch.burstColors().get());
+                        }
+
+                        newMessageBuilder.addReaction(reactionBuilder.build());
                     } else {
                         List<ReactionData> reactions = oldMessage.reactions().get();
                         int i = indexOfReactionByEmojiData(reactions, dispatch.emoji());
@@ -1083,19 +1097,46 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
                         if (i < reactions.size()) {
                             // message already has this reaction: bump 1
                             ReactionData oldExisting = reactions.get(i);
+
+                            // Prepare the updated ReactionCountDetails object depending on if this is a burst or not
+                            ReactionCountDetailsData countDetailsData;
+                            if (dispatch.burst()) {
+                                countDetailsData = ReactionCountDetailsData.builder()
+                                    .normal(oldExisting.countDetails().normal())
+                                    .burst(oldExisting.countDetails().burst() + 1)
+                                    .build();
+                            } else {
+                                countDetailsData = ReactionCountDetailsData.builder()
+                                    .normal(oldExisting.countDetails().normal() + 1)
+                                    .burst(oldExisting.countDetails().burst())
+                                    .build();
+                            }
+
                             ReactionData newExisting = ReactionData.builder()
                                     .from(oldExisting)
                                     .me(oldExisting.me() || me)
+                                    // If the change is me adding a reaction, and this is a burst that was dispatched
+                                    // then this is a me_burst
+                                    .meBurst(!oldExisting.me() && me && dispatch.burst())
                                     .count(oldExisting.count() + 1)
+                                    .countDetails(countDetailsData)
                                     .build();
                             newMessageBuilder.reactions(ListUtil.replace(reactions,
                                     oldExisting, newExisting));
                         } else {
                             // message doesn't have this reaction: create
+                            ReactionCountDetailsData countDetailsData = ReactionCountDetailsData.builder()
+                                .normal(dispatch.burst() ? 0 : 1)
+                                .burst(dispatch.burst() ? 1 : 0)
+                                .build();
+
                             ReactionData reaction = ReactionData.builder()
                                     .emoji(dispatch.emoji())
-                                    .me(me)
                                     .count(1)
+                                    .countDetails(countDetailsData)
+                                    .me(me)
+                                    // If I added the reaction, and this is a burst, this is a me_burst
+                                    .meBurst(me && dispatch.burst())
                                     .build();
                             newMessageBuilder.reactions(ListUtil.add(reactions, reaction));
                         }
@@ -1129,10 +1170,25 @@ public class LegacyStoreLayout implements StoreLayout, DataAccessor, GatewayData
                             newMessageBuilder.reactions(ListUtil.remove(reactions,
                                     reaction -> reaction.equals(existing)));
                         } else {
+                            ReactionCountDetailsData countDetailsData;
+                            if (dispatch.burst()) {
+                                countDetailsData = ReactionCountDetailsData.builder()
+                                    .normal(existing.countDetails().normal())
+                                    .burst(existing.countDetails().burst() - 1)
+                                    .build();
+                            } else {
+                                countDetailsData = ReactionCountDetailsData.builder()
+                                    .normal(existing.countDetails().normal() - 1)
+                                    .burst(existing.countDetails().burst())
+                                    .build();
+                            }
+
                             ReactionData newExisting = ReactionData.builder()
                                     .from(existing)
                                     .count(existing.count() - 1)
+                                    .countDetails(countDetailsData)
                                     .me(!me && existing.me())
+                                    .meBurst(existing.meBurst() && me)
                                     .build();
                             newMessageBuilder.reactions(ListUtil.replace(reactions, existing, newExisting));
                         }


### PR DESCRIPTION
**Description:** Recently, I got IllegalStateExceptions when using the LegacyStoreLayout and managing ReactionEvent, because it does not provide required fields for building a ReactionData.

**Justification:** IllegalStateException when using LegacyStoreLayout and having the required conditions regarding the previous state.

Here's an example of one IllegalStateException.
```
2024-07-15 10:12:31:990 [reactor-http-epoll-3] ERROR DispatchStoreLayer - Error when executing store action on dispatch MessageReactionAdd{userId=<REDACTED>, channelId=<REDACTED>, messageId=<REDACTED>, guildId=Possible{<REDACTED>}, member=Possible{MemberData{nick=Possible{Optional[<REDACTED>]}, roles=[J@1de5bff0, joinedAt=2020-11-06T05:24:51.771000+00:00, premiumSince=Possible{Optional.empty}, deaf=false, mute=false, communicationDisabledUntil=Possible{Optional.empty}, flags=6, user=UserData{id=<REDACTED>, globalName=<REDACTED>, username=<REDACTED>, discriminator=0, avatar=<REDACTED>, banner=Possible.absent, accentColor=Possible.absent, bot=Possible{false}, system=Possible.absent, mfaEnabled=Possible.absent, locale=Possible.absent, verified=Possible.absent, email=Possible.absent, flags=Possible.absent, premiumType=Possible.absent, publicFlags=Possible{0}}, pending=Possible{false}, permissions=Possible.absent}}, emoji=EmojiData{id=Optional.empty, name=<REDACTED>, roles=null, user=Possible.absent, requireColons=Possible.absent, managed=Possible.absent, available=Possible.absent, animated=Possible.absent}, messageAuthorId=<REDACTED>}
 java.lang.IllegalStateException: Cannot build ReactionData, some of required attributes are not set [countDetails, meBurst]
         at discord4j.discordjson.json.ImmutableReactionData$Builder.build(ImmutableReactionData.java:559)
         at discord4j.common.store.legacy.LegacyStoreLayout.lambda$onMessageReactionAdd$95(LegacyStoreLayout.java:1104)
         at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:106)
         at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2545)
         at reactor.core.publisher.FluxMap$MapSubscriber.request(FluxMap.java:164)
         at reactor.core.publisher.MonoFlatMap$FlatMapMain.request(MonoFlatMap.java:194)
         at reactor.core.publisher.MonoFlatMap$FlatMapInner.onSubscribe(MonoFlatMap.java:291)
         at reactor.core.publisher.MonoFlatMap$FlatMapMain.onSubscribe(MonoFlatMap.java:117)
         at reactor.core.publisher.FluxMap$MapSubscriber.onSubscribe(FluxMap.java:92)
         at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55)
         at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:53)
         <... X more ...>
```

This fix can be implement for both 3.2.X and 3.3.0 snapshots.

PS: I also reorganized fields to be in the same order as in ReactionData.