### PR TITLE
feat: Support File Upload and Resolved Data in Modals

### DIFF
--- a/core/src/main/java/discord4j/core/event/domain/interaction/ModalSubmitInteractionEvent.java
+++ b/core/src/main/java/discord4j/core/event/domain/interaction/ModalSubmitInteractionEvent.java
@@ -21,6 +21,7 @@ import discord4j.common.annotations.Experimental;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.command.ApplicationCommandInteraction;
+import discord4j.core.object.command.ApplicationCommandInteractionResolved;
 import discord4j.core.object.command.Interaction;
 import discord4j.core.object.component.ActionRow;
 import discord4j.core.object.component.Label;
@@ -31,6 +32,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -86,6 +88,15 @@ public class ModalSubmitInteractionEvent extends ComponentInteractionEvent {
         return getInteraction().getCommandInteraction()
                 .flatMap(ApplicationCommandInteraction::getCustomId)
                 .orElseThrow(IllegalStateException::new); // should always be present for modal submits
+    }
+
+    /**
+     * Gets the converted users + roles + channels + attachments.
+     *
+     * @return The converted users + roles + channels + attachments.
+     */
+    public Optional<ApplicationCommandInteractionResolved> getResolved() {
+        return getInteraction().getCommandInteraction().flatMap(ApplicationCommandInteraction::getResolved);
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteraction.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandInteraction.java
@@ -67,6 +67,10 @@ public class ApplicationCommandInteraction implements DiscordObject {
         this.guildId = guildId;
     }
 
+    public ApplicationCommandInteractionData getData() {
+        return data;
+    }
+
     /**
      * Gets	the id of the invoked command.
      *

--- a/core/src/main/java/discord4j/core/object/component/FileUpload.java
+++ b/core/src/main/java/discord4j/core/object/component/FileUpload.java
@@ -56,16 +56,16 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
     }
 
     /**
-     * Get this file upload's custom id if present
+     * Get this file upload's custom id.
      *
-     * @return An {@link Optional} containing the custom id if present
+     * @return A developer-defined custom id
      */
     public String getCustomId() {
         return getData().customId().toOptional().orElseThrow(IllegalStateException::new);
     }
 
     /**
-     * Gets the file upload values, if any. Can be present with an empty list if no elements was added.
+     * Gets the file upload values, if any. Can be present with an empty list if no elements were added.
      *
      * @return the file upload's values
      */
@@ -74,7 +74,7 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
     }
 
     /**
-     * Creates a new file upload with the same data as this one, but depending on the value param it may be
+     * Creates a new file upload with the same data as this one, but depending on the value param, it may be
      * required or not.
      *
      * @param value True if the component should be required otherwise False.

--- a/core/src/main/java/discord4j/core/object/component/FileUpload.java
+++ b/core/src/main/java/discord4j/core/object/component/FileUpload.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.object.component;
+
+import discord4j.common.util.Snowflake;
+import discord4j.discordjson.json.ComponentData;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A File Upload component for modals.
+ *
+ * @see <a href="https://discord.com/developers/docs/components/reference#file-upload">File Upload</a>
+ */
+public class FileUpload extends MessageComponent implements ICanBeUsedInLabelComponent {
+
+    /**
+     * Creates a {@link FileUpload}.
+     *
+     * @param customId A developer-defined identifier
+     * @return A {@link FileUpload}
+     */
+    public static FileUpload of(String customId) {
+        return new FileUpload(MessageComponent.getBuilder(Type.FILE_UPLOAD).customId(customId).build());
+    }
+
+    /**
+     * Creates a {@link FileUpload}.
+     *
+     * @param customId A developer-defined identifier
+     * @param id the component id
+     * @return A {@link FileUpload}
+     */
+    public static FileUpload of(String customId, int id) {
+        return new FileUpload(MessageComponent.getBuilder(Type.FILE_UPLOAD).id(id).customId(customId).build());
+    }
+
+    FileUpload(ComponentData data) {
+        super(data);
+    }
+
+    /**
+     * Get this file upload's custom id if present
+     *
+     * @return An {@link Optional} containing the custom id if present
+     */
+    public String getCustomId() {
+        return getData().customId().toOptional().orElseThrow(IllegalStateException::new);
+    }
+
+    /**
+     * Gets the file upload values, if any. Can be present with an empty list if no elements was added.
+     *
+     * @return the file upload's values
+     */
+    public Optional<List<Snowflake>> getValues() {
+        return getData().values().toOptional().map(strings -> strings.stream().map(Snowflake::of).collect(Collectors.toList()));
+    }
+
+    /**
+     * Creates a new file upload with the same data as this one, but depending on the value param it may be
+     * required or not.
+     *
+     * @param value True if the component should be required otherwise False.
+     * @return A new possibly required select menu with the same data as this one.
+     */
+    public FileUpload required(boolean value) {
+        return new FileUpload(ComponentData.builder().from(this.getData()).required(value).build());
+    }
+
+    /**
+     * Creates a new file upload with the same data as this one, but with the given minimum values.
+     *
+     * @param minValues The new minimum values (0-10)
+     * @return A new file upload with the given minimum values.
+     */
+    public FileUpload withMinValues(int minValues) {
+        return new FileUpload(ComponentData.builder().from(getData()).minValues(minValues).build());
+    }
+
+    /**
+     * Creates a new file upload with the same data as this one, but with the given maximum values.
+     *
+     * @param maxValues The new maximum values (1-10)
+     * @return A new file upload with the given maximum values.
+     */
+    public FileUpload withMaxValues(int maxValues) {
+        return new FileUpload(ComponentData.builder().from(getData()).maxValues(maxValues).build());
+    }
+}

--- a/core/src/main/java/discord4j/core/object/component/FileUpload.java
+++ b/core/src/main/java/discord4j/core/object/component/FileUpload.java
@@ -61,7 +61,7 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
      * @return A developer-defined custom id
      */
     public String getCustomId() {
-        return getData().customId().toOptional().orElseThrow(IllegalStateException::new);
+        return this.getData().customId().toOptional().orElseThrow(IllegalStateException::new);
     }
 
     /**
@@ -70,7 +70,7 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
      * @return the file upload's values
      */
     public Optional<List<Snowflake>> getValues() {
-        return getData().values().toOptional().map(strings -> strings.stream().map(Snowflake::of).collect(Collectors.toList()));
+        return this.getData().values().toOptional().map(strings -> strings.stream().map(Snowflake::of).collect(Collectors.toList()));
     }
 
     /**
@@ -91,7 +91,7 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
      * @return A new file upload with the given minimum values.
      */
     public FileUpload withMinValues(int minValues) {
-        return new FileUpload(ComponentData.builder().from(getData()).minValues(minValues).build());
+        return new FileUpload(ComponentData.builder().from(this.getData()).minValues(minValues).build());
     }
 
     /**
@@ -101,6 +101,6 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
      * @return A new file upload with the given maximum values.
      */
     public FileUpload withMaxValues(int maxValues) {
-        return new FileUpload(ComponentData.builder().from(getData()).maxValues(maxValues).build());
+        return new FileUpload(ComponentData.builder().from(this.getData()).maxValues(maxValues).build());
     }
 }

--- a/core/src/main/java/discord4j/core/object/component/MessageComponent.java
+++ b/core/src/main/java/discord4j/core/object/component/MessageComponent.java
@@ -61,6 +61,7 @@ public class MessageComponent implements BaseMessageComponent {
             case SELECT_MENU_STRING: return new StringSelectMenu(data);
             case TEXT_INPUT: return new TextInput(data);
             case LABEL: return new Label(data);
+            case FILE_UPLOAD: return new FileUpload(data);
             default: {
                 MessageComponent.LOGGER.warn("Unhandled component type: " + data.type());
                 return new MessageComponent(data);
@@ -122,6 +123,7 @@ public class MessageComponent implements BaseMessageComponent {
         SEPARATOR(14, true),
         CONTAINER(17, true),
         LABEL(18),
+        FILE_UPLOAD(19),
         ;
 
         /**
@@ -173,6 +175,7 @@ public class MessageComponent implements BaseMessageComponent {
                 case 14: return SEPARATOR;
                 case 17: return CONTAINER;
                 case 18: return LABEL;
+                case 19: return FILE_UPLOAD;
                 default: return UNKNOWN;
             }
         }


### PR DESCRIPTION
**Description:** This PR add support for file uploads in modals and also add in ModalSubmitInteractionEvent a method for get the resolved data (works like the same than other interactions but the IDs need to be get from the values in the components supported)

**Justification:** Components V2 Phase 3
