### PR TITLE
feat: Add support for Attachment/MessageCreateFields.File in UnfurledMediaItem

### DIFF
--- a/core/src/main/java/discord4j/core/object/component/UnfurledMediaItem.java
+++ b/core/src/main/java/discord4j/core/object/component/UnfurledMediaItem.java
@@ -50,6 +50,8 @@ public class UnfurledMediaItem {
      * @param file The file to use
      * @return An {@link UnfurledMediaItem}
      * @see MessageCreateFields.File#of(String, InputStream)
+     * @see discord4j.core.spec.MessageCreateSpec#withFiles(MessageCreateFields.File...) MessageCreateSpec#withFiles(MessageCreateFields.File...)
+     * @see discord4j.core.spec.InteractionApplicationCommandCallbackReplyMono#withFiles(MessageCreateFields.File...) InteractionApplicationCommandCallbackReplyMono#withFiles(MessageCreateFields.File...)
      */
     public static UnfurledMediaItem of(MessageCreateFields.File file) {
         return UnfurledMediaItem.of(PREFIX_DISCORD_ATTACHMENT_REFERENCE.concat(file.name()));


### PR DESCRIPTION
**Description:** This PR add a few method helpers for `Attachment` and `MessageCreateFields.File`
- For `Attachment` the method just call the `getUrl` method because an attachment was already uploaded to discord
- For `MessageCreateFields.File` this use the `name` method for set the `attachment://name` this require the File being used in the message for upload

**Justification:** [Mentioned in discord](https://canary.discord.com/channels/208023865127862272/451125724766535710/1366237999561707601) about how `attachment://` need to be declared manually by users
