### PR TITLE
fix: onboarding prompt option emoji name can be null

### DIFF
--- a/core/src/main/java/discord4j/core/object/onboarding/OnboardingPromptOption.java
+++ b/core/src/main/java/discord4j/core/object/onboarding/OnboardingPromptOption.java
@@ -37,7 +37,7 @@ public class OnboardingPromptOption implements Entity {
                 .map(Snowflake::of)
                 .collect(Collectors.toList());
 
-        this.emoji = data.emoji().toOptional().map(Emoji::of).orElse(null);
+        this.emoji = data.emoji().toOptional().filter(emoji -> emoji.name().isPresent()).map(Emoji::of).orElse(null);
     }
 
     /**


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->
filter emoji if name is not set to prevent IllegalArgumentException

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->
fixes #1311 