### PR TITLE
fix: allow components v2 in Webhook edit

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Webhook.java
+++ b/core/src/main/java/discord4j/core/object/entity/Webhook.java
@@ -656,13 +656,15 @@ public final class Webhook implements Entity {
                     throw new IllegalArgumentException("Can't edit message with this webhook.");
                 }
 
+                boolean withComponents = !spec.components().isAbsent();
+
                 if (spec.threadId().isAbsent()) {
                     return gateway.getRestClient().getWebhookService()
-                        .modifyWebhookMessage(getId().asLong(), getToken().get(), messageId.asString(), spec.asRequest())
+                        .modifyWebhookMessage(getId().asLong(), getToken().get(), messageId.asString(), withComponents, spec.asRequest())
                         .map(data -> new Message(gateway, data));
                 } else {
                     return gateway.getRestClient().getWebhookService()
-                        .modifyWebhookMessage(getId().asLong(), getToken().get(), messageId.asString(), spec.threadId().get().asLong(), spec.asRequest())
+                        .modifyWebhookMessage(getId().asLong(), getToken().get(), messageId.asString(), spec.threadId().get().asLong(), withComponents, spec.asRequest())
                         .map(data -> new Message(gateway, data));
                 }
             }
@@ -686,8 +688,9 @@ public final class Webhook implements Entity {
                 if (!getToken().isPresent()) {
                     throw new IllegalArgumentException("Can't edit message with this webhook.");
                 }
+                boolean withComponents = !spec.components().isAbsent();
                 return gateway.getRestClient().getWebhookService()
-                    .modifyWebhookMessage(getId().asLong(), getToken().get(), messageId.asString(), threadId.asLong(), spec.asRequest())
+                    .modifyWebhookMessage(getId().asLong(), getToken().get(), messageId.asString(), threadId.asLong(), withComponents, spec.asRequest())
                     .map(data -> new Message(gateway, data));
             }
         );

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.2.9-SNAPSHOT
-discordJsonVersion=1.6.25
+discordJsonVersion=1.6.26
 storesVersion=3.2.3

--- a/rest/src/main/java/discord4j/rest/service/WebhookService.java
+++ b/rest/src/main/java/discord4j/rest/service/WebhookService.java
@@ -194,9 +194,28 @@ public class WebhookService extends RestService {
             .bodyToMono(MessageData.class);
     }
 
+    public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId, boolean withComponents,
+                                                  WebhookMessageEditRequest request) {
+        return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
+            .query("with_components", withComponents)
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(MessageData.class);
+    }
+
     public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId,
                                                   WebhookMessageEditRequest request) {
         return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
+            .body(request)
+            .exchange(getRouter())
+            .bodyToMono(MessageData.class);
+    }
+
+    public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId, long threadId, boolean withComponents,
+                                                  WebhookMessageEditRequest request) {
+        return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
+            .query("thread_id", threadId)
+            .query("with_components", withComponents)
             .body(request)
             .exchange(getRouter())
             .bodyToMono(MessageData.class);
@@ -211,6 +230,16 @@ public class WebhookService extends RestService {
             .bodyToMono(MessageData.class);
     }
 
+    public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId, boolean withComponents,
+                                                  MultipartRequest<WebhookMessageEditRequest> request) {
+        return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
+            .query("with_components", withComponents)
+            .header("content-type", request.getFiles().isEmpty() ? "application/json" : "multipart/form-data")
+            .body(Objects.requireNonNull(request.getFiles().isEmpty() ? request.getJsonPayload() : request))
+            .exchange(getRouter())
+            .bodyToMono(MessageData.class);
+    }
+
     public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId,
                                                   MultipartRequest<WebhookMessageEditRequest> request) {
         return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
@@ -218,6 +247,17 @@ public class WebhookService extends RestService {
                 .body(Objects.requireNonNull(request.getFiles().isEmpty() ? request.getJsonPayload() : request))
                 .exchange(getRouter())
                 .bodyToMono(MessageData.class);
+    }
+
+    public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId, long threadId, boolean withComponents,
+                                                  MultipartRequest<WebhookMessageEditRequest> request) {
+        return Routes.WEBHOOK_MESSAGE_EDIT.newRequest(webhookId, webhookToken, messageId)
+            .query("thread_id", threadId)
+            .query("with_components", withComponents)
+            .header("content-type", request.getFiles().isEmpty() ? "application/json" : "multipart/form-data")
+            .body(Objects.requireNonNull(request.getFiles().isEmpty() ? request.getJsonPayload() : request))
+            .exchange(getRouter())
+            .bodyToMono(MessageData.class);
     }
 
     public Mono<MessageData> modifyWebhookMessage(long webhookId, String webhookToken, String messageId, long threadId,


### PR DESCRIPTION
**Description:** This PR fix an issue where edit a reply or modify a webhook not handle the components v2, this was caused by a missing flags field not documented by discord in the release.

**Justification:** https://github.com/discord/discord-api-docs/pull/7507
