### PR TITLE
feat: make Create/Edit Message Spec include the CV2 flag if can

### DIFF
--- a/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
@@ -30,9 +30,9 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,18 +65,12 @@ interface InteractionApplicationCommandCallbackSpecGenerator extends Spec<Multip
 
     @Override
     default MultipartRequest<InteractionApplicationCommandCallbackData> asRequest() {
-        List<Message.Flag> flagsToApply = new ArrayList<>();
-        if (this.ephemeral().toOptional().orElse(false)) {
-            flagsToApply.add(Message.Flag.EPHEMERAL);
-        }
-        if (!this.components().isAbsent() && this.components().get().stream().anyMatch(topLevelComponent -> topLevelComponent.getType().isRequiredFlag())) {
-            flagsToApply.add(Message.Flag.IS_COMPONENTS_V2);
-        }
-        Possible<List<Message.Flag>> pFlagsToApply = Possible.of(flagsToApply);
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(Collections.emptySet(), this.ephemeral(), Possible.absent(), this.components());
+
         InteractionApplicationCommandCallbackData json = InteractionApplicationCommandCallbackData.builder()
                 .content(content())
                 .tts(tts())
-                .flags(mapPossible(pFlagsToApply, f -> f.stream()
+                .flags(mapPossible(Possible.ofNullable(flagsToApply), f -> f.stream()
                     .mapToInt(Message.Flag::getFlag)
                     .reduce(0, (left, right) -> left | right)))
                 .embeds(mapPossible(embeds(), embeds -> embeds.stream()

--- a/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
@@ -65,7 +65,7 @@ interface InteractionApplicationCommandCallbackSpecGenerator extends Spec<Multip
 
     @Override
     default MultipartRequest<InteractionApplicationCommandCallbackData> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(Collections.emptySet(), this.ephemeral(), Possible.absent(), this.components());
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(null, this.ephemeral(), Possible.absent(), this.components());
 
         InteractionApplicationCommandCallbackData json = InteractionApplicationCommandCallbackData.builder()
                 .content(content())

--- a/core/src/main/java/discord4j/core/spec/InteractionFollowupCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionFollowupCreateSpecGenerator.java
@@ -74,7 +74,7 @@ interface InteractionFollowupCreateSpecGenerator extends Spec<MultipartRequest<F
 
     @Override
     default MultipartRequest<FollowupMessageRequest> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(Collections.emptySet(), this.ephemeral(), Possible.absent(), this.components());
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(null, this.ephemeral(), Possible.absent(), this.components());
 
         FollowupMessageRequest request = FollowupMessageRequest.builder()
                 .content(content())

--- a/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
@@ -32,7 +32,6 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
@@ -71,7 +71,7 @@ interface InteractionReplyEditSpecGenerator extends Spec<MultipartRequest<Webhoo
 
     @Override
     default MultipartRequest<WebhookMessageEditRequest> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(Collections.emptySet(), Possible.absent(), this.suppressEmbeds(), this.components().map(Optional::get));
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(null, Possible.absent(), this.suppressEmbeds(), this.components().map(Optional::get));
 
         WebhookMessageEditRequest json = WebhookMessageEditRequest.builder()
             .content(content())

--- a/core/src/main/java/discord4j/core/spec/InternalMessageSpecUtils.java
+++ b/core/src/main/java/discord4j/core/spec/InternalMessageSpecUtils.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.spec;
+
+import discord4j.core.object.component.TopLevelMessageComponent;
+import discord4j.core.object.entity.Message;
+import discord4j.discordjson.possible.Possible;
+import reactor.util.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class InternalMessageSpecUtils {
+
+    private InternalMessageSpecUtils() {
+        throw new AssertionError();
+    }
+
+    @Nullable
+    static Set<Message.Flag> decorateFlags(final Collection<Message.Flag> oldFlags,
+                                                  final Possible<Boolean> ephemeral,
+                                                  final Possible<Boolean> suppressEmbeds,
+                                                  final Possible<List<TopLevelMessageComponent>> components) {
+        final Set<Message.Flag> newFlags = new HashSet<>(oldFlags);
+        if (ephemeral.toOptional().orElse(false)) {
+            newFlags.add(Message.Flag.EPHEMERAL);
+        }
+        if (suppressEmbeds.toOptional().orElse(false)) {
+            newFlags.add(Message.Flag.SUPPRESS_EMBEDS);
+        }
+
+        if (!components.isAbsent() && components.get().stream().anyMatch(component -> component.getType().isRequiredFlag())) {
+            newFlags.add(Message.Flag.IS_COMPONENTS_V2);
+        }
+
+        if (newFlags.isEmpty()) {
+            return null;
+        }
+        return new HashSet<>(newFlags);
+    }
+}

--- a/core/src/main/java/discord4j/core/spec/InternalMessageSpecUtils.java
+++ b/core/src/main/java/discord4j/core/spec/InternalMessageSpecUtils.java
@@ -32,26 +32,26 @@ final class InternalMessageSpecUtils {
         throw new AssertionError();
     }
 
-    @Nullable
-    static Set<Message.Flag> decorateFlags(final Collection<Message.Flag> oldFlags,
-                                                  final Possible<Boolean> ephemeral,
-                                                  final Possible<Boolean> suppressEmbeds,
-                                                  final Possible<List<TopLevelMessageComponent>> components) {
-        final Set<Message.Flag> newFlags = new HashSet<>(oldFlags);
+    public static @Nullable Set<Message.Flag> decorateFlags(final @Nullable Collection<Message.Flag> oldFlags, final Possible<Boolean> ephemeral, final Possible<Boolean> suppressEmbeds, final Possible<List<TopLevelMessageComponent>> components) {
+        final Set<Message.Flag> newFlags = new HashSet<>();
         if (ephemeral.toOptional().orElse(false)) {
             newFlags.add(Message.Flag.EPHEMERAL);
         }
         if (suppressEmbeds.toOptional().orElse(false)) {
             newFlags.add(Message.Flag.SUPPRESS_EMBEDS);
         }
-
         if (!components.isAbsent() && components.get().stream().anyMatch(component -> component.getType().isRequiredFlag())) {
             newFlags.add(Message.Flag.IS_COMPONENTS_V2);
         }
-
-        if (newFlags.isEmpty()) {
+        if (!newFlags.isEmpty()) {
+            if (oldFlags != null) {
+                newFlags.addAll(oldFlags);
+            }
+            return newFlags;
+        } else if (oldFlags != null) {
+            return new HashSet<>(oldFlags);
+        } else {
             return null;
         }
-        return new HashSet<>(newFlags);
     }
 }

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
@@ -89,7 +89,7 @@ interface MessageCreateSpecGenerator extends Spec<MultipartRequest<MessageCreate
         if (!this.components().isAbsent() && this.components().get().stream().anyMatch(topLevelComponent -> topLevelComponent.getType().isRequiredFlag())) {
             flagsToApply.add(Message.Flag.IS_COMPONENTS_V2);
         }
-        Possible<List<Message.Flag>> pFlagsToApply = Possible.of(new ArrayList<>(flagsToApply));
+        Possible<List<Message.Flag>> pFlagsToApply = flagsToApply.isEmpty() ? Possible.absent() : Possible.of(new ArrayList<>(flagsToApply));
 
         MessageCreateRequest json = MessageCreateRequest.builder()
             .content(content())

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
@@ -85,7 +85,7 @@ interface MessageCreateSpecGenerator extends Spec<MultipartRequest<MessageCreate
 
     @Override
     default MultipartRequest<MessageCreateRequest> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(this.flags().toOptional().orElse(new ArrayList<>()), Possible.absent(), Possible.absent(), this.components());
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(this.flags().toOptional().orElse(null), Possible.absent(), Possible.absent(), this.components());
 
         MessageCreateRequest json = MessageCreateRequest.builder()
             .content(content())

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
@@ -32,9 +32,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
@@ -34,7 +34,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,11 +85,11 @@ interface MessageCreateSpecGenerator extends Spec<MultipartRequest<MessageCreate
 
     @Override
     default MultipartRequest<MessageCreateRequest> asRequest() {
-        List<Message.Flag> flagsToApply = new ArrayList<>(this.flags().toOptional().orElse(new ArrayList<>()));
-        if (!flagsToApply.contains(Message.Flag.IS_COMPONENTS_V2) && !this.components().isAbsent() && this.components().get().stream().anyMatch(topLevelComponent -> topLevelComponent.getType().isRequiredFlag())) {
+        Set<Message.Flag> flagsToApply = new HashSet<>(this.flags().toOptional().orElse(new ArrayList<>()));
+        if (!this.components().isAbsent() && this.components().get().stream().anyMatch(topLevelComponent -> topLevelComponent.getType().isRequiredFlag())) {
             flagsToApply.add(Message.Flag.IS_COMPONENTS_V2);
         }
-        Possible<List<Message.Flag>> pFlagsToApply = Possible.of(flagsToApply);
+        Possible<List<Message.Flag>> pFlagsToApply = Possible.of(new ArrayList<>(flagsToApply));
 
         MessageCreateRequest json = MessageCreateRequest.builder()
             .content(content())

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -67,7 +67,7 @@ interface MessageEditSpecGenerator extends Spec<MultipartRequest<MessageEditRequ
 
     @Override
     default MultipartRequest<MessageEditRequest> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(this.flags().map(Optional::get).toOptional().orElse(Collections.emptyList()), Possible.absent(), Possible.absent(), this.components().map(Optional::get));
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(this.flags().map(Optional::get).toOptional().orElse(null), Possible.absent(), Possible.absent(), this.components().map(Optional::get));
 
         MessageEditRequest json = MessageEditRequest.builder()
             .content(content())

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -29,9 +29,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -75,7 +75,7 @@ interface MessageEditSpecGenerator extends Spec<MultipartRequest<MessageEditRequ
                 .map(EmbedCreateSpec::asRequest)
                 .collect(Collectors.toList())))
             .allowedMentions(mapPossibleOptional(allowedMentions(), AllowedMentions::toData))
-            .flags(mapPossibleOptional(Possible.of(Optional.of(flagsToApply)), f -> f.stream()
+            .flags(mapPossibleOptional(Possible.of(Optional.ofNullable(flagsToApply)), f -> f.stream()
                 .mapToInt(Message.Flag::getFlag)
                 .reduce(0, (left, right) -> left | right)))
             .components(mapPossibleOptional(components(), components -> components.stream()

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -31,8 +31,10 @@ import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,11 +67,11 @@ interface MessageEditSpecGenerator extends Spec<MultipartRequest<MessageEditRequ
 
     @Override
     default MultipartRequest<MessageEditRequest> asRequest() {
-        List<Message.Flag> flagsToApply = new ArrayList<>(this.flags().map(Optional::get).toOptional().orElse(Collections.emptyList()));
-        if (!flagsToApply.contains(Message.Flag.IS_COMPONENTS_V2) && !this.components().isAbsent() && this.components().map(Optional::get).get().stream().anyMatch(topLevelComponent -> topLevelComponent.getType().isRequiredFlag())) {
+        Set<Message.Flag> flagsToApply = new HashSet<>(this.flags().map(Optional::get).toOptional().orElse(Collections.emptyList()));
+        if (!this.components().isAbsent() && this.components().map(Optional::get).get().stream().anyMatch(topLevelComponent -> topLevelComponent.getType().isRequiredFlag())) {
             flagsToApply.add(Message.Flag.IS_COMPONENTS_V2);
         }
-        Possible<Optional<List<Message.Flag>>> pFlagsToApply = Possible.of(Optional.of(flagsToApply));
+        Possible<Optional<List<Message.Flag>>> pFlagsToApply = Possible.of(Optional.of(new ArrayList<>(flagsToApply)));
 
         MessageEditRequest json = MessageEditRequest.builder()
             .content(content())

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -174,7 +174,7 @@ public class RestChannel {
      * Request to create a message using a given {@link MessageCreateRequest} as body. If you want to include
      * attachments to your message, see {@link #createMessage(MultipartRequest)}.
      *
-     * @apiNote this method takes a raw data and not applies any modification (ex: adding the USE_COMPONENTS_V2 tag if the request contains components v2)
+     * @apiNote if the request comes from a {@code Spec} class can be different from a raw {@link ImmutableMessageCreateRequest.Builder#build()} for flags and another internal behaviours
      * @param request request body used to create a new message
      * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an
      * error is received, it is emitted through the {@code Mono}.

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -188,7 +188,6 @@ public class RestChannel {
      * Request to create a message using a given {@link MultipartRequest} as body. A {@link MultipartRequest} is a
      * custom object allowing you to add attachments to a message.
      *
-     * @apiNote this method takes a raw data and not applies any modification (ex: adding the USE_COMPONENTS_V2 tag if the request contains components v2)
      * @param request request body used to create a new message
      * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an
      * error is received, it is emitted through the {@code Mono}.

--- a/rest/src/main/java/discord4j/rest/entity/RestChannel.java
+++ b/rest/src/main/java/discord4j/rest/entity/RestChannel.java
@@ -174,6 +174,7 @@ public class RestChannel {
      * Request to create a message using a given {@link MessageCreateRequest} as body. If you want to include
      * attachments to your message, see {@link #createMessage(MultipartRequest)}.
      *
+     * @apiNote this method takes a raw data and not applies any modification (ex: adding the USE_COMPONENTS_V2 tag if the request contains components v2)
      * @param request request body used to create a new message
      * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an
      * error is received, it is emitted through the {@code Mono}.
@@ -187,6 +188,7 @@ public class RestChannel {
      * Request to create a message using a given {@link MultipartRequest} as body. A {@link MultipartRequest} is a
      * custom object allowing you to add attachments to a message.
      *
+     * @apiNote this method takes a raw data and not applies any modification (ex: adding the USE_COMPONENTS_V2 tag if the request contains components v2)
      * @param request request body used to create a new message
      * @return a {@link Mono} where, upon successful completion, emits the created {@link MessageData}. If an
      * error is received, it is emitted through the {@code Mono}.


### PR DESCRIPTION
**Description:** Make the ofRequest for the specs related to create or edit a message add the CV2 flag if any of the components require that

**Justification:** Make this follow the same behaviour than Interaction Messages where this flag is added internally, this can reduce users confusing about when need add or not the flag, the bad thing with this is users can get errors if try things not allowed by discord like using content and adding components, that require a way to make the spec generator add docs about that.
