### PR TITLE
fix: Role colors are Possible-Optional for role create or edit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.3.0-SNAPSHOT
-discordJsonVersion=1.7.18
+discordJsonVersion=1.7.19
 storesVersion=3.2.3


### PR DESCRIPTION
**Description:** This fix the issue where the colors in Role are Possible and Optional when create or edit a role, this require a change in the discord-json side for allow that behaviour. The tests was:
- Create a role with just name
- Create a role with just the secondaryColor
- Create a role with just primaryColor (with 0, null, value)
- Edit a role with just name
- Edit a role with just the secondaryColor
- Edit a role with just the primaryColor (with 0, null, value)

**Justification:** Closes https://github.com/Discord4J/Discord4J/issues/1331
