### PR TITLE
Support for PRUNE_REQUIRES_ADMIN guild feature

### DIFF
--- a/core/src/main/java/discord4j/core/object/entity/Guild.java
+++ b/core/src/main/java/discord4j/core/object/entity/Guild.java
@@ -2708,8 +2708,9 @@ public final class Guild implements Entity {
         /* guild has access to set guild tags */
         GUILD_TAGS("GUILD_TAGS", false),
         /* guild is able to set gradient colors to roles */
-        ENHANCED_ROLE_COLORS("ENHANCED_ROLE_COLORS", false);
-        ;
+        ENHANCED_ROLE_COLORS("ENHANCED_ROLE_COLORS", false),
+        /* guild's prune feature requires admin permission */
+        PRUNE_REQUIRES_ADMIN("PRUNE_REQUIRES_ADMIN", true);
 
         private final String value;
 


### PR DESCRIPTION
**Description:** Adds `PRUNE_REQUIRES_ADMIN` to the list of recognized guild features.

Also there's an extra semicolon since I don't know when

**Justification:** See [Change Log](https://docs.discord.com/developers/change-log#prune_requires_admin-guild-feature)


