### PR TITLE
fix: bump discord-json version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 version=3.3.3-SNAPSHOT
-discordJsonVersion=1.7.23
+discordJsonVersion=1.7.24
 storesVersion=3.2.3


### PR DESCRIPTION
Waiting for https://github.com/Discord4J/discord-json/pull/240 & release