### PR TITLE
refactor: avoid Component double inheritance

### DIFF
--- a/core/src/main/java/discord4j/core/object/component/Container.java
+++ b/core/src/main/java/discord4j/core/object/component/Container.java
@@ -96,7 +96,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components The child components of the container.
      * @return A {@link Container} containing the given components.
      */
-    public static Container of(List<ICanBeUsedInContainerComponent> components) {
+    public static Container of(List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(null, null, false, components);
     }
 
@@ -107,7 +107,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components The child components of the container.
      * @return A {@link Container} containing the given components.
      */
-    public static Container of(boolean spoiler, List<ICanBeUsedInContainerComponent> components) {
+    public static Container of(boolean spoiler, List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(null, null, spoiler, components);
     }
 
@@ -118,7 +118,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components The components of the container.
      * @return A {@link Container} containing the given components.
      */
-    public static Container of(@Nullable Color color, List<ICanBeUsedInContainerComponent> components) {
+    public static Container of(@Nullable Color color, List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(null, color, false, components);
     }
 
@@ -131,7 +131,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @return A {@link Container} containing the given components.
      */
     public static Container of(@Nullable Color color, boolean spoiler,
-                               List<ICanBeUsedInContainerComponent> components) {
+                               List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(null, color, spoiler, components);
     }
 
@@ -191,7 +191,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components The child components of the container.
      * @return A {@link Container} containing the given components.
      */
-    public static Container of(int id, List<ICanBeUsedInContainerComponent> components) {
+    public static Container of(int id, List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(id, null, false, components);
     }
 
@@ -203,7 +203,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components The components of the container.
      * @return A {@link Container} containing the given components.
      */
-    public static Container of(int id, @Nullable Color color, List<ICanBeUsedInContainerComponent> components) {
+    public static Container of(int id, @Nullable Color color, List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(id, color, false, components);
     }
 
@@ -215,7 +215,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components The components of the container.
      * @return A {@link Container} containing the given components.
      */
-    public static Container of(int id, boolean spoiler, List<ICanBeUsedInContainerComponent> components) {
+    public static Container of(int id, boolean spoiler, List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(id, null, spoiler, components);
     }
 
@@ -229,19 +229,19 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @return A {@link Container} containing the given components.
      */
     public static Container of(int id, @Nullable Color color, boolean spoiler,
-                               List<ICanBeUsedInContainerComponent> components) {
+                               List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(id, color, spoiler, components);
     }
 
     protected Container(@Nullable Integer id, @Nullable Color color, boolean spoiler,
-                        List<ICanBeUsedInContainerComponent> components) {
+                        List<? extends ICanBeUsedInContainerComponent> components) {
         this(
                 MessageComponent.getBuilder(Type.CONTAINER)
                         .id(Possible.ofNullable(id))
                         .spoiler(spoiler)
                         .components(components.stream()
                                 .filter(c -> c instanceof MessageComponent)
-                                .map(c -> ((MessageComponent) c).getData())
+                                .map(BaseMessageComponent::getData)
                                 .collect(Collectors.toList()))
                         .accentColor(Possible.of(Optional.ofNullable(color).map(Color::getRGB)))
                         .build()
@@ -291,7 +291,7 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * @param components the child components to be added
      * @return a {@link Container} containing the existing and added components
      */
-    public Container withAddedComponents(List<ICanBeUsedInContainerComponent> components) {
+    public Container withAddedComponents(List<? extends ICanBeUsedInContainerComponent> components) {
         return new Container(ComponentData.builder()
                 .from(this.getData())
                 .components(Stream.concat(getChildren().stream(), components.stream())

--- a/core/src/main/java/discord4j/core/object/component/Container.java
+++ b/core/src/main/java/discord4j/core/object/component/Container.java
@@ -50,51 +50,43 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * Creates a {@link Container} with the given components.
      *
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(C... components) {
+    public static Container of(ICanBeUsedInContainerComponent... components) {
         return new Container(null, null, false, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param color The accent color
+     * @param color      The accent color
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(@Nullable Color color, C... components) {
+    public static Container of(@Nullable Color color, ICanBeUsedInContainerComponent... components) {
         return new Container(null, color, false, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param spoiler If the container should be blurred
+     * @param spoiler    If the container should be blurred
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(boolean spoiler, C... components) {
+    public static Container of(boolean spoiler, ICanBeUsedInContainerComponent... components) {
         return new Container(null, null, spoiler, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param color The accent color
-     * @param spoiler If the container should be blurred
+     * @param color      The accent color
+     * @param spoiler    If the container should be blurred
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(@Nullable Color color, boolean spoiler, C... components) {
+    public static Container of(@Nullable Color color, boolean spoiler, ICanBeUsedInContainerComponent... components) {
         return new Container(null, color, spoiler, Arrays.asList(components));
     }
 
@@ -102,169 +94,157 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * Creates a {@link Container} with the given components.
      *
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(List<C> components) {
+    public static Container of(List<ICanBeUsedInContainerComponent> components) {
         return new Container(null, null, false, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param spoiler If the container should be blurred
+     * @param spoiler    If the container should be blurred
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(boolean spoiler, List<C> components) {
+    public static Container of(boolean spoiler, List<ICanBeUsedInContainerComponent> components) {
         return new Container(null, null, spoiler, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param color The accent color
+     * @param color      The accent color
      * @param components The components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(@Nullable Color color, List<C> components) {
+    public static Container of(@Nullable Color color, List<ICanBeUsedInContainerComponent> components) {
         return new Container(null, color, false, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param color The accent color
-     * @param spoiler If the container should be blurred
+     * @param color      The accent color
+     * @param spoiler    If the container should be blurred
      * @param components The components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(@Nullable Color color, boolean spoiler, List<C> components) {
+    public static Container of(@Nullable Color color, boolean spoiler,
+                               List<ICanBeUsedInContainerComponent> components) {
         return new Container(null, color, spoiler, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
+     * @param id         the component id
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(int id, C... components) {
+    public static Container of(int id, ICanBeUsedInContainerComponent... components) {
         return new Container(id, null, false, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
-     * @param spoiler If the container should be blurred
+     * @param id         the component id
+     * @param spoiler    If the container should be blurred
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(int id, boolean spoiler, C... components) {
+    public static Container of(int id, boolean spoiler, ICanBeUsedInContainerComponent... components) {
         return new Container(id, null, spoiler, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
-     * @param color The accent color
+     * @param id         the component id
+     * @param color      The accent color
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(int id, @Nullable Color color, C... components) {
+    public static Container of(int id, @Nullable Color color, ICanBeUsedInContainerComponent... components) {
         return new Container(id, color, false, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
-     * @param color The accent color
-     * @param spoiler If the container should be blurred
+     * @param id         the component id
+     * @param color      The accent color
+     * @param spoiler    If the container should be blurred
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInContainerComponent> Container of(int id, @Nullable Color color, boolean spoiler, C... components) {
+    public static Container of(int id, @Nullable Color color, boolean spoiler,
+                               ICanBeUsedInContainerComponent... components) {
         return new Container(id, color, spoiler, Arrays.asList(components));
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
+     * @param id         the component id
      * @param components The child components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(int id, List<C> components) {
+    public static Container of(int id, List<ICanBeUsedInContainerComponent> components) {
         return new Container(id, null, false, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
-     * @param color The accent color
+     * @param id         the component id
+     * @param color      The accent color
      * @param components The components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(int id, @Nullable Color color, List<C> components) {
+    public static Container of(int id, @Nullable Color color, List<ICanBeUsedInContainerComponent> components) {
         return new Container(id, color, false, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
-     * @param spoiler If the container should be blurred
+     * @param id         the component id
+     * @param spoiler    If the container should be blurred
      * @param components The components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(int id, boolean spoiler, List<C> components) {
+    public static Container of(int id, boolean spoiler, List<ICanBeUsedInContainerComponent> components) {
         return new Container(id, null, spoiler, components);
     }
 
     /**
      * Creates a {@link Container} with the given components.
      *
-     * @param id the component id
-     * @param color The accent color
-     * @param spoiler If the container should be blurred
+     * @param id         the component id
+     * @param color      The accent color
+     * @param spoiler    If the container should be blurred
      * @param components The components of the container.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return A {@link Container} containing the given components.
      */
-    public static <C extends ICanBeUsedInContainerComponent> Container of(int id, @Nullable Color color, boolean spoiler, List<C> components) {
+    public static Container of(int id, @Nullable Color color, boolean spoiler,
+                               List<ICanBeUsedInContainerComponent> components) {
         return new Container(id, color, spoiler, components);
     }
 
-    protected <C extends ICanBeUsedInContainerComponent> Container(@Nullable Integer id, @Nullable Color color, boolean spoiler, List<C> components) {
+    protected Container(@Nullable Integer id, @Nullable Color color, boolean spoiler,
+                        List<ICanBeUsedInContainerComponent> components) {
         this(
-            MessageComponent.getBuilder(Type.CONTAINER)
-                .id(Possible.ofNullable(id))
-                .spoiler(spoiler)
-                .components(components.stream()
-                    .filter(c -> c instanceof MessageComponent)
-                    .map(c -> ((MessageComponent) c).getData())
-                    .collect(Collectors.toList()))
-                .accentColor(Possible.of(Optional.ofNullable(color).map(Color::getRGB)))
-                .build()
+                MessageComponent.getBuilder(Type.CONTAINER)
+                        .id(Possible.ofNullable(id))
+                        .spoiler(spoiler)
+                        .components(components.stream()
+                                .filter(c -> c instanceof MessageComponent)
+                                .map(c -> ((MessageComponent) c).getData())
+                                .collect(Collectors.toList()))
+                        .accentColor(Possible.of(Optional.ofNullable(color).map(Color::getRGB)))
+                        .build()
         );
     }
 
@@ -276,44 +256,49 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      * Create a new {@link Container} instance from {@code this}, adding a given component.
      *
      * @param component the child component to be added
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
      * @return a {@link Container} containing the existing and added components
      */
-    public <C extends MessageComponent & ICanBeUsedInContainerComponent> Container withAddedComponent(C component) {
-        List<MessageComponent> components = new ArrayList<>(getChildren());
+    public Container withAddedComponent(ICanBeUsedInContainerComponent component) {
+        List<BaseMessageComponent> components = new ArrayList<>(getChildren());
         components.add(component);
-        return new Container(ComponentData.builder().from(this.getData()).components(components.stream().map(MessageComponent::getData).collect(Collectors.toList())).build());
-    }
-
-    /**
-     * Create a new {@link Container} instance from {@code this}, adding given components.
-     *
-     * @param components the child components to be added
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInContainerComponent}
-     * @return a {@link Container} containing the existing and added components
-     */
-    @SafeVarargs
-    public final <C extends MessageComponent & ICanBeUsedInContainerComponent> Container withAddedComponents(C... components) {
-        List<MessageComponent> componentsToAdd = new ArrayList<>(getChildren());
-        componentsToAdd.addAll(Arrays.asList(components));
-        return new Container(ComponentData.builder().from(this.getData()).components(componentsToAdd.stream().map(MessageComponent::getData).collect(Collectors.toList())).build());
-    }
-
-    /**
-     * Create a new {@link Container} instance from {@code this}, adding given components.
-     *
-     * @param components the child components to be added
-     * @param <C> The type of components to add, needs to be {@link ICanBeUsedInContainerComponent}
-     * @return a {@link Container} containing the existing and added components
-     */
-    public <C extends ICanBeUsedInContainerComponent> Container withAddedComponents(List<C> components) {
         return new Container(ComponentData.builder()
-            .from(this.getData())
-            .components(Stream.concat(getChildren().stream(), components.stream())
-                .filter(c -> c instanceof MessageComponent)
-                .map(c -> ((MessageComponent) c).getData())
-                .collect(Collectors.toList()))
-            .build());
+                .from(this.getData())
+                .components(components.stream()
+                        .map(BaseMessageComponent::getData)
+                        .collect(Collectors.toList()))
+                .build());
+    }
+
+    /**
+     * Create a new {@link Container} instance from {@code this}, adding given components.
+     *
+     * @param components the child components to be added
+     * @return a {@link Container} containing the existing and added components
+     */
+    public final Container withAddedComponents(ICanBeUsedInContainerComponent... components) {
+        List<BaseMessageComponent> componentsToAdd = new ArrayList<>(getChildren());
+        componentsToAdd.addAll(Arrays.asList(components));
+        return new Container(ComponentData.builder().from(this.getData())
+                .components(componentsToAdd.stream()
+                        .map(BaseMessageComponent::getData)
+                        .collect(Collectors.toList()))
+                .build());
+    }
+
+    /**
+     * Create a new {@link Container} instance from {@code this}, adding given components.
+     *
+     * @param components the child components to be added
+     * @return a {@link Container} containing the existing and added components
+     */
+    public Container withAddedComponents(List<ICanBeUsedInContainerComponent> components) {
+        return new Container(ComponentData.builder()
+                .from(this.getData())
+                .components(Stream.concat(getChildren().stream(), components.stream())
+                        .filter(c -> c instanceof MessageComponent)
+                        .map(BaseMessageComponent::getData)
+                        .collect(Collectors.toList()))
+                .build());
     }
 
     /**
@@ -327,9 +312,9 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
         components.removeIf(messageComponent -> componentId == messageComponent.getId());
 
         return new Container(ComponentData.builder()
-            .from(this.getData())
-            .components(components.stream().map(MessageComponent::getData).collect(Collectors.toList()))
-            .build());
+                .from(this.getData())
+                .components(components.stream().map(MessageComponent::getData).collect(Collectors.toList()))
+                .build());
     }
 
     /**
@@ -340,9 +325,9 @@ public class Container extends LayoutComponent implements TopLevelMessageCompone
      */
     public Container withColor(@Nullable Color color) {
         return new Container(ComponentData.builder()
-            .from(this.getData())
-            .accentColor(Possible.of(Optional.ofNullable(color).map(Color::getRGB)))
-            .build());
+                .from(this.getData())
+                .accentColor(Possible.of(Optional.ofNullable(color).map(Color::getRGB)))
+                .build());
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/component/ICanBeUsedInContainerComponent.java
+++ b/core/src/main/java/discord4j/core/object/component/ICanBeUsedInContainerComponent.java
@@ -20,5 +20,5 @@ package discord4j.core.object.component;
 /**
  * A special type of {@link MessageComponent} that can be used in a {@link Container}
  */
-public interface ICanBeUsedInContainerComponent {
+public interface ICanBeUsedInContainerComponent extends BaseMessageComponent {
 }

--- a/core/src/main/java/discord4j/core/object/component/ICanBeUsedInLabelComponent.java
+++ b/core/src/main/java/discord4j/core/object/component/ICanBeUsedInLabelComponent.java
@@ -20,5 +20,5 @@ package discord4j.core.object.component;
 /**
  * A special type of {@link ActionComponent} that can be used in a {@link Label}
  */
-public interface ICanBeUsedInLabelComponent {
+public interface ICanBeUsedInLabelComponent extends BaseMessageComponent {
 }

--- a/core/src/main/java/discord4j/core/object/component/ICanBeUsedInSectionComponent.java
+++ b/core/src/main/java/discord4j/core/object/component/ICanBeUsedInSectionComponent.java
@@ -20,5 +20,5 @@ package discord4j.core.object.component;
 /**
  * A special type of {@link MessageComponent} that can be used in a {@link Section}
  */
-public interface ICanBeUsedInSectionComponent {
+public interface ICanBeUsedInSectionComponent extends BaseMessageComponent {
 }

--- a/core/src/main/java/discord4j/core/object/component/Label.java
+++ b/core/src/main/java/discord4j/core/object/component/Label.java
@@ -33,7 +33,7 @@ public class Label extends LayoutComponent implements TopLevelModalComponent {
      * @return A {@link Label} containing the given components.
      */
     public static Label of(String label, ICanBeUsedInLabelComponent component) {
-        return new Label(label, null, component);
+        return new Label(null, label, null, component);
     }
 
     /**
@@ -44,14 +44,37 @@ public class Label extends LayoutComponent implements TopLevelModalComponent {
      * @return A {@link Label} containing the given components.
      */
     public static Label of(String label, String description, ICanBeUsedInLabelComponent component) {
-        return new Label(label, description, component);
+        return new Label(null, label, description, component);
     }
 
-    protected Label(String label, @Nullable String description, ICanBeUsedInLabelComponent component) {
+    /**
+     * Creates a {@link Label} with the given component.
+     *
+     * @param component The component of the label.
+     * @return A {@link Label} containing the given components.
+     */
+    public static Label of(int componentId, String label, ICanBeUsedInLabelComponent component) {
+        return new Label(componentId, label, null, component);
+    }
+
+    /**
+     * Creates a {@link Label} with the given component.
+     *
+     * @param component The component of the label.
+     * @param description The description of the label.
+     * @return A {@link Label} containing the given components.
+     */
+    public static Label of(int componentId, String label, String description, ICanBeUsedInLabelComponent component) {
+        return new Label(componentId, label, description, component);
+    }
+
+
+    protected Label(@Nullable Integer componentId, String label, @Nullable String description, ICanBeUsedInLabelComponent component) {
         this(
             MessageComponent.getBuilder(Type.LABEL)
+                .id(Possible.ofNullable(componentId))
                 .label(Possible.of(Optional.of(label)))
-                .component(((BaseMessageComponent) component).getData())
+                .component((component).getData())
                 .description(Possible.ofNullable(description).map(Optional::ofNullable))
                 .build()
         );
@@ -64,13 +87,13 @@ public class Label extends LayoutComponent implements TopLevelModalComponent {
     /**
      * Create a new {@link Label} instance from {@code this}, using a given component.
      *
-     * @param component the child component to be added
-     * @return an {@code Section} containing the existing and added components with an accessory
+     * @param component the child component to be replaced
+     * @return a {@link Label} containing the new component
      */
-    public Label withAddedComponent(ICanBeUsedInLabelComponent component) {
+    public Label withComponent(ICanBeUsedInLabelComponent component) {
         return new Label(ComponentData.builder()
             .from(getData())
-            .component(Possible.of(((BaseMessageComponent) component).getData()))
+            .component(Possible.of((component).getData()))
             .build());
     }
 

--- a/core/src/main/java/discord4j/core/object/component/Label.java
+++ b/core/src/main/java/discord4j/core/object/component/Label.java
@@ -30,10 +30,9 @@ public class Label extends LayoutComponent implements TopLevelModalComponent {
      * Creates a {@link Label} with the given component.
      *
      * @param component The component of the label.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInLabelComponent}
      * @return A {@link Label} containing the given components.
      */
-    public static <C extends MessageComponent & ICanBeUsedInLabelComponent> Label of(String label, C component) {
+    public static Label of(String label, ICanBeUsedInLabelComponent component) {
         return new Label(label, null, component);
     }
 
@@ -42,14 +41,13 @@ public class Label extends LayoutComponent implements TopLevelModalComponent {
      *
      * @param component The component of the label.
      * @param description The description of the label.
-     * @param <C> The type of component to add, needs to be a {@link ICanBeUsedInLabelComponent}
      * @return A {@link Label} containing the given components.
      */
-    public static <C extends MessageComponent & ICanBeUsedInLabelComponent> Label of(String label, String description, C component) {
+    public static Label of(String label, String description, ICanBeUsedInLabelComponent component) {
         return new Label(label, description, component);
     }
 
-    protected <C extends ICanBeUsedInLabelComponent> Label(String label, @Nullable String description, C component) {
+    protected Label(String label, @Nullable String description, ICanBeUsedInLabelComponent component) {
         this(
             MessageComponent.getBuilder(Type.LABEL)
                 .label(Possible.of(Optional.of(label)))

--- a/core/src/main/java/discord4j/core/object/component/Section.java
+++ b/core/src/main/java/discord4j/core/object/component/Section.java
@@ -56,7 +56,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param components The components of the section
      * @return A {@link Section} containing the given components
      */
-    public static Section of(IAccessoryComponent accessory, List<ICanBeUsedInSectionComponent> components) {
+    public static Section of(IAccessoryComponent accessory, List<? extends ICanBeUsedInSectionComponent> components) {
         return new Section(MessageComponent.getBuilder(Type.SECTION)
             .accessory(accessory.getData())
             .components(components.stream()
@@ -86,7 +86,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param components The components of the section
      * @return A {@link Section} containing the given components
      */
-    public static Section of(int id, IAccessoryComponent accessory, List<ICanBeUsedInSectionComponent> components) {
+    public static Section of(int id, IAccessoryComponent accessory, List<? extends ICanBeUsedInSectionComponent> components) {
         return new Section(MessageComponent.getBuilder(Type.SECTION)
             .id(id)
             .accessory(accessory.getData())
@@ -98,7 +98,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
     }
 
 
-    protected Section(Integer id, IAccessoryComponent accessory, List<ICanBeUsedInSectionComponent> components) {
+    protected Section(Integer id, IAccessoryComponent accessory, List<? extends ICanBeUsedInSectionComponent> components) {
         this(MessageComponent.getBuilder(Type.SECTION)
             .id(Possible.ofNullable(id))
             .accessory(accessory.getData())
@@ -166,7 +166,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param components the child components to be added
      * @return an {@code Section} containing the existing and added components with the current accessory
      */
-    public Section withAddedComponents(List<ICanBeUsedInSectionComponent> components) {
+    public Section withAddedComponents(List<? extends ICanBeUsedInSectionComponent> components) {
         return new Section(ComponentData.builder()
             .from(getData())
             .accessory(Possible.ofNullable(this.getData().accessory().toOptional().orElse(null)))

--- a/core/src/main/java/discord4j/core/object/component/Section.java
+++ b/core/src/main/java/discord4j/core/object/component/Section.java
@@ -43,11 +43,9 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      *
      * @param accessory The accessory component of the section
      * @param components The components of the section
-     * @param <C> The type of component, must implement {@link ICanBeUsedInSectionComponent}
      * @return A {@link Section} containing the given components
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInSectionComponent> Section of(IAccessoryComponent accessory, C... components) {
+    public static Section of(IAccessoryComponent accessory, ICanBeUsedInSectionComponent... components) {
         return of(accessory, Arrays.asList(components));
     }
 
@@ -56,10 +54,9 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      *
      * @param accessory The accessory component of the section
      * @param components The components of the section
-     * @param <C> The type of component, must implement {@link ICanBeUsedInSectionComponent}
      * @return A {@link Section} containing the given components
      */
-    public static <C extends ICanBeUsedInSectionComponent> Section of(IAccessoryComponent accessory, List<C> components) {
+    public static Section of(IAccessoryComponent accessory, List<ICanBeUsedInSectionComponent> components) {
         return new Section(MessageComponent.getBuilder(Type.SECTION)
             .accessory(accessory.getData())
             .components(components.stream()
@@ -75,11 +72,9 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param id the component id
      * @param accessory The accessory component of the section
      * @param components The components of the section
-     * @param <C> The type of component, must implement {@link ICanBeUsedInSectionComponent}
      * @return A {@link Section} containing the given components
      */
-    @SafeVarargs
-    public static <C extends MessageComponent & ICanBeUsedInSectionComponent> Section of(int id, IAccessoryComponent accessory, C... components) {
+    public static Section of(int id, IAccessoryComponent accessory, ICanBeUsedInSectionComponent... components) {
         return of(id, accessory, Arrays.asList(components));
     }
 
@@ -89,10 +84,9 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param id the component id
      * @param accessory The accessory component of the section
      * @param components The components of the section
-     * @param <C> The type of component, must implement {@link ICanBeUsedInSectionComponent}
      * @return A {@link Section} containing the given components
      */
-    public static <C extends ICanBeUsedInSectionComponent> Section of(int id, IAccessoryComponent accessory, List<C> components) {
+    public static Section of(int id, IAccessoryComponent accessory, List<ICanBeUsedInSectionComponent> components) {
         return new Section(MessageComponent.getBuilder(Type.SECTION)
             .id(id)
             .accessory(accessory.getData())
@@ -104,7 +98,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
     }
 
 
-    protected <C extends ICanBeUsedInSectionComponent> Section(Integer id, IAccessoryComponent accessory, List<C> components) {
+    protected Section(Integer id, IAccessoryComponent accessory, List<ICanBeUsedInSectionComponent> components) {
         this(MessageComponent.getBuilder(Type.SECTION)
             .id(Possible.ofNullable(id))
             .accessory(accessory.getData())
@@ -140,13 +134,13 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param component the child component to be added
      * @return an {@code Section} containing the existing and added components with the current accessory
      */
-    public <C extends MessageComponent & ICanBeUsedInSectionComponent> Section withAddedComponent(C component) {
-        List<MessageComponent> components = new ArrayList<>(getChildren());
+    public Section withAddedComponent(ICanBeUsedInSectionComponent component) {
+        List<BaseMessageComponent> components = new ArrayList<>(getChildren());
         components.add(component);
         return new Section(ComponentData.builder()
             .from(getData())
             .accessory(Possible.ofNullable(this.getData().accessory().toOptional().orElse(null)))
-            .components(components.stream().map(MessageComponent::getData).collect(Collectors.toList()))
+            .components(components.stream().map(BaseMessageComponent::getData).collect(Collectors.toList()))
             .build());
     }
 
@@ -156,14 +150,13 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param components the child components to be added
      * @return an {@code Section} containing the existing and added components with the current accessory
      */
-    @SafeVarargs
-    public final <C extends MessageComponent & ICanBeUsedInSectionComponent> Section withAddedComponents(C... components) {
-        List<MessageComponent> componentsToAdd = new ArrayList<>(getChildren());
+    public final Section withAddedComponents(ICanBeUsedInSectionComponent... components) {
+        List<BaseMessageComponent> componentsToAdd = new ArrayList<>(getChildren());
         componentsToAdd.addAll(Arrays.asList(components));
         return new Section(ComponentData.builder()
             .from(getData())
             .accessory(Possible.ofNullable(this.getData().accessory().toOptional().orElse(null)))
-            .components(componentsToAdd.stream().map(MessageComponent::getData).collect(Collectors.toList()))
+            .components(componentsToAdd.stream().map(BaseMessageComponent::getData).collect(Collectors.toList()))
             .build());
     }
 
@@ -173,7 +166,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param components the child components to be added
      * @return an {@code Section} containing the existing and added components with the current accessory
      */
-    public <C extends ICanBeUsedInSectionComponent> Section withAddedComponents(List<C> components) {
+    public Section withAddedComponents(List<ICanBeUsedInSectionComponent> components) {
         return new Section(ComponentData.builder()
             .from(getData())
             .accessory(Possible.ofNullable(this.getData().accessory().toOptional().orElse(null)))
@@ -190,7 +183,7 @@ public class Section extends LayoutComponent implements TopLevelMessageComponent
      * @param accessory the child component to be added
      * @return an {@code Section} containing the existing and added components with an accessory
      */
-    public Section withAddedAccessory(IAccessoryComponent accessory) {
+    public Section withAccessory(IAccessoryComponent accessory) {
         List<MessageComponent> components = new ArrayList<>(getChildren());
         return new Section(ComponentData.builder()
             .from(getData())


### PR DESCRIPTION
**Description:** 
- rework the components heritage to remove the double inheritance check on some methods
- fix some javadocs
- add some missing methods on Labels
- rename two methods (see below).

This also makes all the interfaces follow the same structure already present for `TopLevelModalComponent` or `TopLevelMessageComponent`.

This introduces two breaking changes:
- `Label#withAddedComponent` -> `Label#withComponent` (the component is replaced, not added)
- `Section#withAddedAccessory` -> `Section#withAccessory` (the accessory is replaced, not added)