### PR TITLE
feat: Support file types for Component and Command Options

### DIFF
--- a/core/src/main/java/discord4j/core/object/command/ApplicationCommandOption.java
+++ b/core/src/main/java/discord4j/core/object/command/ApplicationCommandOption.java
@@ -236,6 +236,15 @@ public class ApplicationCommandOption implements DiscordObject {
         return data.maxLength().toOptional();
     }
 
+    /**
+     * Returns the list of file types that this option accepts if {@link #getType()} is {@link Type#ATTACHMENT}.
+     *
+     * @return The list of file types that this option accepts, otherwise an empty list.
+     */
+    public List<String> getFileTypes() {
+        return data.fileTypes().toOptional().orElse(Collections.emptyList());
+    }
+
     @Override
     public GatewayDiscordClient getClient() {
         return gateway;

--- a/core/src/main/java/discord4j/core/object/component/FileUpload.java
+++ b/core/src/main/java/discord4j/core/object/component/FileUpload.java
@@ -19,6 +19,7 @@ package discord4j.core.object.component;
 import discord4j.common.util.Snowflake;
 import discord4j.discordjson.json.ComponentData;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -74,6 +75,15 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
     }
 
     /**
+     * Retrieves the list of allowed file types for the file upload component.
+     *
+     * @return A list of allowed file types. Returns an empty list if no file types are defined.
+     */
+    public List<String> getFileTypes() {
+        return this.getData().fileTypes().toOptional().orElse(Collections.emptyList());
+    }
+
+    /**
      * Creates a new file upload with the same data as this one, but depending on the value param, it may be
      * required or not.
      *
@@ -102,5 +112,15 @@ public class FileUpload extends MessageComponent implements ICanBeUsedInLabelCom
      */
     public FileUpload withMaxValues(int maxValues) {
         return new FileUpload(ComponentData.builder().from(this.getData()).maxValues(maxValues).build());
+    }
+
+    /**
+     * Creates a new file upload with the same data as this one, but with the given allowed file types.
+     *
+     * @param fileTypes The new allowed file types. (ex: image, .pdf)
+     * @return A new file upload with the given allowed file types.
+     */
+    public FileUpload withFileTypes(final List<String> fileTypes) {
+        return new FileUpload(ComponentData.builder().from(this.getData()).fileTypes(fileTypes).build());
     }
 }

--- a/core/src/test/java/discord4j/core/ExampleModal.java
+++ b/core/src/test/java/discord4j/core/ExampleModal.java
@@ -86,7 +86,7 @@ public class ExampleModal {
                                     SelectMenu.Option.of("Poetry", "Poetry")
                                 ))),
                                 Label.of("Attach the author", SelectMenu.ofUser(SELECT_USER_CUSTOM_ID)),
-                                Label.of("Add a thumbnail", FileUpload.of(FILE_UPLOAD_CUSTOM_ID).required(true))
+                                Label.of("Add a thumbnail", FileUpload.of(FILE_UPLOAD_CUSTOM_ID).withFileTypes(Collections.singletonList("image")).required(true))
                             ))
                             .build());
                     }


### PR DESCRIPTION
**Description:** Discord allow set type of files or extensions allowed to components and slash command options, this PR handle that.

need discord-json release of https://github.com/Discord4J/discord-json/pull/222