### PR TITLE
Feat: Add missing ThreadChannel#getAppliedTags method

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ThreadChannel.java
@@ -307,7 +307,7 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
      * <br>
      * When the channel does not support tagging, returned values from {@link ThreadChannel#getAppliedTagsIds()} and
      * {@link ThreadChannel#getAppliedTags()} return an empty list or {@link Flux}.
-     * <br>
+     *
      * @return A boolean indicating if the thread channel can be tagged.
      */
     public boolean canBeTagged() {
@@ -317,11 +317,10 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
     /**
      * Returns the list of the applied forum tags on this thread. If the thread channel does not support tagging, the
      * list is empty. To know if the thread supports tagging, use {@link ThreadChannel#canBeTagged()}.
-     * @see ThreadChannel#canBeTagged()
-     * @see ThreadChannel#getAppliedTagsIds()
      *
      * @return An {@link Optional} item, wrapping a list of applied forum or media channel tags to this thread channel.
      * The optional item will be empty if the thread channel cannot contain tags, otherwise the list is empty.
+     * @see ThreadChannel#canBeTagged()
      * @see ThreadChannel#getAppliedTags()
      */
     public List<Snowflake> getAppliedTagsIds() {
@@ -337,6 +336,7 @@ public final class ThreadChannel extends BaseChannel implements GuildMessageChan
      *
      * @return A {@link Flux}, that emits all the applied tags on this thread channel. If an error occurs, it is emitted
      * through the flux. Only emits if the thread channel can have tags applied.
+     * @see ThreadChannel#canBeTagged()
      * @see ThreadChannel#getAppliedTagsIds()
      */
     public Flux<ForumTag> getAppliedTags() {


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** As discussed a few month ago on the Discord4J Discord server (and I'm sorry I forgot this PR), some methods regarding Forum tags were missing in the ForumChannel class.

I first added some documentation within the Thread Channel class, then I implemented two methods : 
* `getAppliedTagsIds()`: Gets an Optional list of the applied tags on the thread channel. The returned optional is empty if the applied_tags field was not sent by Discord, which is when the thread channel is not from a Forum or media channel.
* `getAppliedTags()`: Another method that does the same job but instead of returning the applied tags identifiers, a Flux emits the ForumTag objects directly. Note that, currently, only the forum channels are supported even if the media channels are documented on the API for providing the applied_tags. If the method is used on such a thread, the flux is empty.

**Justification:** The `applied_tags` is already implemented in Discord JSON but was never made available directly on the core layer. 

I still need to test the PR, but I am really really busy, if you don't have news from me, you can ping me (@heliodixy) on the Discord or test it yourself.