### PR TITLE
Fix #1334 Edit specs crash on asRequest() when explicitly setting flags or components to null

### DIFF
--- a/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
@@ -71,7 +71,12 @@ interface InteractionReplyEditSpecGenerator extends Spec<MultipartRequest<Webhoo
 
     @Override
     default MultipartRequest<WebhookMessageEditRequest> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(null, Possible.absent(), this.suppressEmbeds(), this.components().map(Optional::get));
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(
+            null,
+            Possible.absent(),
+            this.suppressEmbeds(),
+            Possible.ofNullable(Possible.flatOpt(this.components()).orElse(null))
+        );
 
         WebhookMessageEditRequest json = WebhookMessageEditRequest.builder()
             .content(content())

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -65,7 +65,12 @@ interface MessageEditSpecGenerator extends Spec<MultipartRequest<MessageEditRequ
 
     @Override
     default MultipartRequest<MessageEditRequest> asRequest() {
-        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(this.flags().map(Optional::get).toOptional().orElse(null), Possible.absent(), Possible.absent(), this.components().map(Optional::get));
+        final Set<Message.Flag> flagsToApply = InternalMessageSpecUtils.decorateFlags(
+            Possible.flatOpt(this.flags()).orElse(null),
+            Possible.absent(),
+            Possible.absent(),
+            Possible.ofNullable(Possible.flatOpt(this.components()).orElse(null))
+        );
 
         MessageEditRequest json = MessageEditRequest.builder()
             .content(content())


### PR DESCRIPTION
<!--
YOUR PULL REQUEST MAY BE CLOSED IF YOU DO NOT FOLLOW THIS TEMPLATE

Consider searching for similar pull requests before submitting yours.

Make sure you select the proper base branch. Latest development is tracked on `master` branch,
but if other supported branches might also benefit from this change, pick the oldest relevant
branch: `3.1.x` or `3.2.x`
-->

**Description:** <!-- A description of the changes made in this pull request. -->

Replace blind `Optional::get` calls with `Possible.flatOpt(..)` in the `asRequest()` method of `MessageEditSpec` and `InteractionReplyEditSpec`

**Justification:** <!-- Justify the changes you are making. If applicable, reference issues fixed by your changes. -->

Fixes #1334

Branch 3.2.x is also affected as it was introduced by #1305 targeting 3.2.x as well. 
