### PR TITLE
feat: support mark File as spoiler with field

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Attachment.java
+++ b/core/src/main/java/discord4j/core/object/entity/Attachment.java
@@ -35,7 +35,13 @@ import java.util.OptionalInt;
  */
 public final class Attachment implements Entity {
 
-    /** The prefix of the name of files which are displayed as spoilers. **/
+    /**
+     * The prefix of the name of files which are displayed as spoilers.
+     *
+     * @deprecated Discord now uses {@code Attachment.AttachmentFlags#IS_SPOILER} flag on the attachment object instead.
+     * The {@code SPOILER_} prefix still marks a file as spoiler, but not all spoilered attachments use it.
+     **/
+    @Deprecated
     public static final String SPOILER_PREFIX = "SPOILER_";
 
     /** The gateway associated to this object. */
@@ -57,12 +63,12 @@ public final class Attachment implements Entity {
 
     @Override
     public GatewayDiscordClient getClient() {
-        return gateway;
+        return this.gateway;
     }
 
     @Override
     public Snowflake getId() {
-        return Snowflake.of(data.id());
+        return Snowflake.of(this.getData().id());
     }
 
     /**
@@ -71,7 +77,7 @@ public final class Attachment implements Entity {
      * @return The data of the attachment.
      */
     public AttachmentData getData() {
-        return data;
+        return this.data;
     }
 
     /**
@@ -80,7 +86,25 @@ public final class Attachment implements Entity {
      * @return The name of the file attached.
      */
     public String getFilename() {
-        return data.filename();
+        return this.getData().filename();
+    }
+
+    /**
+     * Gets the title of the file attached, if present.
+     *
+     * @return The title of the file attached, if present.
+     */
+    public Optional<String> getTitle() {
+        return this.getData().title().toOptional();
+    }
+
+    /**
+     * Gets the description of the file attached, if present.
+     *
+     * @return The description of the file attached, if present.
+     */
+    public Optional<String> getDescription() {
+        return this.getData().description().toOptional();
     }
 
     /**
@@ -89,7 +113,7 @@ public final class Attachment implements Entity {
      * @return The size of the file in bytes.
      */
     public int getSize() {
-        return data.size();
+        return this.getData().size();
     }
 
     /**
@@ -98,7 +122,7 @@ public final class Attachment implements Entity {
      * @return The source URL of the file.
      */
     public String getUrl() {
-        return data.url();
+        return this.getData().url();
     }
 
     /**
@@ -107,7 +131,7 @@ public final class Attachment implements Entity {
      * @return A proxied URL of the file.
      */
     public String getProxyUrl() {
-        return data.proxyUrl();
+        return this.getData().proxyUrl();
     }
 
     /**
@@ -116,7 +140,7 @@ public final class Attachment implements Entity {
      * @return The height of the file, if present.
      */
     public OptionalInt getHeight() {
-        return Possible.flatOpt(data.height())
+        return Possible.flatOpt(this.getData().height())
             .map(OptionalInt::of)
             .orElse(OptionalInt.empty());
     }
@@ -127,7 +151,7 @@ public final class Attachment implements Entity {
      * @return The width of the file, if present.
      */
     public OptionalInt getWidth() {
-        return Possible.flatOpt(data.width())
+        return Possible.flatOpt(this.getData().width())
             .map(OptionalInt::of)
             .orElse(OptionalInt.empty());
     }
@@ -138,7 +162,7 @@ public final class Attachment implements Entity {
      * @return {@code true} if the attachment is a spoiler, {@code false} otherwise.
      */
     public boolean isSpoiler() {
-        return getFilename().startsWith(SPOILER_PREFIX);
+        return this.getFlags().contains(AttachmentFlags.IS_SPOILER);
     }
 
     /**
@@ -147,7 +171,7 @@ public final class Attachment implements Entity {
      * @return The attachment's media type, if present.
      */
     public Optional<String> getContentType() {
-        return data.contentType().toOptional();
+        return this.getData().contentType().toOptional();
     }
 
     /**
@@ -157,7 +181,7 @@ public final class Attachment implements Entity {
      * @return The attachment's duration in seconds, if present.
      */
     public Optional<Float> getDurationSeconds() {
-        return data.durationSeconds().toOptional();
+        return this.getData().durationSeconds().toOptional();
     }
 
     /**
@@ -167,7 +191,7 @@ public final class Attachment implements Entity {
      * @return A base64 encoded bytearray representing a sampled waveform, if present.
      */
     public Optional<String> getWaveform() {
-        return data.waveform().toOptional();
+        return this.getData().waveform().toOptional();
     }
 
     /**
@@ -176,7 +200,7 @@ public final class Attachment implements Entity {
      * @return A {@code EnumSet} with the flags of the attachment.
      */
     public EnumSet<AttachmentFlags> getFlags() {
-        return AttachmentFlags.of(data.flags().toOptional().orElse(0));
+        return AttachmentFlags.of(this.getData().flags().toOptional().orElse(0));
     }
 
     @Override
@@ -192,7 +216,7 @@ public final class Attachment implements Entity {
     @Override
     public String toString() {
         return "Attachment{" +
-                "data=" + data +
+                "data=" + this.data +
                 '}';
     }
 
@@ -258,8 +282,8 @@ public final class Attachment implements Entity {
         public static EnumSet<AttachmentFlags> of(final int value) {
             final EnumSet<AttachmentFlags> flags = EnumSet.noneOf(AttachmentFlags.class);
 
-            for (AttachmentFlags flag : AttachmentFlags.values()) {
-                long flagValue = flag.getValue();
+            for (final AttachmentFlags flag : AttachmentFlags.values()) {
+                final long flagValue = flag.getValue();
 
                 if ((flagValue & value) == flagValue) {
                     flags.add(flag);

--- a/core/src/main/java/discord4j/core/object/entity/Attachment.java
+++ b/core/src/main/java/discord4j/core/object/entity/Attachment.java
@@ -108,6 +108,19 @@ public final class Attachment implements Entity {
     }
 
     /**
+     * Create a copy of this attachment with the given description.
+     *
+     * @param description The new description of the attachment, if present.
+     * @return A copy of this attachment with the given description.
+     */
+    public Attachment withDescription(@Nullable String description) {
+        return new Attachment(this.gateway, AttachmentData.builder()
+                .from(this.getData())
+                .description(Possible.ofNullable(description))
+                .build());
+    }
+
+    /**
      * Gets the size of the file in bytes.
      *
      * @return The size of the file in bytes.
@@ -163,6 +176,19 @@ public final class Attachment implements Entity {
      */
     public boolean isSpoiler() {
         return this.getFlags().contains(AttachmentFlags.IS_SPOILER);
+    }
+
+    /**
+     * Create a copy of this attachment with the given spoiler state.
+     *
+     * @param spoiler Whether the attachment is a spoiler.
+     * @return A copy of this attachment with the given spoiler state.
+     */
+    public Attachment withSpoiler(boolean spoiler) {
+        return new Attachment(this.gateway, AttachmentData.builder()
+                .from(this.getData())
+                .isSpoiler(spoiler)
+                .build());
     }
 
     /**

--- a/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionApplicationCommandCallbackSpecGenerator.java
@@ -54,6 +54,10 @@ interface InteractionApplicationCommandCallbackSpecGenerator extends Spec<Multip
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/main/java/discord4j/core/spec/InteractionFollowupCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionFollowupCreateSpecGenerator.java
@@ -56,6 +56,10 @@ interface InteractionFollowupCreateSpecGenerator extends Spec<MultipartRequest<F
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/InteractionReplyEditSpecGenerator.java
@@ -60,6 +60,10 @@ interface InteractionReplyEditSpecGenerator extends Spec<MultipartRequest<Webhoo
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/main/java/discord4j/core/spec/MessageCreateFields.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateFields.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.spec;
 
-import discord4j.core.object.entity.Attachment;
 import discord4j.discordjson.Id;
 import discord4j.discordjson.json.PartialAttachmentData;
 import discord4j.discordjson.possible.Possible;
@@ -43,8 +42,25 @@ public final class MessageCreateFields {
             return ImmutableMessageCreateFields.File.of(name, null, inputStream);
         }
 
+        static File of(final String name, final InputStream inputStream, final boolean isSpoiler) {
+            return ImmutableMessageCreateFields.File.builder()
+                    .name(name)
+                    .inputStream(inputStream)
+                    .isSpoiler(isSpoiler)
+                    .build();
+        }
+
         static File of(final String name, final String description, final InputStream inputStream) {
             return ImmutableMessageCreateFields.File.of(name, description, inputStream);
+        }
+
+        static File of(final String name, final String description, final InputStream inputStream, final boolean isSpoiler) {
+            return ImmutableMessageCreateFields.File.builder()
+                    .name(name)
+                    .description(description)
+                    .inputStream(inputStream)
+                    .isSpoiler(isSpoiler)
+                    .build();
         }
 
         String name();
@@ -57,11 +73,18 @@ public final class MessageCreateFields {
             return this.name();
         }
 
+        @Value.Default
+        @Value.Parameter(value = false)
+        default boolean isSpoiler() {
+            return false;
+        }
+
         default PartialAttachmentData asPartialAttachmentData(final Id id) {
             return PartialAttachmentData.builder()
                     .id(id)
                     .filename(this.getFileName())
                     .description(Possible.ofNullable(this.description()))
+                    .isSpoiler(this.isSpoiler())
                     .build();
         }
 
@@ -84,8 +107,8 @@ public final class MessageCreateFields {
         }
 
         @Override
-        default String getFileName() {
-            return Attachment.SPOILER_PREFIX + this.name();
+        default boolean isSpoiler() {
+            return true;
         }
 
         @Override

--- a/core/src/main/java/discord4j/core/spec/MessageCreateFields.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateFields.java
@@ -17,6 +17,7 @@
 
 package discord4j.core.spec;
 
+import discord4j.core.object.entity.Attachment;
 import discord4j.discordjson.Id;
 import discord4j.discordjson.json.PartialAttachmentData;
 import discord4j.discordjson.possible.Possible;
@@ -25,7 +26,9 @@ import org.jspecify.annotations.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
 @InlineFieldStyle
 @Value.Enclosing
@@ -42,25 +45,16 @@ public final class MessageCreateFields {
             return ImmutableMessageCreateFields.File.of(name, null, inputStream);
         }
 
-        static File of(final String name, final InputStream inputStream, final boolean isSpoiler) {
-            return ImmutableMessageCreateFields.File.builder()
-                    .name(name)
-                    .inputStream(inputStream)
-                    .isSpoiler(isSpoiler)
-                    .build();
-        }
-
         static File of(final String name, final String description, final InputStream inputStream) {
             return ImmutableMessageCreateFields.File.of(name, description, inputStream);
         }
 
-        static File of(final String name, final String description, final InputStream inputStream, final boolean isSpoiler) {
-            return ImmutableMessageCreateFields.File.builder()
-                    .name(name)
-                    .description(description)
-                    .inputStream(inputStream)
-                    .isSpoiler(isSpoiler)
-                    .build();
+        static File of(FileSpoiler file) {
+            return ImmutableMessageCreateFields.File.of(file.name(), file.description(), file.inputStream());
+        }
+
+        static File of(final Attachment attachment) throws IOException {
+            return ImmutableMessageCreateFields.File.of(attachment.getFilename(), attachment.getDescription().orElse(null), new URL(attachment.getUrl()).openStream());
         }
 
         String name();
@@ -98,12 +92,20 @@ public final class MessageCreateFields {
     @Value.Immutable
     public interface FileSpoiler extends File {
 
-        static FileSpoiler of(String name, InputStream inputStream) {
+        static FileSpoiler of(final String name, final InputStream inputStream) {
             return ImmutableMessageCreateFields.FileSpoiler.of(name, null, inputStream);
         }
 
-        static FileSpoiler of(String name, String description, InputStream inputStream) {
+        static FileSpoiler of(final String name, final String description, final InputStream inputStream) {
             return ImmutableMessageCreateFields.FileSpoiler.of(name, description, inputStream);
+        }
+
+        static FileSpoiler of(final File file) {
+            return ImmutableMessageCreateFields.FileSpoiler.of(file.name(), file.description(), file.inputStream());
+        }
+
+        static File of(final Attachment attachment) throws IOException {
+            return ImmutableMessageCreateFields.FileSpoiler.of(attachment.getFilename(), attachment.getDescription().orElse(null), new URL(attachment.getUrl()).openStream());
         }
 
         @Override

--- a/core/src/main/java/discord4j/core/spec/MessageCreateFields.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateFields.java
@@ -17,7 +17,6 @@
 
 package discord4j.core.spec;
 
-import discord4j.core.object.entity.Attachment;
 import discord4j.discordjson.Id;
 import discord4j.discordjson.json.PartialAttachmentData;
 import discord4j.discordjson.possible.Possible;
@@ -26,9 +25,7 @@ import org.jspecify.annotations.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 
 @InlineFieldStyle
 @Value.Enclosing
@@ -51,10 +48,6 @@ public final class MessageCreateFields {
 
         static File of(FileSpoiler file) {
             return ImmutableMessageCreateFields.File.of(file.name(), file.description(), file.inputStream());
-        }
-
-        static File of(final Attachment attachment) throws IOException {
-            return ImmutableMessageCreateFields.File.of(attachment.getFilename(), attachment.getDescription().orElse(null), new URL(attachment.getUrl()).openStream());
         }
 
         String name();
@@ -102,10 +95,6 @@ public final class MessageCreateFields {
 
         static FileSpoiler of(final File file) {
             return ImmutableMessageCreateFields.FileSpoiler.of(file.name(), file.description(), file.inputStream());
-        }
-
-        static File of(final Attachment attachment) throws IOException {
-            return ImmutableMessageCreateFields.FileSpoiler.of(attachment.getFilename(), attachment.getDescription().orElse(null), new URL(attachment.getUrl()).openStream());
         }
 
         @Override

--- a/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageCreateSpecGenerator.java
@@ -58,6 +58,10 @@ interface MessageCreateSpecGenerator extends Spec<MultipartRequest<MessageCreate
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/MessageEditSpecGenerator.java
@@ -54,6 +54,10 @@ interface MessageEditSpecGenerator extends Spec<MultipartRequest<MessageEditRequ
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/main/java/discord4j/core/spec/WebhookExecuteSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookExecuteSpecGenerator.java
@@ -56,6 +56,10 @@ interface WebhookExecuteSpecGenerator extends Spec<MultipartRequest<WebhookExecu
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/main/java/discord4j/core/spec/WebhookMessageEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/WebhookMessageEditSpecGenerator.java
@@ -49,6 +49,10 @@ public interface WebhookMessageEditSpecGenerator extends Spec<MultipartRequest<W
         return Collections.emptyList();
     }
 
+    /**
+     * @deprecated Use {@link #files()} instead with {@link MessageCreateFields.FileSpoiler}
+     */
+    @Deprecated
     @Value.Default
     default List<MessageCreateFields.FileSpoiler> fileSpoilers() {
         return Collections.emptyList();

--- a/core/src/test/java/discord4j/core/ExampleButtonAttachment.java
+++ b/core/src/test/java/discord4j/core/ExampleButtonAttachment.java
@@ -22,13 +22,14 @@ import discord4j.core.event.domain.interaction.ButtonInteractionEvent;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.object.component.ActionRow;
 import discord4j.core.object.component.Button;
-import discord4j.core.object.entity.Guild;
+import discord4j.core.object.entity.Attachment;
 import discord4j.core.object.entity.Message;
 import discord4j.core.spec.MessageCreateFields;
 import discord4j.rest.interaction.GuildCommandRegistrar;
 import discord4j.discordjson.json.ApplicationCommandRequest;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -60,11 +61,13 @@ public class ExampleButtonAttachment {
                     String append = "append";
                     String replace = "replace";
                     String replaceFirst = "replace-first";
+                    String toggleFirstSpoiler = "toggle-first-spoiler";
                     String clear = "clear";
                     ActionRow row = ActionRow.of(
                             Button.success(append, "Append attachment"),
                             Button.success(replace, "Replace all attachments"),
                             Button.success(replaceFirst, "Replace 1st attachment"),
+                            Button.success(toggleFirstSpoiler, "Toggle spoiler tag 1st attachment"),
                             Button.danger(clear, "Clear attachments"));
 
                     // a listener that captures our slash command interactions
@@ -108,6 +111,24 @@ public class ExampleButtonAttachment {
                                                     .collect(Collectors.toList())));
                             return press.deferEdit().then(edit);
 
+                        } else if (toggleFirstSpoiler.equals(press.getCustomId())) {
+                            Mono<Message> edit = press.getReply()
+                                    .flatMap(reply -> {
+                                        Attachment first = reply.getAttachments().get(0);
+
+                                        return Mono.fromCallable(() -> (first.isSpoiler()) ? MessageCreateFields.File.of(first) : MessageCreateFields.FileSpoiler.of(first))
+                                                .subscribeOn(Schedulers.boundedElastic())
+                                                .flatMap(file -> press.editReply()
+                                                        .withContentOrNull("Replaced the first attachment")
+                                                        .withFiles(file)
+                                                        .withComponents(row)
+                                                        .withAttachmentsOrNull(reply.getAttachments()
+                                                                .stream()
+                                                                .skip(1)
+                                                                .collect(Collectors.toList())));
+                                    });
+                            return press.deferEdit().then(edit);
+
                         } else if (clear.equals(press.getCustomId())) {
                             Mono<Message> edit = press.editReply()
                                     .withContentOrNull("Removed all attachments")
@@ -130,6 +151,6 @@ public class ExampleButtonAttachment {
     private static MessageCreateFields.File getFile() {
         String content = "This is a text file created at " + LocalDateTime.now();
         InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-        return MessageCreateFields.File.of("content.txt", stream);
+        return MessageCreateFields.File.of("content.txt", "A file with content.", stream);
     }
 }

--- a/core/src/test/java/discord4j/core/ExampleButtonAttachment.java
+++ b/core/src/test/java/discord4j/core/ExampleButtonAttachment.java
@@ -25,8 +25,8 @@ import discord4j.core.object.component.Button;
 import discord4j.core.object.entity.Attachment;
 import discord4j.core.object.entity.Message;
 import discord4j.core.spec.MessageCreateFields;
-import discord4j.rest.interaction.GuildCommandRegistrar;
 import discord4j.discordjson.json.ApplicationCommandRequest;
+import discord4j.rest.interaction.GuildCommandRegistrar;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -114,18 +115,18 @@ public class ExampleButtonAttachment {
                         } else if (toggleFirstSpoiler.equals(press.getCustomId())) {
                             Mono<Message> edit = press.getReply()
                                     .flatMap(reply -> {
-                                        Attachment first = reply.getAttachments().get(0);
-
-                                        return Mono.fromCallable(() -> (first.isSpoiler()) ? MessageCreateFields.File.of(first) : MessageCreateFields.FileSpoiler.of(first))
+                                        return Mono.fromCallable(() -> {
+                                                    List<Attachment> attachments = new ArrayList<>(reply.getAttachments());
+                                                    Attachment first = attachments.get(0);
+                                                    first = first.withSpoiler(!first.isSpoiler());
+                                                    attachments.set(0, first);
+                                                    return attachments;
+                                                })
                                                 .subscribeOn(Schedulers.boundedElastic())
-                                                .flatMap(file -> press.editReply()
+                                                .flatMap(newAttachments -> press.editReply()
                                                         .withContentOrNull("Replaced the first attachment")
-                                                        .withFiles(file)
                                                         .withComponents(row)
-                                                        .withAttachmentsOrNull(reply.getAttachments()
-                                                                .stream()
-                                                                .skip(1)
-                                                                .collect(Collectors.toList())));
+                                                        .withAttachmentsOrNull(newAttachments));
                                     });
                             return press.deferEdit().then(edit);
 


### PR DESCRIPTION
**Description:** This PR allow mark a file as Spoiler using the new way discord manage that rather than use `SPOILER_` prefix in file

**Justification:** https://docs.discord.com/developers/change-log#attachment-editing-and-is_spoiler-param
