### PR TITLE
fix: Missing public modifier for `UnfurledMediaItem.LoadingState`

### DIFF
--- a/core/src/main/java/discord4j/core/object/component/UnfurledMediaItem.java
+++ b/core/src/main/java/discord4j/core/object/component/UnfurledMediaItem.java
@@ -138,7 +138,7 @@ public class UnfurledMediaItem {
         return Possible.flatOpt(this.getData().loadingState()).map(LoadingState::of);
     }
 
-    enum LoadingState {
+    public enum LoadingState {
         UNKNOWN(0),
         LOADING(1),
         LOADED_SUCCESS(2),


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->
Since `#getLoadingState()` is already defined in the class, it should probably be public, or not? The `loading_state` is still not described in docs

Should I rebase onto 3.2.x to backport changes?