### PR TITLE
Fix ReactionEmoji.Custom name can be null

### DIFF
--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -129,7 +129,7 @@ public abstract class ReactionEmoji {
     public static ReactionEmoji of(EmojiData data) {
         if (data.id().isPresent()) {
             return custom(Snowflake.of(data.id().get()),
-                    data.name().orElseThrow(IllegalArgumentException::new),
+                    data.name().orElse(""),
                     data.animated().toOptional().orElse(false));
         }
         return unicode(data.name().orElseThrow(IllegalArgumentException::new));

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -183,14 +183,14 @@ public abstract class ReactionEmoji {
         }
 
         /**
-         * Gets the name of the emoji, if present.
+         * Gets the name of the emoji.
          * <br>
-         * <b>Note:</b> this can not be present for reactions or onboarding.
+         * <b>Note:</b> this can be empty for reactions or onboarding.
          *
-         * @return The name of the emoji, if present.
+         * @return The name of the emoji.
          */
-        public Optional<String> getName() {
-            return Optional.ofNullable(name);
+        public String getName() {
+            return (name != null) ? name : "";
         }
 
         /**
@@ -206,7 +206,7 @@ public abstract class ReactionEmoji {
         public EmojiData asEmojiData() {
             return EmojiData.builder()
                     .id(id)
-                    .name(getName())
+                    .name(Optional.ofNullable(name))
                     .animated(isAnimated)
                     .build();
         }
@@ -214,7 +214,7 @@ public abstract class ReactionEmoji {
         /**
          * Gets the formatted version of this emoji (i.e., to display in the client).
          * <br>
-         * <b>Note:</b> please check first if {@link #getName()} is present.
+         * <b>Note:</b> please check first if {@link #getName()} is not empty.
          *
          * @return The formatted version of this emoji (i.e., to display in the client).
          */

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -50,7 +50,7 @@ public abstract class ReactionEmoji {
      * @param isAnimated Whether the custom emoji is animated.
      * @return A reaction emoji using the given information.
      */
-    public static Custom custom(Snowflake id, String name, boolean isAnimated) {
+    public static Custom custom(Snowflake id, @Nullable String name, boolean isAnimated) {
         return new Custom(id.asLong(), name, isAnimated);
     }
 
@@ -129,7 +129,7 @@ public abstract class ReactionEmoji {
     public static ReactionEmoji of(EmojiData data) {
         if (data.id().isPresent()) {
             return custom(Snowflake.of(data.id().get()),
-                    data.name().orElse(""),
+                    data.name().orElse(null),
                     data.animated().toOptional().orElse(false));
         }
         return unicode(data.name().orElseThrow(IllegalArgumentException::new));
@@ -163,10 +163,11 @@ public abstract class ReactionEmoji {
     public static final class Custom extends ReactionEmoji {
 
         private final long id;
+        @Nullable
         private final String name;
         private final boolean isAnimated;
 
-        private Custom(long id, String name, boolean isAnimated) {
+        private Custom(long id, @Nullable String name, boolean isAnimated) {
             this.id = id;
             this.name = name;
             this.isAnimated = isAnimated;
@@ -182,14 +183,14 @@ public abstract class ReactionEmoji {
         }
 
         /**
-         * Gets the name of the emoji.
+         * Gets the name of the emoji, if present.
          * <br>
-         * <b>Note:</b> this can return an empty name for reactions or onboarding
+         * <b>Note:</b> this can not be present for reactions or onboarding.
          *
-         * @return The name of the emoji.
+         * @return The name of the emoji, if present.
          */
-        public String getName() {
-            return name;
+        public Optional<String> getName() {
+            return Optional.ofNullable(name);
         }
 
         /**
@@ -205,13 +206,15 @@ public abstract class ReactionEmoji {
         public EmojiData asEmojiData() {
             return EmojiData.builder()
                     .id(id)
-                    .name(name)
+                    .name(getName())
                     .animated(isAnimated)
                     .build();
         }
 
         /**
          * Gets the formatted version of this emoji (i.e., to display in the client).
+         * <br>
+         * <b>Note:</b> please check first if {@link #getName()} is present.
          *
          * @return The formatted version of this emoji (i.e., to display in the client).
          */

--- a/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
+++ b/core/src/main/java/discord4j/core/object/reaction/ReactionEmoji.java
@@ -183,6 +183,8 @@ public abstract class ReactionEmoji {
 
         /**
          * Gets the name of the emoji.
+         * <br>
+         * <b>Note:</b> this can return an empty name for reactions or onboarding
          *
          * @return The name of the emoji.
          */


### PR DESCRIPTION
**Description:** This fixs a issue where try to parse a EmojiData can throw an exception if the name is null, the current behaviour for throw a exception cause issues in https://github.com/Discord4J/Discord4J/pull/1231 where the emoji in prompts can contain null names.

**Justification:** https://discord.com/developers/docs/resources/emoji#emoji-object-emoji-structure
