### PR TITLE
feat: Basic support for check Obfuscated Channel

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -49,6 +49,18 @@ public interface Channel extends Entity {
     }
 
     /**
+     * Gets the channels {@link discord4j.core.object.entity.channel.Channel.Flag} associated to this channel
+     * Unknown flags are currently ignored.
+     *
+     * @return An {@link EnumSet} representing the <b>known flags</b> for this channel.
+     */
+    default EnumSet<Flag> getFlags() {
+        return getData().flags().toOptional()
+                .map(Flag::valueOf)
+                .orElse(EnumSet.noneOf(Flag.class));
+    }
+
+    /**
      * Requests to delete this channel.
      *
      * @return A {@link Mono} where, upon successful completion, emits nothing; indicating the channel has been deleted.

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -65,7 +65,7 @@ public interface Channel extends Entity {
      *
      * @return {@code true} if this channel is obfuscated, {@code false} otherwise.
      */
-    default Boolean isObfuscated() {
+    default boolean isObfuscated() {
         return getFlags().contains(Flag.CHANNEL_OBFUSCATED);
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -211,6 +211,11 @@ public interface Channel extends Entity {
         HIDE_MEDIA_DOWNLOAD_OPTIONS(15),
 
         /**
+         * Some metadata of this channel is not visible to this client.
+         */
+        CHANNEL_OBFUSCATED(17),
+
+        /**
          * Whether is a Spoiler Channel where users must opt in to view its contents.
          */
         IS_SPOILER_CHANNEL(21);

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -65,7 +65,7 @@ public interface Channel extends Entity {
      *
      * @return {@code true} if this channel is obfuscated, {@code false} otherwise.
      */
-    default Boolean getIsObfuscated() {
+    default Boolean isObfuscated() {
         return getFlags().contains(Flag.CHANNEL_OBFUSCATED);
     }
 

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -60,6 +60,11 @@ public interface Channel extends Entity {
                 .orElse(EnumSet.noneOf(Flag.class));
     }
 
+    /**
+     * Gets whether this channel is obfuscated for this client.
+     *
+     * @return {@code true} if this channel is obfuscated, {@code false} otherwise.
+     */
     default Boolean getIsObfuscated() {
         return getFlags().contains(Flag.CHANNEL_OBFUSCATED);
     }

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -60,6 +60,10 @@ public interface Channel extends Entity {
                 .orElse(EnumSet.noneOf(Flag.class));
     }
 
+    default Boolean getIsObfuscated() {
+        return getFlags().contains(Flag.CHANNEL_OBFUSCATED);
+    }
+
     /**
      * Requests to delete this channel.
      *

--- a/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/Channel.java
@@ -64,6 +64,7 @@ public interface Channel extends Entity {
      * Gets whether this channel is obfuscated for this client.
      *
      * @return {@code true} if this channel is obfuscated, {@code false} otherwise.
+     * @see <a href="https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels">https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels</a>
      */
     default boolean isObfuscated() {
         return getFlags().contains(Flag.CHANNEL_OBFUSCATED);

--- a/core/src/main/java/discord4j/core/object/entity/channel/MessageChannel.java
+++ b/core/src/main/java/discord4j/core/object/entity/channel/MessageChannel.java
@@ -370,18 +370,6 @@ public interface MessageChannel extends Channel {
     }
 
     /**
-     * Gets the channels {@link discord4j.core.object.entity.channel.Channel.Flag} associated to this channel
-     * Unknown flags are currently ignored.
-     *
-     * @return An {@link EnumSet} representing the <b>known flags</b> for this channel.
-     */
-    default EnumSet<Flag> getFlags() {
-        return getData().flags().toOptional()
-                .map(Flag::valueOf)
-                .orElse(EnumSet.noneOf(Flag.class));
-    }
-
-    /**
      * Get the channel visibility mode for the content.
      *
      * @return A ContentVisibilityMode.


### PR DESCRIPTION
**Description**:
Adds support for the new CHANNEL_OBFUSCATED channel metadata to be added in November.
Also moved getFlags() from interface MessageChannel to interface Channel.

**Justification**:
See [Obfuscated Channels](https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels)
The method Channel#getData() is available to all types implementing Channel. Moving MessageChannel#getFlags() to Channel enables other classes implementing Channel to work the the channel's flags without calling getData() first and performing manual bit shifting.
