### PR TITLE
feat: expose Flags to all channels and Visibility Content API

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -180,7 +180,7 @@ public interface Channel extends Entity {
      * Represent the channel flags.
      *
      * @see <a href="https://docs.discord.com/developers/resources/channel#channel-object-channel-flags">https://docs.discord.com/developers/resources/channel#channel-object-channel-flags</a>
-     **/
+     */
     @Experimental
     enum Flag {
         /**
@@ -260,5 +260,19 @@ public interface Channel extends Entity {
             return bitfield;
         }
 
+    }
+
+    /**
+     * Represent the channel content view (like client) for Spoiler or NSFW channels.
+     */
+    @Experimental
+    enum ContentVisibilityMode {
+        DEFAULT,
+        SPOILER,
+        NSFW;
+
+        public String getValue() {
+            return name().toLowerCase();
+        }
     }
 }

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -176,11 +176,15 @@ public interface Channel extends Entity {
         }
     }
 
-    /** Represent channel flags : <a href="https://discord.com/developers/docs/resources/channel#channel-object-channel-flags">https://discord.com/developers/docs/resources/channel#channel-object-channel-flags</a> */
+    /**
+     * Represent the channel flags.
+     *
+     * @see <a href="https://docs.discord.com/developers/resources/channel#channel-object-channel-flags">https://docs.discord.com/developers/resources/channel#channel-object-channel-flags</a>
+     **/
     @Experimental
     enum Flag {
         /**
-         * This {@link ThreadChannel} is pinned to the top of its parent {@link ForumChannel}
+         * This {@link ThreadChannel} is pinned to the top of its parent {@link ForumChannel}.
          */
         PINNED(1),
 
@@ -192,7 +196,12 @@ public interface Channel extends Entity {
         /**
          * Whether hides the embedded media download options. Available only for media channels.
          */
-        HIDE_MEDIA_DOWNLOAD_OPTIONS(15);
+        HIDE_MEDIA_DOWNLOAD_OPTIONS(15),
+
+        /**
+         * Whether is a Spoiler Channel where users must opt in to view its contents.
+         */
+        IS_SPOILER_CHANNEL(21);
 
         private final int shiftValue;
         private final int bitValue;

--- a/core/src/main/java/discord4j/core/object/entity/channel/ForumChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/ForumChannel.java
@@ -15,7 +15,6 @@ import discord4j.discordjson.json.ListThreadsData;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,18 +46,6 @@ public final class ForumChannel extends BaseTopLevelGuildChannel implements Cate
      */
     public boolean isNsfw() {
         return getData().nsfw().toOptional().orElse(false);
-    }
-
-    /**
-     * Gets the channels {@link discord4j.core.object.entity.Message.Flag} associated to this forum channel
-     * Unknown flags are currently ignored.
-     *
-     * @return An {@link EnumSet} representing the <b>known flags</b> for this forum channel.
-     */
-    public EnumSet<Flag> getFlags() {
-        return getData().flags().toOptional()
-            .map(Flag::valueOf)
-            .orElseThrow(IllegalStateException::new); // Mandatory for Forum Channels
     }
 
     /**

--- a/core/src/main/java/discord4j/core/object/entity/channel/MessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/MessageChannel.java
@@ -380,4 +380,18 @@ public interface MessageChannel extends Channel {
                 .map(Flag::valueOf)
                 .orElse(EnumSet.noneOf(Flag.class));
     }
+
+    /**
+     * Get the channel visibility mode for the content.
+     *
+     * @return A ContentVisibilityMode.
+     */
+    default ContentVisibilityMode getContentVisibilityMode() {
+        if (this.getFlags().contains(Flag.IS_SPOILER_CHANNEL)) {
+            return ContentVisibilityMode.SPOILER;
+        } else if (this.getData().nsfw().toOptional().orElse(false)) {
+            return ContentVisibilityMode.NSFW;
+        }
+        return ContentVisibilityMode.DEFAULT;
+    }
 }

--- a/core/src/main/java/discord4j/core/object/entity/channel/MessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/MessageChannel.java
@@ -42,6 +42,7 @@ import reactor.core.scheduler.Scheduler;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -366,5 +367,17 @@ public interface MessageChannel extends Channel {
             .map(PinnedMessagesResponseData::items)
             .flatMapMany(pinnedMessagesData -> Flux.fromIterable(pinnedMessagesData)
                 .map(pinnedMessageData -> new PinnedMessageReference(getClient(), pinnedMessageData)));
+    }
+
+    /**
+     * Gets the channels {@link discord4j.core.object.entity.channel.Channel.Flag} associated to this channel
+     * Unknown flags are currently ignored.
+     *
+     * @return An {@link EnumSet} representing the <b>known flags</b> for this channel.
+     */
+    default EnumSet<Flag> getFlags() {
+        return getData().flags().toOptional()
+                .map(Flag::valueOf)
+                .orElse(EnumSet.noneOf(Flag.class));
     }
 }

--- a/core/src/main/java/discord4j/core/spec/ForumChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/ForumChannelCreateSpecGenerator.java
@@ -23,6 +23,7 @@ import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.ForumChannel;
 import discord4j.core.object.reaction.DefaultReaction;
 import discord4j.discordjson.json.ChannelCreateRequest;
+import discord4j.discordjson.json.ImmutableChannelCreateRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -56,6 +57,8 @@ public interface ForumChannelCreateSpecGenerator extends AuditSpec<ChannelCreate
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     Possible<Optional<DefaultReaction>> defaultReactionEmoji();
 
     List<ForumTagCreateSpec> availableTags();
@@ -66,7 +69,7 @@ public interface ForumChannelCreateSpecGenerator extends AuditSpec<ChannelCreate
 
     @Override
     default ChannelCreateRequest asRequest() {
-        return ChannelCreateRequest.builder()
+        ImmutableChannelCreateRequest.Builder builder = ChannelCreateRequest.builder()
                 .type(Channel.Type.GUILD_FORUM.getValue())
                 .name(name())
                 .topic(topic())
@@ -81,8 +84,12 @@ public interface ForumChannelCreateSpecGenerator extends AuditSpec<ChannelCreate
                 .defaultReactionEmoji(mapPossible(defaultReactionEmoji(), opt -> opt.map(DefaultReaction::getData)))
                 .defaultForumLayout(defaultForumLayout())
                 .availableTags(availableTags().stream().map(ForumTagCreateSpec::asRequest).collect(Collectors.toList()))
-                .defaultSortOrder(defaultSortOrder())
-                .build();
+                .defaultSortOrder(defaultSortOrder());
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/ForumChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/ForumChannelCreateSpecGenerator.java
@@ -67,22 +67,22 @@ public interface ForumChannelCreateSpecGenerator extends AuditSpec<ChannelCreate
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
-            .type(Channel.Type.GUILD_FORUM.getValue())
-            .name(name())
-            .topic(topic())
-            .rateLimitPerUser(rateLimitPerUser())
-            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                .map(PermissionOverwrite::getData)
-                .collect(Collectors.toList())))
-            .parentId(mapPossible(parentId(), Snowflake::asString))
-            .nsfw(nsfw())
-            .defaultAutoArchiveDuration(defaultAutoArchiveDuration())
-            .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-            .defaultReactionEmoji(mapPossible(defaultReactionEmoji(), opt -> opt.map(DefaultReaction::getData)))
-            .defaultForumLayout(defaultForumLayout())
-            .availableTags(availableTags().stream().map(ForumTagCreateSpec::asRequest).collect(Collectors.toList()))
-            .defaultSortOrder(defaultSortOrder())
-            .build();
+                .type(Channel.Type.GUILD_FORUM.getValue())
+                .name(name())
+                .topic(topic())
+                .rateLimitPerUser(rateLimitPerUser())
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
+                .parentId(mapPossible(parentId(), Snowflake::asString))
+                .nsfw(nsfw())
+                .defaultAutoArchiveDuration(defaultAutoArchiveDuration())
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
+                .defaultReactionEmoji(mapPossible(defaultReactionEmoji(), opt -> opt.map(DefaultReaction::getData)))
+                .defaultForumLayout(defaultForumLayout())
+                .availableTags(availableTags().stream().map(ForumTagCreateSpec::asRequest).collect(Collectors.toList()))
+                .defaultSortOrder(defaultSortOrder())
+                .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/ForumChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/ForumChannelEditSpecGenerator.java
@@ -22,6 +22,7 @@ import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.ForumChannel;
 import discord4j.core.object.reaction.DefaultReaction;
 import discord4j.discordjson.json.ChannelModifyRequest;
+import discord4j.discordjson.json.ImmutableChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -53,6 +54,8 @@ public interface ForumChannelEditSpecGenerator extends AuditSpec<ChannelModifyRe
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     Possible<Optional<Integer>> defaultAutoArchiveDuration();
 
     Possible<Optional<DefaultReaction>> defaultReactionEmoji();
@@ -65,22 +68,26 @@ public interface ForumChannelEditSpecGenerator extends AuditSpec<ChannelModifyRe
 
     @Override
     default ChannelModifyRequest asRequest() {
-        return ChannelModifyRequest.builder()
-            .name(name())
-            .topic(topic())
-            .rateLimitPerUser(rateLimitPerUser())
-            .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
-                .map(PermissionOverwrite::getData)
-                .collect(Collectors.toList())))
-            .parentId(mapPossible(parentId(), snowflake -> Optional.of(snowflake.asString())))
-            .nsfw(nsfw())
-            .defaultAutoArchiveDuration(defaultAutoArchiveDuration())
-            .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-            .defaultReactionEmoji(mapPossible(defaultReactionEmoji(), opt -> opt.map(DefaultReaction::getData)))
-            .defaultForumLayout(defaultForumLayout())
-            .availableTags(mapPossible(availableTags(), list -> list.stream().map(ForumTagCreateSpecGenerator::asRequest).collect(Collectors.toList())))
-            .defaultSortOrder(defaultSortOrder())
-            .build();
+        ImmutableChannelModifyRequest.Builder builder = ChannelModifyRequest.builder()
+                .name(name())
+                .topic(topic())
+                .rateLimitPerUser(rateLimitPerUser())
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
+                .parentId(mapPossible(parentId(), snowflake -> Optional.of(snowflake.asString())))
+                .nsfw(nsfw())
+                .defaultAutoArchiveDuration(defaultAutoArchiveDuration())
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
+                .defaultReactionEmoji(mapPossible(defaultReactionEmoji(), opt -> opt.map(DefaultReaction::getData)))
+                .defaultForumLayout(defaultForumLayout())
+                .availableTags(mapPossible(availableTags(), list -> list.stream().map(ForumTagCreateSpecGenerator::asRequest).collect(Collectors.toList())))
+                .defaultSortOrder(defaultSortOrder());
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/InternalChannelSpecUtils.java
+++ b/core/src/main/java/discord4j/core/spec/InternalChannelSpecUtils.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Discord4J.
+ *
+ * Discord4J is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Discord4J is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Discord4J. If not, see <http://www.gnu.org/licenses/>.
+ */
+package discord4j.core.spec;
+
+import discord4j.core.object.entity.channel.Channel;
+import discord4j.discordjson.json.ImmutableChannelCreateRequest;
+import discord4j.discordjson.json.ImmutableChannelModifyRequest;
+import discord4j.discordjson.possible.Possible;
+
+import java.util.EnumSet;
+
+final class InternalChannelSpecUtils {
+
+    private InternalChannelSpecUtils() {
+        throw new AssertionError();
+    }
+
+    public static void handleContentVisibilityMode(
+            final ImmutableChannelModifyRequest.Builder builder,
+            final Possible<Channel.ContentVisibilityMode> contentVisibilityModePossible,
+            final EnumSet<Channel.Flag> currentFlags
+    ) {
+        if (contentVisibilityModePossible.isAbsent()) {
+            return;
+        }
+        final Channel.ContentVisibilityMode contentVisibilityMode = contentVisibilityModePossible.get();
+        if (contentVisibilityMode == Channel.ContentVisibilityMode.DEFAULT) {
+            builder.nsfw(false);
+            currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
+        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.SPOILER) {
+            builder.nsfw(false);
+            currentFlags.add(Channel.Flag.IS_SPOILER_CHANNEL);
+        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.NSFW) {
+            builder.nsfw(true);
+            currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
+        }
+        builder.flags(Channel.Flag.toBitfield(currentFlags));
+    }
+
+    public static void handleContentVisibilityMode(
+            final ImmutableChannelCreateRequest.Builder builder,
+            final Possible<Channel.ContentVisibilityMode> contentVisibilityModePossible,
+            final EnumSet<Channel.Flag> currentFlags
+    ) {
+        if (contentVisibilityModePossible.isAbsent()) {
+            return;
+        }
+        final Channel.ContentVisibilityMode contentVisibilityMode = contentVisibilityModePossible.get();
+        if (contentVisibilityMode == Channel.ContentVisibilityMode.DEFAULT) {
+            builder.nsfw(false);
+            currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
+        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.SPOILER) {
+            builder.nsfw(false);
+            currentFlags.add(Channel.Flag.IS_SPOILER_CHANNEL);
+        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.NSFW) {
+            builder.nsfw(true);
+            currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
+        }
+        builder.flags(Channel.Flag.toBitfield(currentFlags));
+    }
+
+}

--- a/core/src/main/java/discord4j/core/spec/InternalChannelSpecUtils.java
+++ b/core/src/main/java/discord4j/core/spec/InternalChannelSpecUtils.java
@@ -38,17 +38,13 @@ final class InternalChannelSpecUtils {
             return;
         }
         final Channel.ContentVisibilityMode contentVisibilityMode = contentVisibilityModePossible.get();
-        if (contentVisibilityMode == Channel.ContentVisibilityMode.DEFAULT) {
-            builder.nsfw(false);
-            currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
-        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.SPOILER) {
-            builder.nsfw(false);
+        if (contentVisibilityMode == Channel.ContentVisibilityMode.SPOILER) {
             currentFlags.add(Channel.Flag.IS_SPOILER_CHANNEL);
-        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.NSFW) {
-            builder.nsfw(true);
+        } else {
             currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
         }
         builder.flags(Channel.Flag.toBitfield(currentFlags));
+        builder.nsfw(contentVisibilityMode == Channel.ContentVisibilityMode.NSFW);
     }
 
     public static void handleContentVisibilityMode(
@@ -60,17 +56,13 @@ final class InternalChannelSpecUtils {
             return;
         }
         final Channel.ContentVisibilityMode contentVisibilityMode = contentVisibilityModePossible.get();
-        if (contentVisibilityMode == Channel.ContentVisibilityMode.DEFAULT) {
-            builder.nsfw(false);
-            currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
-        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.SPOILER) {
-            builder.nsfw(false);
+        if (contentVisibilityMode == Channel.ContentVisibilityMode.SPOILER) {
             currentFlags.add(Channel.Flag.IS_SPOILER_CHANNEL);
-        } else if (contentVisibilityMode == Channel.ContentVisibilityMode.NSFW) {
-            builder.nsfw(true);
+        } else {
             currentFlags.remove(Channel.Flag.IS_SPOILER_CHANNEL);
         }
         builder.flags(Channel.Flag.toBitfield(currentFlags));
+        builder.nsfw(contentVisibilityMode == Channel.ContentVisibilityMode.NSFW);
     }
 
 }

--- a/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
@@ -23,6 +23,7 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.NewsChannel;
 import discord4j.discordjson.json.ChannelCreateRequest;
+import discord4j.discordjson.json.ImmutableChannelCreateRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -53,9 +54,11 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelCreateRequest asRequest() {
-        return ChannelCreateRequest.builder()
+        ImmutableChannelCreateRequest.Builder builder = ChannelCreateRequest.builder()
                 .type(Channel.Type.GUILD_NEWS.getValue())
                 .name(name())
                 .topic(topic())
@@ -66,8 +69,12 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .nsfw(nsfw())
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelCreateSpecGenerator.java
@@ -28,6 +28,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,8 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
 
     Possible<Boolean> nsfw();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
@@ -63,6 +66,7 @@ interface NewsChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .nsfw(nsfw())
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
@@ -22,6 +22,7 @@ import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.NewsChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
+import discord4j.discordjson.json.ImmutableChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -54,20 +55,26 @@ interface NewsChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelModifyRequest asRequest() {
-        return ChannelModifyRequest.builder()
+        ImmutableChannelModifyRequest.Builder builder = ChannelModifyRequest.builder()
                 .name(name())
                 .position(position())
                 .rateLimitPerUser(rateLimitPerUser())
                 .topic(topic())
                 .nsfw(nsfw())
-                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/NewsChannelEditSpecGenerator.java
@@ -19,6 +19,7 @@ package discord4j.core.spec;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.PermissionOverwrite;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.NewsChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
@@ -26,10 +27,12 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static discord4j.core.spec.InternalSpecUtils.mapPossible;
 import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
 
 @Value.Immutable(singleton = true)
@@ -49,19 +52,22 @@ interface NewsChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
 
     Possible<Optional<Snowflake>> parentId();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
-            .name(name())
-            .position(position())
-            .rateLimitPerUser(rateLimitPerUser())
-            .topic(topic())
-            .nsfw(nsfw())
-            .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
-                .map(PermissionOverwrite::getData)
-                .collect(Collectors.toList())))
-            .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
-            .build();
+                .name(name())
+                .position(position())
+                .rateLimitPerUser(rateLimitPerUser())
+                .topic(topic())
+                .nsfw(nsfw())
+                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                        .map(PermissionOverwrite::getData)
+                        .collect(Collectors.toList())))
+                .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
+                .build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/StageChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StageChannelCreateSpecGenerator.java
@@ -23,6 +23,7 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.VoiceChannel;
 import discord4j.discordjson.json.ChannelCreateRequest;
+import discord4j.discordjson.json.ImmutableChannelCreateRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -51,9 +52,11 @@ interface StageChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelCreateRequest asRequest() {
-        return ChannelCreateRequest.builder()
+        ImmutableChannelCreateRequest.Builder builder = ChannelCreateRequest.builder()
                 .type(Channel.Type.GUILD_STAGE_VOICE.getValue())
                 .name(name())
                 .bitrate(bitrate())
@@ -63,8 +66,12 @@ interface StageChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/StageChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StageChannelCreateSpecGenerator.java
@@ -28,6 +28,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -48,6 +49,8 @@ interface StageChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
 
     Possible<Snowflake> parentId();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
@@ -60,6 +63,7 @@ interface StageChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/StageChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StageChannelEditSpecGenerator.java
@@ -22,6 +22,7 @@ import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.StageChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
+import discord4j.discordjson.json.ImmutableChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -54,9 +55,11 @@ interface StageChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelModifyRequest asRequest() {
-        return ChannelModifyRequest.builder()
+        ImmutableChannelModifyRequest.Builder builder = ChannelModifyRequest.builder()
                 .name(name())
                 .bitrate(bitrate())
                 .position(position())
@@ -66,8 +69,12 @@ interface StageChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
                         .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .rtcRegion(rtcRegion())
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/StageChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/StageChannelEditSpecGenerator.java
@@ -19,6 +19,7 @@ package discord4j.core.spec;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.PermissionOverwrite;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.StageChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
@@ -26,6 +27,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,6 +52,8 @@ interface StageChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
 
     Possible<Optional<String>> rtcRegion();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
@@ -62,6 +66,7 @@ interface StageChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
                         .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .rtcRegion(rtcRegion())
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
@@ -23,6 +23,7 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.TextChannel;
 import discord4j.discordjson.json.ChannelCreateRequest;
+import discord4j.discordjson.json.ImmutableChannelCreateRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -53,9 +54,11 @@ interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelCreateRequest asRequest() {
-        return ChannelCreateRequest.builder()
+        ImmutableChannelCreateRequest.Builder builder = ChannelCreateRequest.builder()
                 .type(Channel.Type.GUILD_TEXT.getValue())
                 .name(name())
                 .topic(topic())
@@ -66,8 +69,12 @@ interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .nsfw(nsfw())
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelCreateSpecGenerator.java
@@ -28,6 +28,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,8 @@ interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
 
     Possible<Boolean> nsfw();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
@@ -63,6 +66,7 @@ interface TextChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest>
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
                 .nsfw(nsfw())
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/TextChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelEditSpecGenerator.java
@@ -19,6 +19,7 @@ package discord4j.core.spec;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.PermissionOverwrite;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.TextChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
@@ -26,10 +27,12 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static discord4j.core.spec.InternalSpecUtils.mapPossible;
 import static discord4j.core.spec.InternalSpecUtils.mapPossibleOptional;
 
 @Value.Immutable(singleton = true)
@@ -49,6 +52,8 @@ interface TextChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
 
     Possible<Optional<Snowflake>> parentId();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
@@ -61,6 +66,7 @@ interface TextChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/TextChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/TextChannelEditSpecGenerator.java
@@ -22,6 +22,7 @@ import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.TextChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
+import discord4j.discordjson.json.ImmutableChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -54,20 +55,26 @@ interface TextChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> {
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelModifyRequest asRequest() {
-        return ChannelModifyRequest.builder()
+        ImmutableChannelModifyRequest.Builder builder = ChannelModifyRequest.builder()
                 .name(name())
                 .position(position())
                 .topic(topic())
                 .rateLimitPerUser(rateLimitPerUser())
                 .nsfw(nsfw())
-                .permissionOverwrites(InternalSpecUtils.mapPossible(permissionOverwrites(), po -> po.stream()
+                .permissionOverwrites(mapPossible(permissionOverwrites(), po -> po.stream()
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
@@ -23,6 +23,7 @@ import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.VoiceChannel;
 import discord4j.discordjson.json.ChannelCreateRequest;
+import discord4j.discordjson.json.ImmutableChannelCreateRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -53,9 +54,11 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelCreateRequest asRequest() {
-        return ChannelCreateRequest.builder()
+        ImmutableChannelCreateRequest.Builder builder = ChannelCreateRequest.builder()
                 .type(Channel.Type.GUILD_VOICE.getValue())
                 .name(name())
                 .bitrate(bitrate())
@@ -66,8 +69,12 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelCreateSpecGenerator.java
@@ -28,6 +28,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,8 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
 
     Possible<Snowflake> parentId();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelCreateRequest asRequest() {
         return ChannelCreateRequest.builder()
@@ -63,6 +66,7 @@ interface VoiceChannelCreateSpecGenerator extends AuditSpec<ChannelCreateRequest
                         .map(PermissionOverwrite::getData)
                         .collect(Collectors.toList())))
                 .parentId(mapPossible(parentId(), Snowflake::asString))
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
@@ -19,6 +19,7 @@ package discord4j.core.spec;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.PermissionOverwrite;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.VoiceChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
@@ -26,6 +27,7 @@ import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -53,6 +55,8 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
 
     Possible<Optional<VoiceChannel.Mode>> videoQualityMode();
 
+    Possible<EnumSet<Channel.Flag>> flags();
+
     @Override
     default ChannelModifyRequest asRequest() {
         return ChannelModifyRequest.builder()
@@ -67,6 +71,7 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .rtcRegion(rtcRegion())
                 .videoQualityMode(mapPossibleOptional(videoQualityMode(), VoiceChannel.Mode::getValue))
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
                 .build();
     }
 }

--- a/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
+++ b/core/src/main/java/discord4j/core/spec/VoiceChannelEditSpecGenerator.java
@@ -22,6 +22,7 @@ import discord4j.core.object.PermissionOverwrite;
 import discord4j.core.object.entity.channel.Channel;
 import discord4j.core.object.entity.channel.VoiceChannel;
 import discord4j.discordjson.json.ChannelModifyRequest;
+import discord4j.discordjson.json.ImmutableChannelModifyRequest;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 import reactor.core.CoreSubscriber;
@@ -57,9 +58,11 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
 
     Possible<EnumSet<Channel.Flag>> flags();
 
+    Possible<Channel.ContentVisibilityMode> contentVisibilityMode();
+
     @Override
     default ChannelModifyRequest asRequest() {
-        return ChannelModifyRequest.builder()
+        ImmutableChannelModifyRequest.Builder builder = ChannelModifyRequest.builder()
                 .name(name())
                 .bitrate(bitrate())
                 .userLimit(userLimit())
@@ -71,8 +74,12 @@ interface VoiceChannelEditSpecGenerator extends AuditSpec<ChannelModifyRequest> 
                 .parentId(mapPossibleOptional(parentId(), Snowflake::asString))
                 .rtcRegion(rtcRegion())
                 .videoQualityMode(mapPossibleOptional(videoQualityMode(), VoiceChannel.Mode::getValue))
-                .flags(mapPossible(flags(), Channel.Flag::toBitfield))
-                .build();
+                .flags(mapPossible(flags(), Channel.Flag::toBitfield));
+
+        InternalChannelSpecUtils.handleContentVisibilityMode(builder, contentVisibilityMode(),
+                flags().toOptional().map(EnumSet::copyOf).orElse(EnumSet.noneOf(Channel.Flag.class)));
+
+        return builder.build();
     }
 }
 


### PR DESCRIPTION
**Description:** Discord now expose a new flag for channels with spoilers (not the same than NSFW), this require expose that new flag and also allow users to know if the flag exists in all channels

**Justification:** https://github.com/discord/discord-api-docs/pull/8465
