### PR TITLE
fix: ConcurrentModification for WrappedGuildData#unwrap in store

### DIFF
--- a/common/src/main/java/discord4j/common/store/impl/WrappedGuildData.java
+++ b/common/src/main/java/discord4j/common/store/impl/WrappedGuildData.java
@@ -52,11 +52,11 @@ class WrappedGuildData {
     ImmutableGuildData unwrap() {
         return ImmutableGuildData.builder()
                 .from(guild)
-                .members(members)
-                .emojis(emojis)
-                .stickers(stickers)
-                .channels(channels)
-                .roles(roles)
+                .members(new ArrayList<>(members))
+                .emojis(new ArrayList<>(emojis))
+                .stickers(new ArrayList<>(stickers))
+                .channels(new ArrayList<>(channels))
+                .roles(new ArrayList<>(roles))
                 .build();
     }
 


### PR DESCRIPTION
**Justification:** As WrappedGuildData#getMembers (and the other getters) returns the underlying Lists that are edited on member add/remove, a call to #unwrap() at the same time raises a CME.

fix #1267