### PR TITLE
feat: abstract Reaction Events

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionAddEvent.java
@@ -17,17 +17,13 @@
 package discord4j.core.event.domain.message;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.Member;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.User;
-import discord4j.core.object.entity.channel.MessageChannel;
-import discord4j.core.object.reaction.Reaction;
 import discord4j.core.object.emoji.Emoji;
 import discord4j.common.util.Snowflake;
 import discord4j.gateway.ShardInfo;
 import discord4j.rest.util.Color;
-import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.util.List;
@@ -37,127 +33,27 @@ import java.util.stream.Collectors;
 /**
  * Dispatched when a reaction is added to a message.
  * <p>
- * {@link #guildId} may not be present if the message was in a private channel.
+ * {@link #getGuildId()} may not be present if the message was in a private channel.
  * <p>
  * This event is dispatched by Discord.
  *
- * @see <a href="https://discord.com/developers/docs/topics/gateway#message-reaction-add">Message Reaction Add</a>
+ * @see <a href="https://discord.com/developers/docs/events/gateway-events#message-reaction-add">Message Reaction Add</a>
  */
-public class ReactionAddEvent extends MessageEvent {
+public class ReactionAddEvent extends ReactionUserEmojiEvent {
 
-    private final long userId;
-    private final long channelId;
-    private final long messageId;
-    @Nullable
-    private final Long guildId;
-    private final Emoji emoji;
     @Nullable
     private final Member member;
     private final long messageAuthorId;
-    private final boolean burst;
     private final List<String> burstColors;
-    private final int type;
 
-    public ReactionAddEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long userId, long channelId, long messageId, @Nullable Long guildId,
-                            Emoji emoji, @Nullable Member member, long messageAuthorId, boolean burst, List<String> burstColors, int type) {
-        super(gateway, shardInfo);
-        this.userId = userId;
-        this.channelId = channelId;
-        this.messageId = messageId;
-        this.guildId = guildId;
-        this.emoji = emoji;
+    public ReactionAddEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long userId, long channelId,
+                            long messageId, @Nullable Long guildId,
+                            Emoji emoji, @Nullable Member member, long messageAuthorId, boolean burst,
+                            List<String> burstColors, int type) {
+        super(gateway, shardInfo, channelId, messageId, guildId, emoji, userId, burst, type);
         this.member = member;
         this.messageAuthorId = messageAuthorId;
-        this.burst = burst;
         this.burstColors = burstColors;
-        this.type = type;
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link User} who added a reaction in this event.
-     *
-     * @return The Id of the {@link User} who added a reaction.
-     */
-    public Snowflake getUserId() {
-        return Snowflake.of(userId);
-    }
-
-    /**
-     * Requests to retrieve the {@link User} who added a reaction in this event.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User} that has added the reaction.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<User> getUser() {
-        return getClient().getUserById(getUserId());
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the {@link Message} and reaction are in.
-     *
-     * @return The ID of the {@link MessageChannel} involved.
-     */
-    public Snowflake getChannelId() {
-        return Snowflake.of(channelId);
-    }
-
-    /**
-     * Requests to retrieve the {@link MessageChannel} the {@link Message} and reaction are in.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing
-     * the {@link Message} in the event. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<MessageChannel> getChannel() {
-        return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Message} the reaction was added to in this event.
-     *
-     * @return The ID of the {@link Message} the reaction was added to.
-     */
-    public Snowflake getMessageId() {
-        return Snowflake.of(messageId);
-    }
-
-    /**
-     * Request to retrieve the {@link Message} the reaction was added to in this event.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link Message} the reaction was added to.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Message> getMessage() {
-        return getClient().getMessageById(getChannelId(), getMessageId());
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Guild} containing the {@link Message} and Reaction, if present.
-     * This may not be available if the reaction is to a {@code Message} in a private channel.
-     *
-     * @return The ID of the {@link Guild} involved in the event, if present.
-     */
-    public Optional<Snowflake> getGuildId() {
-        return Optional.ofNullable(guildId).map(Snowflake::of);
-    }
-
-    /**
-     * Request to retrieve the {@link Guild} containing the {@link Message} and reaction, if present.
-     * This may not be available if the reaction is to a {@code Message} in a private channel.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the {@link Message}
-     * involved, if present. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Guild> getGuild() {
-        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
-    }
-
-    /**
-     * Gets the {@link Emoji} that was added to the {@link Message} in this event.
-     *
-     * @return The {@code Emoji} added to the {@link Message} as a reaction.
-     */
-    public Emoji getEmoji() {
-        return emoji;
     }
 
     /**
@@ -189,33 +85,11 @@ public class ReactionAddEvent extends MessageEvent {
         return this.burstColors.stream().map(Color::of).collect(Collectors.toList());
     }
 
-    /**
-     * Gets whether the reaction related to this event is "Super".
-     *
-     * @return Whether the reaction related to this event is "Super".
-     */
-    public boolean isSuperReaction() {
-        return this.burst;
-    }
-
-    /**
-     * Gets the {@link Reaction.Type} of the reaction.
-     *
-     * @return A {@link Reaction.Type}
-     */
-    public Reaction.Type getType() {
-        return Reaction.Type.of(this.type);
-    }
-
     @Override
     public String toString() {
         return "ReactionAddEvent{" +
-                "userId=" + userId +
-                ", channelId=" + channelId +
-                ", messageId=" + messageId +
-                ", guildId=" + guildId +
-                ", emoji=" + emoji +
-                ", member=" + member +
-                '}';
+            ", member=" + member +
+            ", burstColors=" + burstColors +
+            "} " + super.toString();
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionBaseEmojiEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionBaseEmojiEvent.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.event.domain.message;
+
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.emoji.Emoji;
+import discord4j.core.object.entity.Message;
+import discord4j.gateway.ShardInfo;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Represents an event related to a {@link discord4j.core.object.reaction.Reaction} with an Emoji.
+ */
+public class ReactionBaseEmojiEvent extends ReactionEvent {
+
+    private final Emoji emoji;
+
+    public ReactionBaseEmojiEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, long messageId,
+                                  @Nullable Long guildId, Emoji emoji) {
+        super(gateway, shardInfo, channelId, messageId, guildId);
+        this.emoji = emoji;
+    }
+
+    /**
+     * Gets the {@link Emoji} in the {@link Message} related in this event.
+     *
+     * @return The {@code Emoji} of to the {@link Message} as a reaction.
+     */
+    public Emoji getEmoji() {
+        return emoji;
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionEmojiEvent{" +
+            ", emoji=" + emoji +
+            "} " + super.toString();
+    }
+}

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionBaseEmojiEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionBaseEmojiEvent.java
@@ -25,7 +25,7 @@ import reactor.util.annotation.Nullable;
 /**
  * Represents an event related to a {@link discord4j.core.object.reaction.Reaction} with an Emoji.
  */
-public class ReactionBaseEmojiEvent extends ReactionEvent {
+public abstract class ReactionBaseEmojiEvent extends ReactionEvent {
 
     private final Emoji emoji;
 

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionEvent.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.event.domain.message;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.entity.Guild;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.channel.MessageChannel;
+import discord4j.gateway.ShardInfo;
+import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Represents an event related to a {@link discord4j.core.object.reaction.Reaction}.
+ */
+public class ReactionEvent extends MessageEvent {
+
+    private final long channelId;
+    private final long messageId;
+    private final @Nullable Long guildId;
+
+    public ReactionEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, long messageId,
+                         @Nullable Long guildId) {
+        super(gateway, shardInfo);
+        this.channelId = channelId;
+        this.messageId = messageId;
+        this.guildId = guildId;
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link MessageChannel} the {@link Message} and reaction are in.
+     *
+     * @return The ID of the {@link MessageChannel} involved.
+     */
+    public Snowflake getChannelId() {
+        return Snowflake.of(channelId);
+    }
+
+    /**
+     * Requests to retrieve the {@link MessageChannel} the {@link Message} and reaction are in.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing
+     * the {@link Message} in the event. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<MessageChannel> getChannel() {
+        return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Message} the reaction was added to in this event.
+     *
+     * @return The ID of the {@link Message} the reaction was added to.
+     */
+    public Snowflake getMessageId() {
+        return Snowflake.of(messageId);
+    }
+
+    /**
+     * Request to retrieve the {@link Message} the reaction related this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Message} the reaction related.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Message> getMessage() {
+        return getClient().getMessageById(getChannelId(), getMessageId());
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link Guild} containing the {@link Message} and Reaction, if present.
+     * This may not be available if the reaction is to a {@code Message} in a private channel.
+     *
+     * @return The ID of the {@link Guild} involved in the event, if present.
+     */
+    public Optional<Snowflake> getGuildId() {
+        return Optional.ofNullable(guildId).map(Snowflake::of);
+    }
+
+    /**
+     * Request to retrieve the {@link Guild} containing the {@link Message} and reaction, if present.
+     * This may not be available if the reaction is to a {@code Message} in a private channel.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the {@link Message}
+     * involved, if present. If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<Guild> getGuild() {
+        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionEvent{" +
+            "channelId=" + channelId +
+            ", messageId=" + messageId +
+            ", guildId=" + guildId +
+            '}';
+    }
+}

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionEvent.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 /**
  * Represents an event related to a {@link discord4j.core.object.reaction.Reaction}.
  */
-public class ReactionEvent extends MessageEvent {
+public abstract class ReactionEvent extends MessageEvent {
 
     private final long channelId;
     private final long messageId;

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveAllEvent.java
@@ -17,109 +17,32 @@
 package discord4j.core.event.domain.message;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.object.entity.Guild;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.channel.MessageChannel;
-import discord4j.common.util.Snowflake;
 import discord4j.gateway.ShardInfo;
-import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
-import java.util.Optional;
-
 /**
- * Dispatched when all of the reactions on a message are removed.
+ * Dispatched when all the reactions on a message are removed.
  * <p>
- * {@link #guildId} may not be present if the message was in a private channel.
+ * {@link #getGuildId()} may not be present if the message was in a private channel.
  * <p>
- * Corresponding {@link discord4j.core.event.domain.message.ReactionRemoveEvent reactions removes} are NOT dispatched
+ * Corresponding {@link ReactionRemoveEvent reactions removes} are NOT dispatched
  * for messages included in this event.
  * <p>
  * This event is dispatched by Discord.
  *
- * @see <a href="https://discord.com/developers/docs/topics/gateway#message-reaction-remove-all">Message Reaction
+ * @see <a href="https://discord.com/developers/docs/events/gateway-events#message-reaction-remove-all">Message Reaction
  * Remove All</a>
  */
-public class ReactionRemoveAllEvent extends MessageEvent {
+public class ReactionRemoveAllEvent extends ReactionEvent {
 
-    private final long channelId;
-    private final long messageId;
-    @Nullable
-    private final Long guildId;
-
-    public ReactionRemoveAllEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, long messageId, @Nullable Long guildId) {
-        super(gateway, shardInfo);
-        this.channelId = channelId;
-        this.messageId = messageId;
-        this.guildId = guildId;
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the channel containing the {@link Message} and the removed Reactions.
-     *
-     * @return The ID of the {@link MessageChannel} involved.
-     */
-    public Snowflake getChannelId() {
-        return Snowflake.of(channelId);
-    }
-
-    /**
-     * Requests to retrieve the {@link MessageChannel} containing the {@link Message} and the removed reactions.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing the message
-     * involved. If an error is received, it is emitted through the {@code Mono}
-     */
-    public Mono<MessageChannel> getChannel() {
-        return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Message} the reactions were removed from in this event.
-     *
-     * @return The ID of the {@link Message} involved.
-     */
-    public Snowflake getMessageId() {
-        return Snowflake.of(messageId);
-    }
-
-    /**
-     * Requests to retrieve the {@link Message} the reactions were removed from in this event.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link Message} the reactions were
-     * removed from. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Message> getMessage() {
-        return getClient().getMessageById(getChannelId(), getMessageId());
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Guild} containing the {@link Message} the
-     * reactions were removed from, if present.
-     * This may not be available if the {@code Message} was sent in a private channel.
-     *
-     * @return The ID of the {@link Guild} containing the {@link Message} involved, if present.
-     */
-    public Optional<Snowflake> getGuildId() {
-        return Optional.ofNullable(guildId).map(Snowflake::of);
-    }
-
-    /**
-     * Request to retrieve the {@link Guild} containing the {@link Message} the reactions were removed from, if present.
-     * This may not if the {@code Message} was sent in a private channel.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing
-     * the {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Guild> getGuild() {
-        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
+    public ReactionRemoveAllEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, long messageId,
+                                  @Nullable Long guildId) {
+        super(gateway, shardInfo, channelId, messageId, guildId);
     }
 
     @Override
     public String toString() {
         return "ReactionRemoveAllEvent{" +
-                "channelId=" + channelId +
-                ", messageId=" + messageId +
-                ", guildId=" + guildId +
-                '}';
+            "} " + super.toString();
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEmojiEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEmojiEvent.java
@@ -17,121 +17,30 @@
 package discord4j.core.event.domain.message;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.object.entity.Guild;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.channel.MessageChannel;
 import discord4j.core.object.emoji.Emoji;
 import discord4j.gateway.ShardInfo;
-import discord4j.common.util.Snowflake;
-import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
-import java.util.Optional;
-
 /**
- * Dispatched when a reactions of one emoji are removed on a message.
+ * Dispatched when a reaction of one emoji is removed on a message.
  * <p>
- * {@link #guildId} may not be present if the message was in a private channel.
+ * {@link #getGuildId()} may not be present if the message was in a private channel.
  * <p>
  * This event is dispatched by Discord.
  *
- * @see <a href="https://discord.com/developers/docs/topics/gateway#message-reaction-remove-emoji">Message Reaction
+ * @see <a href="https://discord.com/developers/docs/events/gateway-events#message-reaction-remove-emoji">Message Reaction
  * Remove Emoji</a>
  */
-public class ReactionRemoveEmojiEvent extends MessageEvent {
-
-    private final long channelId;
-    private final long messageId;
-    @Nullable
-    private final Long guildId;
-    private final Emoji emoji;
+public class ReactionRemoveEmojiEvent extends ReactionBaseEmojiEvent {
 
     public ReactionRemoveEmojiEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, long messageId,
                                     @Nullable Long guildId, Emoji emoji) {
-        super(gateway, shardInfo);
-        this.channelId = channelId;
-        this.messageId = messageId;
-        this.guildId = guildId;
-        this.emoji = emoji;
-    }
-
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link MessageChannel} containing the {@link Message} the reaction
-     * was removed from.
-     *
-     * @return The ID of the {@link MessageChannel} involved.
-     */
-    public Snowflake getChannelId() {
-        return Snowflake.of(channelId);
-    }
-
-    /**
-     * Requests to retrieve the {@link MessageChannel} containing the {@link Message} the reaction was removed from.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing the
-     * {@link Message} involved. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<MessageChannel> getChannel() {
-        return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Message} the reaction was removed from.
-     *
-     * @return The ID of the {@link Message} involved.
-     */
-    public Snowflake getMessageId() {
-        return Snowflake.of(messageId);
-    }
-
-    /**
-     * Requests to retrieve the {@link Message} the reaction was removed from.
-     *
-     * @return A {@link Mono} where, upon completion, emits the {@link Message} the reaction was removed from.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Message> getMessage() {
-        return getClient().getMessageById(getChannelId(), getMessageId());
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Message} involved is in, if present.
-     * This may not be available if the {@code Message} was sent in a private channel.
-     *
-     * @return The ID of the {@link Guild} involved, if present.
-     */
-    public Optional<Snowflake> getGuildId() {
-        return Optional.ofNullable(guildId).map(Snowflake::of);
-    }
-
-    /**
-     * Requests to retrieve the {@link Guild} the {@link Message} involved is in, if present.
-     * This may not be available if the {@code Message} was sent in a private channel.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the
-     * {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Guild> getGuild() {
-        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
-    }
-
-    /**
-     * The {@link Emoji} that was removed from a message.
-     *
-     * @return The {@code Emoji} that has been removed.
-     */
-    public Emoji getEmoji() {
-        return emoji;
+        super(gateway, shardInfo, channelId, messageId, guildId, emoji);
     }
 
     @Override
     public String toString() {
         return "ReactionRemoveEvent{" +
-                "channelId=" + channelId +
-                ", messageId=" + messageId +
-                ", guildId=" + guildId +
-                ", emoji=" + emoji +
-                '}';
+            "} " + super.toString();
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionRemoveEvent.java
@@ -17,166 +17,31 @@
 package discord4j.core.event.domain.message;
 
 import discord4j.core.GatewayDiscordClient;
-import discord4j.core.object.entity.Guild;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.User;
-import discord4j.core.object.entity.channel.MessageChannel;
-import discord4j.core.object.reaction.Reaction;
 import discord4j.core.object.emoji.Emoji;
-import discord4j.common.util.Snowflake;
 import discord4j.gateway.ShardInfo;
-import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
-import java.util.Optional;
-
 /**
- * Dispatched when a reaction is removed on a message.
+ * Dispatched when a reaction is removed from a message.
  * <p>
- * {@link #guildId} may not be present if the message was in a private channel.
+ * {@link #getGuildId()} may not be present if the message was in a private channel.
  * <p>
  * This event is dispatched by Discord.
  *
- * @see <a href="https://discord.com/developers/docs/topics/gateway#message-reaction-remove">Message Reaction
+ * @see <a href="https://discord.com/developers/docs/events/gateway-events#message-reaction-remove">Message Reaction
  * Remove</a>
  */
-public class ReactionRemoveEvent extends MessageEvent {
+public class ReactionRemoveEvent extends ReactionUserEmojiEvent {
 
-    private final long userId;
-    private final long channelId;
-    private final long messageId;
-    @Nullable
-    private final Long guildId;
-    private final Emoji emoji;
-    private final boolean burst;
-    private final int type;
-
-    public ReactionRemoveEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long userId, long channelId, long messageId,
+    public ReactionRemoveEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long userId, long channelId,
+                               long messageId,
                                @Nullable Long guildId, Emoji emoji, boolean burst, int type) {
-        super(gateway, shardInfo);
-        this.userId = userId;
-        this.channelId = channelId;
-        this.messageId = messageId;
-        this.guildId = guildId;
-        this.emoji = emoji;
-        this.burst = burst;
-        this.type = type;
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link User} who's reaction has been removed.
-     *
-     * @return The ID of the {@link User} who's reaction has been removed.
-     */
-    public Snowflake getUserId() {
-        return Snowflake.of(userId);
-    }
-
-    /**
-     * Requests to retrieve the {@link User} who's reaction has been removed.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link User} who's reaction has been removed.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<User> getUser() {
-        return getClient().getUserById(getUserId());
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link MessageChannel} containing the {@link Message} the reaction
-     * was removed from.
-     *
-     * @return The ID of the {@link MessageChannel} involved.
-     */
-    public Snowflake getChannelId() {
-        return Snowflake.of(channelId);
-    }
-
-    /**
-     * Requests to retrieve the {@link MessageChannel} containing the {@link Message} the reaction was removed from.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link MessageChannel} containing the
-     * {@link Message} involved. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<MessageChannel> getChannel() {
-        return getClient().getChannelById(getChannelId()).cast(MessageChannel.class);
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Message} the reaction was removed from.
-     *
-     * @return The ID of the {@link Message} involved.
-     */
-    public Snowflake getMessageId() {
-        return Snowflake.of(messageId);
-    }
-
-    /**
-     * Requests to retrieve the {@link Message} the reaction was removed from.
-     *
-     * @return A {@link Mono} where, upon completion, emits the {@link Message} the reaction was removed from.
-     * If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Message> getMessage() {
-        return getClient().getMessageById(getChannelId(), getMessageId());
-    }
-
-    /**
-     * Gets the {@link Snowflake} ID of the {@link Guild} the {@link Message} involved is in, if present.
-     * This may not be available if the {@code Message} was sent in a private channel.
-     *
-     * @return The ID of the {@link Guild} involved, if present.
-     */
-    public Optional<Snowflake> getGuildId() {
-        return Optional.ofNullable(guildId).map(Snowflake::of);
-    }
-
-    /**
-     * Requests to retrieve the {@link Guild} the {@link Message} involved is in, if present.
-     * This may not be available if the {@code Message} was sent in a private channel.
-     *
-     * @return A {@link Mono} where, upon successful completion, emits the {@link Guild} containing the
-     * {@link Message} involved, if present. If an error is received, it is emitted through the {@code Mono}.
-     */
-    public Mono<Guild> getGuild() {
-        return Mono.justOrEmpty(getGuildId()).flatMap(getClient()::getGuildById);
-    }
-
-    /**
-     * The {@link Emoji} that was removed from a message.
-     *
-     * @return The {@code Emoji} that has been removed.
-     */
-    public Emoji getEmoji() {
-        return emoji;
-    }
-
-    /**
-     * Gets whether the reaction related to this event is "Super".
-     *
-     * @return Whether the reaction related to this event is "Super".
-     */
-    public boolean isSuperReaction() {
-        return this.burst;
-    }
-
-    /**
-     * Gets the {@link Reaction.Type} of the reaction.
-     *
-     * @return A {@link Reaction.Type}
-     */
-    public Reaction.Type getType() {
-        return Reaction.Type.of(this.type);
+        super(gateway, shardInfo, channelId, messageId, guildId, emoji, userId, burst, type);
     }
 
     @Override
     public String toString() {
         return "ReactionRemoveEvent{" +
-                "userId=" + userId +
-                ", channelId=" + channelId +
-                ", messageId=" + messageId +
-                ", guildId=" + guildId +
-                ", emoji=" + emoji +
-                '}';
+            "} " + super.toString();
     }
 }

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionUserEmojiEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionUserEmojiEvent.java
@@ -28,7 +28,7 @@ import reactor.util.annotation.Nullable;
 /**
  * Represents an event related to a {@link discord4j.core.object.reaction.Reaction} with a user and more data of the reaction.
  */
-public class ReactionUserEmojiEvent extends ReactionBaseEmojiEvent {
+public abstract class ReactionUserEmojiEvent extends ReactionBaseEmojiEvent {
 
     private final long userId;
     private final boolean burst;

--- a/core/src/main/java/discord4j/core/event/domain/message/ReactionUserEmojiEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/message/ReactionUserEmojiEvent.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.event.domain.message;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.object.emoji.Emoji;
+import discord4j.core.object.entity.User;
+import discord4j.core.object.reaction.Reaction;
+import discord4j.gateway.ShardInfo;
+import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Represents an event related to a {@link discord4j.core.object.reaction.Reaction} with a user and more data of the reaction.
+ */
+public class ReactionUserEmojiEvent extends ReactionBaseEmojiEvent {
+
+    private final long userId;
+    private final boolean burst;
+    private final int type;
+
+    public ReactionUserEmojiEvent(GatewayDiscordClient gateway, ShardInfo shardInfo, long channelId, long messageId, @Nullable Long guildId, Emoji emoji, long userId, boolean burst, int type) {
+        super(gateway, shardInfo, channelId, messageId, guildId, emoji);
+        this.userId = userId;
+        this.burst = burst;
+        this.type = type;
+    }
+
+    /**
+     * Gets the {@link Snowflake} ID of the {@link User} related to this event.
+     *
+     * @return The Id of the {@link User} related to this reaction.
+     */
+    public Snowflake getUserId() {
+        return Snowflake.of(userId);
+    }
+
+    /**
+     * Requests to retrieve the {@link User} related to this event.
+     *
+     * @return A {@link Mono} where, upon successful completion, emits the {@link User} related to the reaction.
+     * If an error is received, it is emitted through the {@code Mono}.
+     */
+    public Mono<User> getUser() {
+        return getClient().getUserById(getUserId());
+    }
+
+    /**
+     * Gets whether the reaction related to this event is "Super".
+     *
+     * @return Whether the reaction related to this event is "Super".
+     */
+    public boolean isSuperReaction() {
+        return this.burst;
+    }
+
+    /**
+     * Gets the {@link Reaction.Type} of the reaction.
+     *
+     * @return A {@link Reaction.Type}
+     */
+    public Reaction.Type getType() {
+        return Reaction.Type.of(this.type);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionUserEmojiEvent{" +
+            "userId=" + userId +
+            ", burst=" + burst +
+            ", type=" + type +
+            "} " + super.toString();
+    }
+}


### PR DESCRIPTION
**Description:** Add abstract methods for the Reaction Events for allow more generic in the use of them

**Justification:** Close https://github.com/Discord4J/Discord4J/issues/1306
