### PR TITLE
Support for get role from Guild using REST

### DIFF
--- a/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
+++ b/core/src/main/java/discord4j/core/retriever/RestEntityRetriever.java
@@ -94,9 +94,7 @@ public class RestEntityRetriever implements EntityRetriever {
     @Override
     public Mono<Role> getRoleById(Snowflake guildId, Snowflake roleId) {
         return rest.getGuildService()
-                .getGuildRoles(guildId.asLong())
-                .filter(response -> response.id().asString().equals(roleId.asString()))
-                .singleOrEmpty()
+                .getGuildRole(guildId.asLong(), roleId.asLong())
                 .map(data -> new Role(gateway, data, guildId.asLong()));
     }
 

--- a/rest/src/main/java/discord4j/rest/route/Routes.java
+++ b/rest/src/main/java/discord4j/rest/route/Routes.java
@@ -757,6 +757,14 @@ public abstract class Routes {
     public static final Route GUILD_ROLES_GET = Route.get("/guilds/{guild.id}/roles");
 
     /**
+     * Returns a role object for the specified role id. Requires the 'MANAGE_ROLES' permission.
+     *
+     * @see <a href="https://discord.com/developers/docs/resources/guild#get-guild-role">
+     * https://discord.com/developers/docs/resources/guild#get-guild-role</a>
+     */
+    public static final Route GUILD_ROLE_GET = Route.get("/guilds/{guild.id}/roles/{role.id}");
+
+    /**
      * Create a new role for the guild. Requires the 'MANAGE_ROLES' permission. Returns the new role object on success.
      * Fires a Guild Role Create Gateway event. All JSON params are optional.
      *

--- a/rest/src/main/java/discord4j/rest/service/GuildService.java
+++ b/rest/src/main/java/discord4j/rest/service/GuildService.java
@@ -208,6 +208,12 @@ public class GuildService extends RestService {
             .flatMapMany(Flux::fromArray);
     }
 
+    public Mono<RoleData> getGuildRole(long guildId, long roleId) {
+        return Routes.GUILD_ROLE_GET.newRequest(guildId, roleId)
+            .exchange(getRouter())
+            .bodyToMono(RoleData.class);
+    }
+
     public Mono<RoleData> createGuildRole(long guildId, RoleCreateRequest request, @Nullable String reason) {
         return Routes.GUILD_ROLE_CREATE.newRequest(guildId)
             .body(request)


### PR DESCRIPTION
**Description:** Implement a REST behaviour for get the Role (thanks adavaith xd) from guild using Id and avoid make things like handle the whole role list in REST and set a filter

**Justification:** https://github.com/discord/discord-api-docs/pull/7074
