### PR TITLE
Fix AllowedMentions usage when starting a thread

### DIFF
--- a/core/src/main/java/discord4j/core/spec/ForumThreadMessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/ForumThreadMessageCreateSpecGenerator.java
@@ -21,7 +21,7 @@ public interface ForumThreadMessageCreateSpecGenerator extends Spec<ForumThreadM
 
     Possible<List<EmbedCreateSpec>> embeds();
 
-    Possible<List<AllowedMentions>> allowedMentions();
+    Possible<AllowedMentions> allowedMentions();
 
     Possible<List<MessageComponent>> components();
 
@@ -33,7 +33,7 @@ public interface ForumThreadMessageCreateSpecGenerator extends Spec<ForumThreadM
 
         return builder.content(content())
             .embeds(mapPossible(embeds(), list -> list.stream().map(EmbedCreateSpec::asRequest).collect(Collectors.toList())))
-            .allowedMentions(mapPossible(allowedMentions(), list -> list.stream().map(AllowedMentions::toData).collect(Collectors.toList())))
+            .allowedMentions(mapPossible(allowedMentions(), AllowedMentions::toData))
             .components(mapPossible(components(), list -> list.stream().map(MessageComponent::getData).collect(Collectors.toList())))
             .stickerIds(mapPossible(stickerIds(), list -> list.stream().map(snowflake -> Id.of(snowflake.asLong())).collect(Collectors.toList())))
             .build();


### PR DESCRIPTION
**Description** : ForumThreadMessageCreateSpec is now accepting only one AllowedMentions object instead of an array.

**Justification** : This fixes the issue #1314.

This fix requires discord-json PR 205 to be merged : https://github.com/Discord4J/discord-json/pull/205
The CI build won't pass because of this.

There is a small API change within the ForumThreadMessageCreateSpec due to this fix, here is a proposal for the changelog line : 

`* Fixed ForumThreadMessageCreateSpec to correctly include AllowedMentions objects. It does now only accept one AllowedMentions object instead of a collection.`

### Testing

As always, I test my fix by publishing a snapshot on my Nexus repo.
You can test it on your side.

The repository is : 
```
maven {
   url 'https://nexus.klutometis.net/repository/maven-public'
}
``` 

And the dependency : 
```
implementation 'com.discord4j:discord4j-core:3.3.0-FIX-1314-20250803.182824-1'
```

It pulls a fixed discord-json dependency on the same Nexus repository.

When creating a new thread within a forum channel the payload is this time fixed (I'm in real testing conditions so I'm redacting a bit the logs) : 

```
2025-08-03 20:33:47:265 [reactor-http-epoll-4] TRACE DiscordWebClient - [B:f5804146, R:23f62a90] [request_prepared] POST{uri=/api/v10/channels/1401590389139312642/threads, connection=PooledConnection{channel=[id: 0x3885988a, L:/192.168.1.34:51430 - R:discord.com/162.159.128.233:443]}}
2025-08-03 20:33:47:268 [reactor-http-epoll-4] TRACE JacksonWriterStrategy - {"name":"Evil","message":{"attachments":[],"content":"From <@254370344268201986> : Testing evil @everyone","allowed_mentions":{"users":["254370344268201986"]}}}
-03 20:33:47:270 [reactor-http-epoll-4] TRACE DiscordWebClient - [B:f5804146, R:23f62a90] [request_sent] POST{uri=/api/v10/channels/1401590389139312642/threads, connection=PooledConnection{channel=[id: 0x3885988a, L:/192.168.1.34:51430 - R:discord.com/162.159.128.233:443]}}
2025-08-03 20:33:47:565 [reactor-http-epoll-3] TRACE receiver - [G:789779fb, S:0] {"t":"THREAD_CREATE","s":21,"op":0,"d":{"type":11,"total_message_sent":0,"thread_metadata":{"locked":false,"create_timestamp":"2025-08-03T18:33:47.388000+00:00","auto_archive_duration":4320,"archived":false,"archive_timestamp":"2025-08-03T18:33:47.388000+00:00"},"rate_limit_per_user":0,"parent_id":"1401590389139312642","owner_id":"828995103783125102","newly_created":true,"name":"Evil","message_count":0,"member_count":1,"last_message_id":null,"id":"1401634170655998064","guild_id":"828985959911653427","flags":0}}
```

We can see that the thread create gateway event has been received following our request.
