### PR TITLE
feat: add bot permissions for resolved channel

### DIFF
--- a/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
+++ b/core/src/main/java/discord4j/core/object/command/ResolvedChannel.java
@@ -154,6 +154,16 @@ public class ResolvedChannel implements DiscordObject {
     }
 
     /**
+     * Gets the computed permissions for the bot in the channel, including overwrites.
+     * This field can be absent when the bot is not in a guild, e.g. when providing a DM channel.
+     *
+     * @return The permissions of the channel.
+     */
+    public Optional<PermissionSet> getEffectiveAppPermissions() {
+        return Possible.flatOpt(this.getData().appPermissions()).map(PermissionSet::of);
+    }
+
+    /**
      * Gets the associated thread metadata, if the provided channel is a thread.
      *
      * @return Associated {@link ThreadMetadata}, if present.


### PR DESCRIPTION
**Description:** Expose the app permissions for a ResolvedChannel

**Justification:** https://github.com/Discord4J/discord-json/pull/232 and https://docs.discord.com/developers/change-log#resolved-channel-app_permissions-in-interactions
