### PR TITLE
Fix: Nullable messageAuthorId for Reaction Add Event

### DIFF
--- a/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
+++ b/core/src/main/java/discord4j/core/event/dispatch/MessageDispatchHandlers.java
@@ -23,6 +23,7 @@ import discord4j.core.object.Embed;
 import discord4j.core.object.entity.Member;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.reaction.ReactionEmoji;
+import discord4j.discordjson.Id;
 import discord4j.discordjson.json.MemberData;
 import discord4j.discordjson.json.MessageData;
 import discord4j.discordjson.json.PartialMessageData;
@@ -105,7 +106,7 @@ class MessageDispatchHandlers {
         long userId = Snowflake.asLong(context.getDispatch().userId());
         long channelId = Snowflake.asLong(context.getDispatch().channelId());
         long messageId = Snowflake.asLong(context.getDispatch().messageId());
-        long messageAuthorId = Snowflake.asLong(context.getDispatch().messageAuthorId());
+        long messageAuthorId = Snowflake.asLong(context.getDispatch().messageAuthorId().toOptional().orElse(Id.of(0L)));
         Long guildId = context.getDispatch().guildId()
                 .toOptional()
                 .map(Snowflake::asLong)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.2.7-SNAPSHOT
-discordJsonVersion=1.6.21
+discordJsonVersion=1.6.22-SNAPSHOT
 storesVersion=3.2.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
-version=3.2.7-SNAPSHOT
-discordJsonVersion=1.6.22-SNAPSHOT
+version=3.2.8-SNAPSHOT
+discordJsonVersion=1.6.22
 storesVersion=3.2.3


### PR DESCRIPTION
**Description:** This handle a case where the messageAuthorId can not be set in the gateway, for reduce breaking things this fix just handle the missing case with a 0 ID like currently the D4J docs mention in the method. For 3.3.x this can be a Optional.

**Justification:** https://github.com/discord/discord-api-docs/commit/26b95485354b4d583b35f6dd5b149d1ab0ff42ae and close #1273
