### PR TITLE
chore: add dependabot auto-pr and gradle dependencies submission

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directories:
+        - "/"
+        - "common"
+        - "core"
+        - "gateway"
+        - "oauth2"
+        - "rest"
+        - "voice"
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependencies-submission.yml
+++ b/.github/workflows/dependencies-submission.yml
@@ -1,0 +1,26 @@
+name: Dependencies Submission
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  dependencies-submission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+          cache: 'gradle'
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v6


### PR DESCRIPTION
**Description:**
Adds dependabot and dependencies submission actions

**Justification:**
We currently do not monitor dependencies updates, and have a lot of CVEs in transitive dependencies that needs to be updated. These actions will allow to:
1. Automatically report current dependencies to the "Security and quality" feature of GitHub
2. Automatically open PRs for updates with dependabot

Note that I configured it to group all minor & patches versions together in one PR, it *shouldn't* break too much things.