### PR TITLE
Fix return of Channel Position in REST and allow reason for Role Posi…

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Role.java
+++ b/core/src/main/java/discord4j/core/object/entity/Role.java
@@ -394,12 +394,24 @@ public final class Role implements Entity {
      * Requests to change this role's position.
      *
      * @param position The position to change for this role.
+     * @param reason The reason, if present.
+     * @return A {@link Flux} that continually emits all the {@link Role roles} associated to this role's
+     * {@link #getGuild() guild}. If an error is received, it is emitted through the {@code Flux}.
+     */
+    public Flux<Role> changePosition(final int position, @Nullable final String reason) {
+        return rest.changePosition(position, reason)
+            .map(data -> new Role(gateway, data, getGuildId().asLong()));
+    }
+
+    /**
+     * Requests to change this role's position.
+     *
+     * @param position The position to change for this role.
      * @return A {@link Flux} that continually emits all the {@link Role roles} associated to this role's
      * {@link #getGuild() guild}. If an error is received, it is emitted through the {@code Flux}.
      */
     public Flux<Role> changePosition(final int position) {
-        return rest.changePosition(position)
-                .map(data -> new Role(gateway, data, getGuildId().asLong()));
+        return this.changePosition(position, null);
     }
 
     @Override

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -178,9 +178,9 @@ public class RestGuild {
         return restClient.getGuildService().createGuildChannel(id, request, reason);
     }
 
-    public Flux<RoleData> modifyChannelPositions(List<ChannelPositionModifyRequest> requests) {
+    public Flux<Void> modifyChannelPositions(List<ChannelPositionModifyRequest> requests) {
         return restClient.getGuildService()
-                .modifyGuildChannelPositions(id, requests.toArray(new ChannelPositionModifyRequest[0]));
+            .modifyGuildChannelPositions(id, requests.toArray(new ChannelPositionModifyRequest[0]));
     }
 
     public Mono<MemberData> getMember(Snowflake userId) {
@@ -264,9 +264,14 @@ public class RestGuild {
         return restClient.getGuildService().createGuildRole(id, request, reason);
     }
 
-    public Flux<RoleData> modifyRolePositions(List<RolePositionModifyRequest> requests) {
+    public Flux<RoleData> modifyRolePositions(List<RolePositionModifyRequest> requests, @Nullable String reason) {
         return restClient.getGuildService().modifyGuildRolePositions(id,
-                requests.toArray(new RolePositionModifyRequest[0]));
+            requests.toArray(new RolePositionModifyRequest[0]), reason);
+    }
+
+    @Deprecated
+    public Flux<RoleData> modifyRolePositions(List<RolePositionModifyRequest> requests) {
+        return modifyRolePositions(requests, null);
     }
 
     public Mono<RoleData> modifyRole(Snowflake roleId, RoleModifyRequest request, @Nullable String reason) {

--- a/rest/src/main/java/discord4j/rest/entity/RestGuild.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestGuild.java
@@ -269,7 +269,6 @@ public class RestGuild {
             requests.toArray(new RolePositionModifyRequest[0]), reason);
     }
 
-    @Deprecated
     public Flux<RoleData> modifyRolePositions(List<RolePositionModifyRequest> requests) {
         return modifyRolePositions(requests, null);
     }

--- a/rest/src/main/java/discord4j/rest/entity/RestRole.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestRole.java
@@ -112,15 +112,27 @@ public class RestRole {
      * Requests to change this role's position.
      *
      * @param position The position to change for this role.
+     * @param reason The reason, if present.
+     * @return A {@link Flux} that continually emits all the {@link RoleData roles} associated to this role's
+     * guild. If an error is received, it is emitted through the {@code Flux}.
+     */
+    public Flux<RoleData> changePosition(final int position, @Nullable final String reason) {
+        final RolePositionModifyRequest[] requests = {RolePositionModifyRequest.builder()
+            .id(Snowflake.asString(id))
+            .positionOrNull(position)
+            .build()};
+        return restClient.getGuildService().modifyGuildRolePositions(guildId, requests, reason);
+    }
+
+    /**
+     * Requests to change this role's position.
+     *
+     * @param position The position to change for this role.
      * @return A {@link Flux} that continually emits all the {@link RoleData roles} associated to this role's
      * guild. If an error is received, it is emitted through the {@code Flux}.
      */
     public Flux<RoleData> changePosition(final int position) {
-        final RolePositionModifyRequest[] requests = {RolePositionModifyRequest.builder()
-                .id(Snowflake.asString(id))
-                .position(position)
-                .build()};
-        return restClient.getGuildService().modifyGuildRolePositions(guildId, requests);
+        return changePosition(position, null);
     }
 
     /**

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -35,9 +35,9 @@ public class GuildService extends RestService {
 
     public Mono<GuildUpdateData> createGuild(GuildCreateRequest request) {
         return Routes.GUILD_CREATE.newRequest()
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(GuildUpdateData.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(GuildUpdateData.class);
     }
 
     public Mono<GuildUpdateData> getGuild(long guildId, Map<String, Object> queryParams) {
@@ -55,53 +55,53 @@ public class GuildService extends RestService {
 
     public Mono<GuildUpdateData> modifyGuild(long guildId, GuildModifyRequest request, @Nullable String reason) {
         return Routes.GUILD_MODIFY.newRequest(guildId)
-                .body(request)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(GuildUpdateData.class);
+            .body(request)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(GuildUpdateData.class);
     }
 
     public Mono<Void> deleteGuild(long guildId) {
         return Routes.GUILD_DELETE.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Flux<ChannelData> getGuildChannels(long guildId) {
         return Routes.GUILD_CHANNELS_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(ChannelData[].class)
-                .flatMapMany(Flux::fromArray);
+            .exchange(getRouter())
+            .bodyToMono(ChannelData[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Mono<ChannelData> createGuildChannel(long guildId, ChannelCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_CHANNEL_CREATE.newRequest(guildId)
-                .body(request)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(ChannelData.class);
+            .body(request)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(ChannelData.class);
     }
 
-    public Flux<RoleData> modifyGuildChannelPositions(long guildId, ChannelPositionModifyRequest[] request) {
+    public Flux<Void> modifyGuildChannelPositions(long guildId, ChannelPositionModifyRequest[] request) {
         return Routes.GUILD_CHANNEL_POSITIONS_MODIFY.newRequest(guildId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(RoleData[].class)
-                .flatMapMany(Flux::fromArray);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(Void[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Mono<MemberData> getGuildMember(long guildId, long userId) {
         return Routes.GUILD_MEMBER_GET.newRequest(guildId, userId)
-                .exchange(getRouter())
-                .bodyToMono(MemberData.class);
+            .exchange(getRouter())
+            .bodyToMono(MemberData.class);
     }
 
     public Flux<MemberData> getGuildMembers(long guildId, Map<String, Object> queryParams) {
         return Routes.GUILD_MEMBERS_LIST.newRequest(guildId)
-                .query(queryParams)
-                .exchange(getRouter())
-                .bodyToMono(MemberData[].class)
-                .flatMapMany(Flux::fromArray);
+            .query(queryParams)
+            .exchange(getRouter())
+            .bodyToMono(MemberData[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Flux<MemberData> searchGuildMembers(long guildId, Map<String, Object> queryParams) {
@@ -114,81 +114,83 @@ public class GuildService extends RestService {
 
     public Mono<MemberData> addGuildMember(long guildId, long userId, GuildMemberAddRequest request) {
         return Routes.GUILD_MEMBER_ADD.newRequest(guildId, userId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(MemberData.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(MemberData.class);
     }
 
-    public Mono<MemberData> modifyGuildMember(long guildId, long userId, GuildMemberModifyRequest request, @Nullable String reason) {
+    public Mono<MemberData> modifyGuildMember(long guildId, long userId, GuildMemberModifyRequest request,
+                                              @Nullable String reason) {
         return Routes.GUILD_MEMBER_MODIFY.newRequest(guildId, userId)
-                .body(request)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(MemberData.class);
+            .body(request)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(MemberData.class);
     }
 
     @Deprecated
     public Mono<NicknameModifyData> modifyOwnNickname(long guildId, NicknameModifyData request) {
         return Routes.NICKNAME_MODIFY_OWN.newRequest(guildId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(NicknameModifyData.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(NicknameModifyData.class);
     }
 
     public Mono<MemberData> modifyCurrentMember(long guildId, CurrentMemberModifyData request) {
         return Routes.CURRENT_MEMBER_MODIFY.newRequest(guildId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(MemberData.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(MemberData.class);
     }
 
     public Mono<Void> addGuildMemberRole(long guildId, long userId, long roleId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_ROLE_ADD.newRequest(guildId, userId, roleId)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<Void> removeGuildMemberRole(long guildId, long userId, long roleId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_ROLE_REMOVE.newRequest(guildId, userId, roleId)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<Void> removeGuildMember(long guildId, long userId, @Nullable String reason) {
         return Routes.GUILD_MEMBER_REMOVE.newRequest(guildId, userId)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Flux<BanData> getGuildBans(long guildId) {
         return Routes.GUILD_BANS_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(BanData[].class)
-                .flatMapMany(Flux::fromArray);
+            .exchange(getRouter())
+            .bodyToMono(BanData[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Mono<BanData> getGuildBan(long guildId, long userId) {
         return Routes.GUILD_BAN_GET.newRequest(guildId, userId)
-                .exchange(getRouter())
-                .bodyToMono(BanData.class);
+            .exchange(getRouter())
+            .bodyToMono(BanData.class);
     }
 
-    public Mono<Void> createGuildBan(long guildId, long userId, Map<String, Object> queryParams, @Nullable String reason) {
+    public Mono<Void> createGuildBan(long guildId, long userId, Map<String, Object> queryParams,
+                                     @Nullable String reason) {
         return Routes.GUILD_BAN_CREATE.newRequest(guildId, userId)
-                .query(queryParams)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .query(queryParams)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<Void> removeGuildBan(long guildId, long userId, @Nullable String reason) {
         return Routes.GUILD_BAN_REMOVE.newRequest(guildId, userId)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<BulkBanResponseData> bulkGuildBan(long guildId, BulkBanRequest request, @Nullable String reason) {
@@ -201,86 +203,93 @@ public class GuildService extends RestService {
 
     public Flux<RoleData> getGuildRoles(long guildId) {
         return Routes.GUILD_ROLES_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(RoleData[].class)
-                .flatMapMany(Flux::fromArray);
+            .exchange(getRouter())
+            .bodyToMono(RoleData[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Mono<RoleData> createGuildRole(long guildId, RoleCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_ROLE_CREATE.newRequest(guildId)
-                .body(request)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(RoleData.class);
+            .body(request)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(RoleData.class);
     }
 
+    @Deprecated
     public Flux<RoleData> modifyGuildRolePositions(long guildId, RolePositionModifyRequest[] request) {
-        return Routes.GUILD_ROLE_POSITIONS_MODIFY.newRequest(guildId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(RoleData[].class)
-                .flatMapMany(Flux::fromArray);
+        return modifyGuildRolePositions(guildId, request, null);
     }
 
-    public Mono<RoleData> modifyGuildRole(long guildId, long roleId, RoleModifyRequest request, @Nullable String reason) {
+    public Flux<RoleData> modifyGuildRolePositions(long guildId, RolePositionModifyRequest[] request, @Nullable String reason) {
+        return Routes.GUILD_ROLE_POSITIONS_MODIFY.newRequest(guildId)
+            .body(request)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(RoleData[].class)
+            .flatMapMany(Flux::fromArray);
+    }
+
+    public Mono<RoleData> modifyGuildRole(long guildId, long roleId, RoleModifyRequest request,
+                                          @Nullable String reason) {
         return Routes.GUILD_ROLE_MODIFY.newRequest(guildId, roleId)
-                .body(request)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(RoleData.class);
+            .body(request)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(RoleData.class);
     }
 
     public Mono<Void> deleteGuildRole(long guildId, long roleId, @Nullable String reason) {
         return Routes.GUILD_ROLE_DELETE.newRequest(guildId, roleId)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     @Deprecated
     public Mono<PruneData> getGuildPruneCount(long guildId, Map<String, Object> queryParams) {
         return Routes.GUILD_PRUNE_COUNT_GET.newRequest(guildId)
-                .query(queryParams)
-                .exchange(getRouter())
-                .bodyToMono(PruneData.class);
+            .query(queryParams)
+            .exchange(getRouter())
+            .bodyToMono(PruneData.class);
     }
 
     public Mono<PruneData> getGuildPruneCount(long guildId, Multimap<String, Object> params) {
         return Routes.GUILD_PRUNE_COUNT_GET.newRequest(guildId)
-                .query(params)
-                .exchange(getRouter())
-                .bodyToMono(PruneData.class);
+            .query(params)
+            .exchange(getRouter())
+            .bodyToMono(PruneData.class);
     }
 
     @Deprecated
     public Mono<PruneData> beginGuildPrune(long guildId, Map<String, Object> queryParams, @Nullable String reason) {
         return Routes.GUILD_PRUNE_BEGIN.newRequest(guildId)
-                .query(queryParams)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(PruneData.class);
+            .query(queryParams)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(PruneData.class);
     }
 
     public Mono<PruneData> beginGuildPrune(long guildId, Multimap<String, Object> params, @Nullable String reason) {
         return Routes.GUILD_PRUNE_BEGIN.newRequest(guildId)
-                .query(params)
-                .optionalHeader("X-Audit-Log-Reason", reason)
-                .exchange(getRouter())
-                .bodyToMono(PruneData.class);
+            .query(params)
+            .optionalHeader("X-Audit-Log-Reason", reason)
+            .exchange(getRouter())
+            .bodyToMono(PruneData.class);
     }
 
     public Flux<RegionData> getGuildVoiceRegions(long guildId) {
         return Routes.GUILD_VOICE_REGIONS_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(RegionData[].class)
-                .flatMapMany(Flux::fromArray);
+            .exchange(getRouter())
+            .bodyToMono(RegionData[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Flux<InviteData> getGuildInvites(long guildId) {
         return Routes.GUILD_INVITES_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(InviteData[].class)
-                .flatMapMany(Flux::fromArray);
+            .exchange(getRouter())
+            .bodyToMono(InviteData[].class)
+            .flatMapMany(Flux::fromArray);
     }
 
     public Flux<IntegrationData> getGuildIntegrations(long guildId) {
@@ -292,41 +301,41 @@ public class GuildService extends RestService {
 
     public Mono<Void> createGuildIntegration(long guildId, IntegrationCreateRequest request) {
         return Routes.GUILD_INTEGRATION_CREATE.newRequest(guildId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<Void> modifyGuildIntegration(long guildId, long integrationId, IntegrationModifyRequest request) {
         return Routes.GUILD_INTEGRATION_MODIFY.newRequest(guildId, integrationId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<Void> deleteGuildIntegration(long guildId, long integrationId) {
         return Routes.GUILD_INTEGRATION_DELETE.newRequest(guildId, integrationId)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<Void> syncGuildIntegration(long guildId, long integrationId) {
         return Routes.GUILD_INTEGRATION_SYNC.newRequest(guildId, integrationId)
-                .exchange(getRouter())
-                .bodyToMono(Void.class);
+            .exchange(getRouter())
+            .bodyToMono(Void.class);
     }
 
     public Mono<GuildWidgetData> getGuildWidget(long guildId) {
         return Routes.GUILD_WIDGET_GET.newRequest(guildId)
-                .exchange(getRouter())
-                .bodyToMono(GuildWidgetData.class);
+            .exchange(getRouter())
+            .bodyToMono(GuildWidgetData.class);
     }
 
     public Mono<GuildWidgetData> modifyGuildWidget(long guildId, GuildWidgetModifyRequest request) {
         return Routes.GUILD_WIDGET_MODIFY.newRequest(guildId)
-                .body(request)
-                .exchange(getRouter())
-                .bodyToMono(GuildWidgetData.class);
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(GuildWidgetData.class);
     }
 
     public Mono<GuildPreviewData> getGuildPreview(long guildId) {
@@ -349,7 +358,8 @@ public class GuildService extends RestService {
             .bodyToMono(Void.class);
     }
 
-    public Mono<GuildScheduledEventData> getScheduledEvent(long guildId, long eventId, Map<String, Object> queryParams) {
+    public Mono<GuildScheduledEventData> getScheduledEvent(long guildId, long eventId,
+                                                           Map<String, Object> queryParams) {
         return Routes.GUILD_SCHEDULED_EVENT_GET.newRequest(guildId, eventId)
             .query(queryParams)
             .exchange(getRouter())
@@ -371,7 +381,9 @@ public class GuildService extends RestService {
             .bodyToMono(GuildScheduledEventData.class);
     }
 
-    public Mono<GuildScheduledEventData> modifyScheduledEvent(long guildId, long eventId, GuildScheduledEventModifyRequest request, @Nullable String reason) {
+    public Mono<GuildScheduledEventData> modifyScheduledEvent(long guildId, long eventId,
+                                                              GuildScheduledEventModifyRequest request,
+                                                              @Nullable String reason) {
         return Routes.GUILD_SCHEDULED_EVENT_MODIFY.newRequest(guildId, eventId)
             .body(request)
             .optionalHeader("X-Audit-Log-Reason", reason)
@@ -386,7 +398,8 @@ public class GuildService extends RestService {
             .bodyToMono(Void.class);
     }
 
-    public Flux<GuildScheduledEventUserData> getScheduledEventUsers(long guildId, long eventId, Map<String, Object> queryParams) {
+    public Flux<GuildScheduledEventUserData> getScheduledEventUsers(long guildId, long eventId,
+                                                                    Map<String, Object> queryParams) {
         return Routes.GUILD_SCHEDULED_EVENT_USERS_GET.newRequest(guildId, eventId)
             .query(queryParams)
             .exchange(getRouter())

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -216,7 +216,6 @@ public class GuildService extends RestService {
             .bodyToMono(RoleData.class);
     }
 
-    @Deprecated
     public Flux<RoleData> modifyGuildRolePositions(long guildId, RolePositionModifyRequest[] request) {
         return modifyGuildRolePositions(guildId, request, null);
     }


### PR DESCRIPTION
**Description:** This PR make the follow changes.
- fix a bad return for the modify channel position using REST
- allow set reason for modify role position and deprecate the old method for being remove in 3.3.0

**Justification:** Originally this PR was to backport the old behaviour for the method but based in the issues its better include the breaking change in 3.2.x for handle correctly the behaviour of the methods.
