### PR TITLE
Feat: deprecate IntegrationApplication#getSummary

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/IntegrationApplication.java
+++ b/core/src/main/java/discord4j/core/object/entity/IntegrationApplication.java
@@ -105,7 +105,9 @@ public class IntegrationApplication implements Entity {
      * Gets the summary of the app.
      *
      * @return The description of the app.
+     * @deprecated Discord just return an empty string you can consider use {@link #getDescription()}
      */
+    @Deprecated
     public String getSummary() {
         return data.summary();
     }


### PR DESCRIPTION
**Description:** This PR just deprecate the summary method based in how discord just return an empty string

**Justification:** https://github.com/discord/discord-api-docs/commit/a36e8112a7e63b8105be54fea3d18611552fedb4
